### PR TITLE
Make PatientChartActivityTest slightly less flaky.

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartActivityTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartActivityTest.java
@@ -252,7 +252,7 @@ public class PatientChartActivityTest extends FunctionalTestCase {
 
         // Update a vital tile (pulse) as well as a couple of observations (temperature, vomiting
         // count), and verify that the latest value is visible for each.
-        for (int i = 0; i < 6; i++) {
+        for (int i = 0; i < 3; i++) {
             openEncounterForm();
 
             String temp = Integer.toString(i + 35) + ".7";
@@ -271,8 +271,8 @@ public class PatientChartActivityTest extends FunctionalTestCase {
             // TODO: implement IdlingResource for webview to remove this sleep.
             // Wait a bit for the chart to update it's values.
             try{
-                Thread.sleep(30000);
-            } catch (InterruptedException e){}
+                Thread.sleep(5000);
+            } catch (InterruptedException ignored){}
 
             //checkVitalValueContains("Pulse", pulse);
             checkObservationValueEquals("[test] Temperature (°C)", temp);
@@ -352,7 +352,11 @@ public class PatientChartActivityTest extends FunctionalTestCase {
         waitForProgressFragment();
         // Expect a WebView with JS enabled to be visible soon (the chart).
         expectVisibleSoon(viewThat(isJavascriptEnabled()));
-        checkObservationValueEquals("[test] Temperature (°C)", "36");
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException ignored) {
+        }
+        checkObservationValueEquals("[test] Temperature (°C)", "36.5");
         checkObservationValueEquals("[test] Respiratory rate (bpm)", "23");
         checkObservationValueEquals("[test] SpO₂ oxygen sat (%)", "95");
         checkObservationValueEquals("[test] Blood pressure, systolic", "80");


### PR DESCRIPTION
Previously, testEncounter_latestEncounterIsAlwaysShown would take 3 minutes to run because there was
a 30 second wait and 6 iterations. A 5 second wait is enough for it to work, and 3 iterations is
enough to actually test the same behavior.

Fix an error in testCombinesNonOverlappingObservationsForSameEncounter such that it works with the
test profile and with the dev server.
