### PR TITLE
Fix UserManagerTest#testLoadKnownUsers_GeneratesEventOnFailure

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/user/UserManagerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/user/UserManagerTest.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableSet;
 
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.projectbuendia.client.FakeAsyncTaskRunner;
 import org.projectbuendia.client.events.user.KnownUsersLoadFailedEvent;
 import org.projectbuendia.client.events.user.KnownUsersLoadedEvent;
@@ -52,19 +54,24 @@ public final class UserManagerTest extends InstrumentationTestCase {
         mFakeAsyncTaskRunner.runUntilEmpty();
         // THEN the user manager fires off a KnownUsersLoadedEvent
         assertTrue(mFakeEventBus.getEventLog().contains(
-            new KnownUsersLoadedEvent(ImmutableSet.of(USER))));
+                new KnownUsersLoadedEvent(ImmutableSet.of(USER))));
     }
 
     /** Tests that an event is posted when users fail to load. */
     public void testLoadKnownUsers_GeneratesEventOnFailure() throws Exception {
-        // GIVEN the user store returns an empty set of users
-        when(mMockUserStore.loadKnownUsers()).thenReturn(ImmutableSet.<JsonUser> of());
+        // GIVEN the user store throws an exception when trying to load the users
+        when(mMockUserStore.loadKnownUsers()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                throw new InterruptedException("INTENDED FOR TEST");
+            }
+        });
         // WHEN loadKnownUsers is called and the async task is run
         mUserManager.loadKnownUsers();
         mFakeAsyncTaskRunner.runUntilEmpty();
         // THEN the user manager fires off a KnownUsersLoadFailedEvent
         mFakeEventBus.assertEventLogContains(
-            new KnownUsersLoadFailedEvent(KnownUsersLoadFailedEvent.REASON_NO_USERS_RETURNED));
+                new KnownUsersLoadFailedEvent(KnownUsersLoadFailedEvent.REASON_UNKNOWN));
     }
 
     @Override protected void setUp() throws Exception {

--- a/app/src/androidTest/java/org/projectbuendia/client/user/UserManagerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/user/UserManagerTest.java
@@ -54,7 +54,7 @@ public final class UserManagerTest extends InstrumentationTestCase {
         mFakeAsyncTaskRunner.runUntilEmpty();
         // THEN the user manager fires off a KnownUsersLoadedEvent
         assertTrue(mFakeEventBus.getEventLog().contains(
-                new KnownUsersLoadedEvent(ImmutableSet.of(USER))));
+            new KnownUsersLoadedEvent(ImmutableSet.of(USER))));
     }
 
     /** Tests that an event is posted when users fail to load. */
@@ -71,7 +71,7 @@ public final class UserManagerTest extends InstrumentationTestCase {
         mFakeAsyncTaskRunner.runUntilEmpty();
         // THEN the user manager fires off a KnownUsersLoadFailedEvent
         mFakeEventBus.assertEventLogContains(
-                new KnownUsersLoadFailedEvent(KnownUsersLoadFailedEvent.REASON_UNKNOWN));
+            new KnownUsersLoadFailedEvent(KnownUsersLoadFailedEvent.REASON_UNKNOWN));
     }
 
     @Override protected void setUp() throws Exception {

--- a/app/src/main/java/org/projectbuendia/client/events/user/KnownUsersLoadFailedEvent.java
+++ b/app/src/main/java/org/projectbuendia/client/events/user/KnownUsersLoadFailedEvent.java
@@ -15,7 +15,6 @@ package org.projectbuendia.client.events.user;
 public final class KnownUsersLoadFailedEvent {
 
     public static final int REASON_UNKNOWN = 0;
-    public static final int REASON_NO_USERS_RETURNED = 1;
     public static final int REASON_CANCELLED = 2;
 
     public final int reason;


### PR DESCRIPTION
As of PR #91, having zero users is no longer an error. This test was previously based on
zero users being an error, so we change it such that the UserStore throws an error instead - a
condition that's still considered an error by the system.
