### PR TITLE
Enable Stetho to intercept and inspect network requests.

### DIFF
--- a/.idea/inspectionProfiles/Buendia.xml
+++ b/.idea/inspectionProfiles/Buendia.xml
@@ -107,7 +107,7 @@
     <inspection_tool class="StaticMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_regex" value="[a-z][a-z0-9]+([A-Z][a-z0-9]+)*" />
       <option name="m_minLength" value="2" />
-      <option name="m_maxLength" value="32" />
+      <option name="m_maxLength" value="50" />
     </inspection_tool>
     <inspection_tool class="StaticVariableNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="checkMutableFinals" value="false" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ def debugContentAuthority = debugAppId + '.provider'
 android {
     dexOptions {
         preDexLibraries = false
+        javaMaxHeapSize = '4g'
     }
 }
 dependencies {
@@ -61,6 +62,7 @@ dependencies {
     compile 'de.greenrobot:eventbus:2.4.0' // The event bus
     compile 'joda-time:joda-time:2.5' // Better dates and times
     compile 'com.facebook.stetho:stetho:1.2.0' // Handy debugging bridge
+    compile 'com.facebook.stetho:stetho-okhttp:1.2.0' // Network debugging
 
     // Testing
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'

--- a/app/src/main/java/com/circle/android/api/OkHttpStack.java
+++ b/app/src/main/java/com/circle/android/api/OkHttpStack.java
@@ -48,8 +48,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
-
 
 /**
  * OkHttp backed {@link com.android.volley.toolbox.HttpStack HttpStack} that does not
@@ -65,7 +63,7 @@ public class OkHttpStack implements HttpStack {
 
     @Override
     public HttpResponse performRequest(Request<?> request, Map<String, String> additionalHeaders)
-        throws IOException, AuthFailureError {
+            throws IOException, AuthFailureError {
 
         OkHttpClient client = mClient.clone();
         int timeoutMs = request.getTimeoutMs();
@@ -121,7 +119,7 @@ public class OkHttpStack implements HttpStack {
 
     @SuppressWarnings("deprecation")
     private static void setConnectionParametersForRequest(com.squareup.okhttp.Request.Builder builder, Request<?> request)
-        throws IOException, AuthFailureError {
+            throws IOException, AuthFailureError {
         switch (request.getMethod()) {
             case Request.Method.DEPRECATED_GET_OR_POST:
                 // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.
@@ -171,10 +169,10 @@ public class OkHttpStack implements HttpStack {
                 return new ProtocolVersion("HTTP", 2, 0);
         }
 
-        throw new IllegalAccessError("Unknown protocol");
+        throw new IllegalAccessError("Unkwown protocol");
     }
 
-    private static @Nullable RequestBody createRequestBody(Request r) throws AuthFailureError {
+    private static RequestBody createRequestBody(Request r) throws AuthFailureError {
         final byte[] body = r.getBody();
         if (body == null) return null;
 

--- a/app/src/main/java/com/circle/android/api/OkHttpStack.java
+++ b/app/src/main/java/com/circle/android/api/OkHttpStack.java
@@ -1,0 +1,183 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Circle Internet Financial
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.circle.android.api;
+
+import com.android.volley.AuthFailureError;
+import com.android.volley.Request;
+import com.android.volley.toolbox.HttpStack;
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * OkHttp backed {@link com.android.volley.toolbox.HttpStack HttpStack} that does not
+ * use okhttp-urlconnection
+ */
+public class OkHttpStack implements HttpStack {
+
+    private final OkHttpClient mClient;
+
+    public OkHttpStack(OkHttpClient client) {
+        this.mClient = client;
+    }
+
+    @Override
+    public HttpResponse performRequest(Request<?> request, Map<String, String> additionalHeaders)
+        throws IOException, AuthFailureError {
+
+        OkHttpClient client = mClient.clone();
+        int timeoutMs = request.getTimeoutMs();
+        client.setConnectTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        client.setReadTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        client.setWriteTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+
+        com.squareup.okhttp.Request.Builder okHttpRequestBuilder = new com.squareup.okhttp.Request.Builder();
+        okHttpRequestBuilder.url(request.getUrl());
+
+        Map<String, String> headers = request.getHeaders();
+        for (final String name : headers.keySet()) {
+            okHttpRequestBuilder.addHeader(name, headers.get(name));
+        }
+        for (final String name : additionalHeaders.keySet()) {
+            okHttpRequestBuilder.addHeader(name, additionalHeaders.get(name));
+        }
+
+        setConnectionParametersForRequest(okHttpRequestBuilder, request);
+
+        com.squareup.okhttp.Request okHttpRequest = okHttpRequestBuilder.build();
+        Call okHttpCall = client.newCall(okHttpRequest);
+        Response okHttpResponse = okHttpCall.execute();
+
+        StatusLine responseStatus = new BasicStatusLine(parseProtocol(okHttpResponse.protocol()), okHttpResponse.code(), okHttpResponse.message());
+        BasicHttpResponse response = new BasicHttpResponse(responseStatus);
+        response.setEntity(entityFromOkHttpResponse(okHttpResponse));
+
+        Headers responseHeaders = okHttpResponse.headers();
+        for (int i = 0, len = responseHeaders.size(); i < len; i++) {
+            final String name = responseHeaders.name(i), value = responseHeaders.value(i);
+            if (name != null) {
+                response.addHeader(new BasicHeader(name, value));
+            }
+        }
+
+        return response;
+    }
+
+    private static HttpEntity entityFromOkHttpResponse(Response r) throws IOException {
+        BasicHttpEntity entity = new BasicHttpEntity();
+        ResponseBody body = r.body();
+
+        entity.setContent(body.byteStream());
+        entity.setContentLength(body.contentLength());
+        entity.setContentEncoding(r.header("Content-Encoding"));
+
+        if (body.contentType() != null) {
+            entity.setContentType(body.contentType().type());
+        }
+        return entity;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void setConnectionParametersForRequest(com.squareup.okhttp.Request.Builder builder, Request<?> request)
+        throws IOException, AuthFailureError {
+        switch (request.getMethod()) {
+            case Request.Method.DEPRECATED_GET_OR_POST:
+                // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.
+                byte[] postBody = request.getPostBody();
+                if (postBody != null) {
+                    builder.post(RequestBody.create(MediaType.parse(request.getPostBodyContentType()), postBody));
+                }
+                break;
+            case Request.Method.GET:
+                builder.get();
+                break;
+            case Request.Method.DELETE:
+                builder.delete();
+                break;
+            case Request.Method.POST:
+                builder.post(createRequestBody(request));
+                break;
+            case Request.Method.PUT:
+                builder.put(createRequestBody(request));
+                break;
+            case Request.Method.HEAD:
+                builder.head();
+                break;
+            case Request.Method.OPTIONS:
+                builder.method("OPTIONS", null);
+                break;
+            case Request.Method.TRACE:
+                builder.method("TRACE", null);
+                break;
+            case Request.Method.PATCH:
+                builder.patch(createRequestBody(request));
+                break;
+            default:
+                throw new IllegalStateException("Unknown method type.");
+        }
+    }
+
+    private static ProtocolVersion parseProtocol(final Protocol p) {
+        switch (p) {
+            case HTTP_1_0:
+                return new ProtocolVersion("HTTP", 1, 0);
+            case HTTP_1_1:
+                return new ProtocolVersion("HTTP", 1, 1);
+            case SPDY_3:
+                return new ProtocolVersion("SPDY", 3, 1);
+            case HTTP_2:
+                return new ProtocolVersion("HTTP", 2, 0);
+        }
+
+        throw new IllegalAccessError("Unknown protocol");
+    }
+
+    private static @Nullable RequestBody createRequestBody(Request r) throws AuthFailureError {
+        final byte[] body = r.getBody();
+        if (body == null) return null;
+
+        return RequestBody.create(MediaType.parse(r.getBodyContentType()), body);
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/App.java
+++ b/app/src/main/java/org/projectbuendia/client/App.java
@@ -62,10 +62,9 @@ public class App extends Application {
         Collect.onCreate(this);
         super.onCreate();
 
-        Stetho.initialize(Stetho.newInitializerBuilder(this)
-            .enableDumpapp(Stetho.defaultDumperPluginsProvider(this))
-            .enableWebKitInspector(Stetho.defaultInspectorModulesProvider(this))
-            .build());
+        // Enable Stetho, which lets you inspect the app's database, UI, and network activity
+        // just by opening chrome://inspect in Chrome on a computer connected to the tablet.
+        Stetho.initializeWithDefaults(this);
 
         SQLiteDatabase.loadLibs(this);
 

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -72,7 +72,7 @@ public class Database extends SQLiteOpenHelper {
      * A map of SQL table schemas, with one entry per table.  The values should
      * be strings that take the place of X in a "CREATE TABLE foo (X)" statement.
      */
-    static final Map<Table, String> SCHEMAS = new HashMap();
+    static final Map<Table, String> SCHEMAS = new HashMap<>();
 
     // For descriptions of these tables and the meanings of their columns, see Contracts.java.
     static {


### PR DESCRIPTION
Stetho can show you all the network requests made by our app, in the Network tab, in Chrome Developer Tools.  But, to make that work, we have to install a StethoInterceptor to intercept our Volley requests, and that requires an OkHttp-based network stack.  This change adds an open source OkHttpStack class by Bryan Stern (https://gist.github.com/bryanstern/4e8f1cb5a8e14c202750) and installs the interceptor.

![image](https://cloud.githubusercontent.com/assets/236086/10200676/9ff53080-675c-11e5-9733-b830468f23f9.png)
