### PR TITLE
Changing time formatter to use specif time zone rather than UTC

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
@@ -263,7 +263,9 @@ public class PebbleExtension extends AbstractExtension {
             String pattern = "" + args.get("pattern");
 
             if (input instanceof ReadableInstant) {
-                return DateTimeFormat.forPattern(pattern).print(new DateTime(input));
+                //Return time specif to time zone rather than UTC
+                return DateTimeFormat.forPattern(pattern).print(
+                    new DateTime(((ReadableInstant) input).getMillis()));
             } else return TYPE_ERROR;
         }
     }


### PR DESCRIPTION
The timestamp showed in patient's dialog was inaccurate. 
It was showing the timestamp in UTC rather than the user time zone. 
