### PR TITLE
Fix order cells not being clickable for orders with no stop time.

### DIFF
--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -117,7 +117,7 @@
           {% for column in columns %}
             <td class="{{column.start == nowColumnStart ? 'now' : ''}}">
               {% set active = intervals_overlap(order.interval, column.interval) %}
-              {% if order.stop == null and previousActive %}
+              {% if future and order.stop == null %}
                 <div class="future">&nbsp;</div>
               {% elseif order.stop != null and previousActive and not active %}
                 <div class="stop">Stop</div>

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -258,8 +258,6 @@ public class ChartRenderer {
             List<Instant> consecutiveEmptyColumns = new ArrayList<>();
 
             for (LocalDate d = since; !d.isAfter(to); d = d.plusDays(1)) {
-                //Column column = getColumnContainingTime(d.toDateTimeAtStartOfDay());
-
                 Column column = getColumnContainingTime(d.toDateTimeAtStartOfDay());
 
                 if(!column.hasObservations() && d.isBefore(mToday)) {
@@ -273,6 +271,9 @@ public class ChartRenderer {
                     consecutiveEmptyColumns.clear();
                 }
             }
+
+            // Ensure that the last column is present.
+            getColumnContainingTime(to.toDateTimeAtStartOfDay());
         }
 
         /** Returns all non null start and stop observation dates */


### PR DESCRIPTION
This fixes a bug that caused no number to be displayed in grid cells for orders with no stop time (thus making it impossible to click to bring up the order execution dialog).
