### PR TITLE
Fix incremental fetch missing observations

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
@@ -100,8 +100,19 @@ public class OpenMrsChartServer {
         Instant lastTime,
         Response.Listener<JsonPatientRecordResponse> successListener,
         Response.ErrorListener errorListener) {
+
+        // TODO/cleanup: Remove this fix from the client once the equivalent fix in
+        // EncounterResource.filterEncountersByModificationTime is deployed in the server.
+
+        // Even though OpenMRS getDateCreated() and getDateModified() return Date objects that
+        // have millisecond precision, it truncates away the fractional milliseconds from these
+        // values when storing them in the database!!  Bad OpenMRS.  So for example, an observation
+        // created at 12:00:00.750 will be stored with a creation time of 12:00:00 -- which means
+        // that in order to return all the observations that were created after 12:00:00.500, we
+        // actually have to check for creation times after 12:00:00.000.
+        long startMillis = ((int) (lastTime.getMillis() / 1000)) * 1000;
         doEncountersRequest(mConnectionDetails.getBuendiaApiUrl()
-                + "/encounters?sm=" + lastTime.getMillis(),
+                + "/encounters?sm=" + startMillis,
             successListener, errorListener);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
@@ -110,7 +110,7 @@ public class OpenMrsChartServer {
         // created at 12:00:00.750 will be stored with a creation time of 12:00:00 -- which means
         // that in order to return all the observations that were created after 12:00:00.500, we
         // actually have to check for creation times after 12:00:00.000.
-        long startMillis = ((int) (lastTime.getMillis() / 1000)) * 1000;
+        long startMillis = (lastTime.getMillis() / 1000) * 1000;
         doEncountersRequest(mConnectionDetails.getBuendiaApiUrl()
                 + "/encounters?sm=" + startMillis,
             successListener, errorListener);


### PR DESCRIPTION
This is a pretty subtle bug due to OpenMRS yet again failing to store and retrieve data faithfully.  OpenMRS uses the Java Date object for representing timestamps, but it does not preserve Date objects correctly—it truncates the fractional seconds in storage, leading to bugs like this one.

There is a corresponding fix on the server side, but because the loss of observations is such a bad, user-visible bug, so it's worth doing a quick fix on the client side until the fix on the server is in production.
