### PR TITLE
Removed the double html load in patient chart.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -90,10 +90,6 @@ public class ChartRenderer {
         mView.setWebChromeClient(new WebChromeClient());
         String html = new GridHtmlGenerator(chart, latestObservations, observations, orders,
                                             admissionDate, firstSymptomsDate).getHtml();
-        // If we only call loadData once, the WebView doesn't render the new HTML.
-        // If we call loadData twice, it works.  TODO: Figure out what's going on.
-        mView.loadDataWithBaseURL("file:///android_asset/", html,
-            "text/html; charset=utf-8", "utf-8", null);
         mView.loadDataWithBaseURL("file:///android_asset/", html,
             "text/html; charset=utf-8", "utf-8", null);
         mView.setWebContentsDebuggingEnabled(true);


### PR DESCRIPTION
I've tested this on the emulator when I implemented the freeze panes and now tested on the tablet and did not see any problem so I removed the double loadDataWithBaseURL call.
