### PR TITLE
Improve reliability of PatientChartActivityTest.

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartActivityTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartActivityTest.java
@@ -13,21 +13,15 @@ package org.projectbuendia.client.ui.chart;
 
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingResource;
+import android.support.test.espresso.ViewInteraction;
 import android.support.test.espresso.web.webdriver.Locator;
-
-import static android.support.test.espresso.web.assertion.WebViewAssertions.webMatches;
-import static android.support.test.espresso.web.sugar.Web.onWebView;
-import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
-import static android.support.test.espresso.web.webdriver.DriverAtoms.getText;
-
-import static org.hamcrest.Matchers.containsString;
-
 import android.test.suitebuilder.annotation.MediumTest;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.RadioButton;
 
+import org.hamcrest.Matcher;
 import org.odk.collect.android.views.MediaLayout;
 import org.odk.collect.android.views.ODKView;
 import org.odk.collect.android.widgets2.group.TableWidgetGroup;
@@ -42,6 +36,19 @@ import org.projectbuendia.client.utils.Utils;
 
 import java.util.UUID;
 
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isJavascriptEnabled;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.web.assertion.WebViewAssertions.webMatches;
+import static android.support.test.espresso.web.sugar.Web.onWebView;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.getText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+
 /** Functional tests for {@link PatientChartActivity}. */
 @MediumTest
 public class PatientChartActivityTest extends FunctionalTestCase {
@@ -51,6 +58,9 @@ public class PatientChartActivityTest extends FunctionalTestCase {
     private static final String YES = "●";
 
     private static final int ROW_HEIGHT = 84;
+    private static final Matcher<View> OVERFLOW_BUTTON_MATCHER = anyOf(
+            allOf(isDisplayed(), withContentDescription("More options")),
+            allOf(isDisplayed(), withClassName(endsWith("OverflowMenuButton"))));;
 
     public PatientChartActivityTest() {
         super();
@@ -148,13 +158,15 @@ public class PatientChartActivityTest extends FunctionalTestCase {
     }*/
 
     protected void openEncounterForm() {
-        // TODO: this method is still producing intermittent errors
+        // Wait until the overflow menu button is available.
+        expectVisibleSoon(Espresso.onView(OVERFLOW_BUTTON_MATCHER));
         openActionBarOptionsMenu();
 
         EventBusIdlingResource<FetchXformSucceededEvent> xformIdlingResource =
-            new EventBusIdlingResource<FetchXformSucceededEvent>(
-                UUID.randomUUID().toString(), mEventBus);
-        click(viewWithText("[test] Form"));
+                new EventBusIdlingResource<>(UUID.randomUUID().toString(), mEventBus);
+        ViewInteraction testForm = viewWithText("[test] Form");
+        expectVisibleSoon(testForm);
+        click(testForm);
         Espresso.registerIdlingResources(xformIdlingResource);
 
         // Give the form time to be parsed on the client (this does not result in an event firing).
@@ -338,6 +350,8 @@ public class PatientChartActivityTest extends FunctionalTestCase {
 
         // Check that all values are now visible.
         waitForProgressFragment();
+        // Expect a WebView with JS enabled to be visible soon (the chart).
+        expectVisibleSoon(viewThat(isJavascriptEnabled()));
         checkObservationValueEquals("[test] Temperature (°C)", "36");
         checkObservationValueEquals("[test] Respiratory rate (bpm)", "23");
         checkObservationValueEquals("[test] SpO₂ oxygen sat (%)", "95");


### PR DESCRIPTION
Improve reliability of PatientChartActivityTest by waiting for views to be shown before attempting
to click on them.

I suspect the root cause might be something to do with the way our Activity is structured, or
general flakiness in Espresso, but this resulted in a vast improvement on my setup, pointed at the
dev server.

Note also that this doesn't fix the tests - there are multiple issues that should be addressed in
future commits - but this allows the tests to actually get to the assertions instead of failing in
the setup code.
