### PR TITLE
Add an ID prefix field for patients.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -62,7 +62,7 @@ public class EditPatientDialogFragment extends DialogFragment {
     @InjectView(R.id.patient_sex_female) RadioButton mSexFemale;
     @InjectView(R.id.patient_sex_male) RadioButton mSexMale;
 
-    private static final Pattern ID_PATTERN = Pattern.compile("([a-zA-Z]+)/?([0-9]+)");
+    private static final Pattern ID_PATTERN = Pattern.compile("([a-zA-Z]+)/?([0-9]+)*");
 
     private LayoutInflater mInflater;
     @Nullable private ActivityUi mActivityUi;  // optional UI for showing a spinner

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -14,7 +14,9 @@ package org.projectbuendia.client.ui.dialogs;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
@@ -37,6 +39,9 @@ import org.projectbuendia.client.models.Patient;
 import org.projectbuendia.client.models.PatientDelta;
 import org.projectbuendia.client.utils.Utils;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.inject.Inject;
 
 import butterknife.ButterKnife;
@@ -47,6 +52,7 @@ public class EditPatientDialogFragment extends DialogFragment {
     @Inject AppModel mModel;
     @Inject CrudEventBus mCrudEventBus;
 
+    @InjectView(R.id.patient_id_prefix) EditText mIdPrefix;
     @InjectView(R.id.patient_id) EditText mId;
     @InjectView(R.id.patient_given_name) EditText mGivenName;
     @InjectView(R.id.patient_family_name) EditText mFamilyName;
@@ -55,6 +61,8 @@ public class EditPatientDialogFragment extends DialogFragment {
     @InjectView(R.id.patient_sex) RadioGroup mSex;
     @InjectView(R.id.patient_sex_female) RadioButton mSexFemale;
     @InjectView(R.id.patient_sex_male) RadioButton mSexMale;
+
+    private static final Pattern ID_PATTERN = Pattern.compile("([a-zA-Z]+)/?([0-9]+)");
 
     private LayoutInflater mInflater;
     @Nullable private ActivityUi mActivityUi;  // optional UI for showing a spinner
@@ -92,7 +100,19 @@ public class EditPatientDialogFragment extends DialogFragment {
     }
 
     private void populateFields(Bundle args) {
-        mId.setText(Utils.valueOrDefault(args.getString("id"), ""));
+        String idPrefix = "";
+        String id = Utils.valueOrDefault(args.getString("id"), "");
+        Matcher matcher = ID_PATTERN.matcher(id);
+        if (matcher.matches()) {
+            idPrefix = matcher.group(1);
+            id = matcher.group(2);
+        }
+        if (idPrefix.isEmpty() && id.isEmpty()) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getActivity());
+            idPrefix = pref.getString("last_id_prefix", "");
+        }
+        mIdPrefix.setText(idPrefix);
+        mId.setText(id);
         mGivenName.setText(Utils.valueOrDefault(args.getString("givenName"), ""));
         mFamilyName.setText(Utils.valueOrDefault(args.getString("familyName"), ""));
         LocalDate birthdate = Utils.toLocalDate(args.getString("birthdate"));
@@ -112,7 +132,8 @@ public class EditPatientDialogFragment extends DialogFragment {
     }
 
     public void onSubmit() {
-        String id = Utils.toNonemptyOrNull(mId.getText().toString().trim());
+        String idPrefix = mIdPrefix.getText().toString().trim();
+        String id = mId.getText().toString().trim();
         String givenName = Utils.toNonemptyOrNull(mGivenName.getText().toString().trim());
         String familyName = Utils.toNonemptyOrNull(mFamilyName.getText().toString().trim());
         String ageYears = mAgeYears.getText().toString().trim();
@@ -136,6 +157,8 @@ public class EditPatientDialogFragment extends DialogFragment {
                 sex = Patient.GENDER_MALE;
                 break;
         }
+
+        id = idPrefix.isEmpty() ? id : idPrefix + "/" + id;
         Utils.logUserAction("patient_submitted",
             "id", id,
             "given_name", givenName,
@@ -145,12 +168,17 @@ public class EditPatientDialogFragment extends DialogFragment {
             "sex", "" + sex);
 
         PatientDelta delta = new PatientDelta();
-        delta.id = Optional.fromNullable(id);
+        delta.id = Optional.of(id);
         delta.givenName = Optional.fromNullable(givenName);
         delta.familyName = Optional.fromNullable(familyName);
         delta.birthdate = Optional.fromNullable(birthdate);
         delta.gender = Optional.of(sex);
         delta.admissionDate = Optional.of(admissionDate);
+
+        if (!idPrefix.isEmpty()) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getActivity());
+            pref.edit().putString("last_id_prefix", idPrefix).commit();
+        }
 
         Bundle args = getArguments();
         if (args.getBoolean("new")) {
@@ -164,6 +192,23 @@ public class EditPatientDialogFragment extends DialogFragment {
         // TODO: While the network request is in progress, show a spinner and/or keep the
         // dialog open but greyed out -- keep the UI blocked to make it clear that there is a
         // modal operation going on, while providing a way for the user to abort the operation.
+    }
+
+    public void focusFirstEmptyField(Dialog dialog) {
+        // Open the keyboard.
+        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
+        // Set focus.
+        EditText[] fields = {mIdPrefix, mId, mGivenName, mFamilyName, mAgeYears, mAgeMonths};
+        for (EditText field : fields) {
+            if (field.getText().toString().isEmpty()) {
+                field.requestFocus();
+                break;
+            }
+        }
+
+        // Default to focusing on the given name field.
+        mGivenName.requestFocus();
     }
 
     @Override public @NonNull Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -186,8 +231,7 @@ public class EditPatientDialogFragment extends DialogFragment {
             .setView(fragment)
             .create();
 
-        // Open the keyboard, ready to type into the given name field.
-        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        focusFirstEmptyField(dialog);
         return dialog;
     }
 

--- a/app/src/main/res/layout/listview_cell_search_results.xml
+++ b/app/src/main/res/layout/listview_cell_search_results.xml
@@ -33,14 +33,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16sp"
-        android:width="108sp"
+        android:width="120sp"
         android:background="@android:color/darker_gray"
         android:gravity="center"
         android:paddingBottom="12sp"
         android:paddingTop="12sp"
         android:textAppearance="@style/text.large"
         android:textColor="@color/white"
-        tools:text="Kh.1234"/>
+        tools:text="BOK/1234"/>
 
     <TextView
         android:id="@+id/listview_cell_search_results_name"

--- a/app/src/main/res/layout/patient_dialog_fragment.xml
+++ b/app/src/main/res/layout/patient_dialog_fragment.xml
@@ -24,6 +24,20 @@
     <TableRow>
       <TextView
           style="@style/field_label"
+          android:labelFor="@+id/patient_id_prefix"
+          android:text="@string/id_prefix" />
+      <EditText
+          android:id="@+id/patient_id_prefix"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:inputType="textCapCharacters"
+          android:singleLine="true"
+          android:ems="5" />
+    </TableRow>
+
+    <TableRow>
+      <TextView
+          style="@style/field_label"
           android:labelFor="@+id/patient_id"
           android:text="@string/id" />
       <EditText

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -120,6 +120,7 @@
   <string name="since_symptom_onset">Depuis début des symptômes</string>
   <string name="location">Emplacement</string>
   <string name="id">ID</string>
+  <string name="id_prefix">Préfix de l\'ID</string>
   <string name="patient_creation_given_name_label">Prénom</string>
   <string name="patient_creation_family_name_label">Nom de famille</string>
   <string name="age">Age</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
   <string name="since_symptom_onset">Since symptom onset</string>
   <string name="location">Location</string>
   <string name="id">ID</string>
+  <string name="id_prefix">ID prefix</string>
   <string name="patient_creation_given_name_label">Given name</string>
   <string name="patient_creation_family_name_label">Family name</string>
   <string name="age">Age</string>


### PR DESCRIPTION
We added this field because of the way that facility codes become part of patient IDs in the Bokoro project.  In this project IDs are quite long due to Ministry of Health conventions, like HAD/BOK/BOK/123, even though the first part (HAD/BOK/BOK) is highly redundant and something like BOK/123 alone would suffice in practice.

This implementation assumes that IDs will look like XYZ/123 where XYZ is a facility prefix and 123 is the numeric patient ID.  We haven't validated that this will actually work for users in Bokoro yet, but we know that numbers alone are not sufficient and we needed an interim solution to disambiguate patients from different facilities.  I think it doesn't hurt to review this anyway, and possibly merge it this week, even though we will probably change our approach to this later.
