### PR TITLE
Remove singleton pattern from within SyncAdapterService.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterService.java
@@ -18,23 +18,16 @@ import android.os.IBinder;
 /** A service that holds a singleton SyncAdapter and provides it to the OS on request. */
 public class SyncAdapterService extends Service {
 
-    private static SyncAdapter sInstance = null;
-    private static final Object sLock = new Object();
+    private SyncAdapter mSyncAdapter = null;
 
     @Override
     public void onCreate() {
         super.onCreate();
-        if (sInstance == null) {
-            synchronized (sLock) {
-                if (sInstance == null) {
-                    sInstance = new SyncAdapter(getApplicationContext(), true);
-                }
-            }
-        }
+        mSyncAdapter = new SyncAdapter(getApplicationContext(), true);
     }
 
     @Override
     public IBinder onBind(Intent intent) {
-        return sInstance.getSyncAdapterBinder();
+        return mSyncAdapter.getSyncAdapterBinder();
     }
 }


### PR DESCRIPTION
Services are singletons anyway, so it's redundant for this one to have a private singleton members. Additionally, the onBind() and the onCreate() calls are both called from the Main Thread, so we can remove the lock.
