### PR TITLE
Fixing error when OdkDatabase tries to fetch the form id from a nonexistent file

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/net/OdkDatabaseTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/net/OdkDatabaseTest.java
@@ -1,0 +1,35 @@
+// Copyright 2015 The Project Buendia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distrib-
+// uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+// specific language governing permissions and limitations under the License.
+
+package org.projectbuendia.client.net;
+
+import android.test.InstrumentationTestCase;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.projectbuendia.client.utils.RelativeDateTimeFormatter;
+
+import java.io.File;
+import java.util.UUID;
+
+/** Test cases for {@link OdkDatabaseTest}. */
+public class OdkDatabaseTest extends InstrumentationTestCase {
+
+    public void testNonExistentFile_getFormIdForPathMustReturnOneNegative() throws Exception {
+        File nonExistentFile = new File("/nonExistentPath_ " + UUID.randomUUID().toString());
+        long expectedFormId = -1;
+
+        long actualFormId = OdkDatabase.getFormIdForPath(nonExistentFile);
+
+        assertEquals("Given an non existent file, the form id must be -1", expectedFormId,
+            actualFormId);
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/net/OdkDatabase.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OdkDatabase.java
@@ -45,7 +45,6 @@ public class OdkDatabase {
                         + "error occurred on insert (probably a race condition) and should be "
                         + "fixed. However, the app should still function correctly");
                 }
-                Preconditions.checkArgument(cursor.getColumnCount() == 1);
                 // getCursorForFormFile returns the most recent element first, so we can just use
                 // the first one.
                 cursor.moveToNext();

--- a/app/src/main/java/org/projectbuendia/client/net/OdkDatabase.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OdkDatabase.java
@@ -36,18 +36,21 @@ public class OdkDatabase {
                 path, new String[] {
                     BaseColumns._ID
                 });
-            // There should only ever be one form per UUID. But if something goes wrong, we want the
-            // app to keep working. Assume the latest one is correct.
-            if (cursor.getCount() > 1) {
-                Log.e(TAG, "More than one form in database with the same id. This indicates an "
-                    + "error occurred on insert (probably a race condition) and should be "
-                    + "fixed. However, the app should still function correctly");
+            //if any form was found by the given file.
+            if(cursor.getCount() >= 1) {
+                // There should only ever be one form per UUID. But if something goes wrong, we want
+                // the app to keep working. Assume the latest one is correct.
+                if (cursor.getCount() > 1) {
+                    Log.e(TAG, "More than one form in database with the same id. This indicates an "
+                        + "error occurred on insert (probably a race condition) and should be "
+                        + "fixed. However, the app should still function correctly");
+                }
+                Preconditions.checkArgument(cursor.getColumnCount() == 1);
+                // getCursorForFormFile returns the most recent element first, so we can just use
+                // the first one.
+                cursor.moveToNext();
+                formId = cursor.getLong(0);
             }
-            Preconditions.checkArgument(cursor.getColumnCount() == 1);
-            // getCursorForFormFile returns the most recent element first, so we can just use the
-            // first one.
-            cursor.moveToNext();
-            formId = cursor.getLong(0);
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
The method `OdkDatabe#getFormIdForPath` was throwing an `CursorIndexOutOfBoundsException` when it was trying to fetch the form id from a nonexistent file. But the proper was, as documented in javadoc, was to return `-1` if no match was found.

Here the full stack trace

``` java

android.database.CursorIndexOutOfBoundsException: Index 0 requested, with a size of 0
at android.database.AbstractCursor.checkPosition(AbstractCursor.java:426)
at android.database.AbstractWindowedCursor.checkPosition(AbstractWindowedCursor.java:136)
at android.database.AbstractWindowedCursor.getLong(AbstractWindowedCursor.java:74)
at android.database.CursorWrapper.getLong(CursorWrapper.java:106)
at org.projectbuendia.client.net.OdkDatabase.getFormIdForPath(OdkDatabase.java:50)
at org.projectbuendia.client.net.OdkDatabaseTest.testInexistentFile_getFormIdForPathMustReturnOneNegative(OdkDatabaseTest.java:30)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at android.test.InstrumentationTestCase.runMethod(InstrumentationTestCase.java:214)
at android.test.InstrumentationTestCase.runTest(InstrumentationTestCase.java:199)
at junit.framework.TestCase.runBare(TestCase.java:134)
at junit.framework.TestResult$1.protect(TestResult.java:115)
at junit.framework.TestResult.runProtected(TestResult.java:133)
at android.support.test.internal.runner.junit3.DelegatingTestResult.runProtected(DelegatingTestResult.java:90)
at junit.framework.TestResult.run(TestResult.java:118)
at android.support.test.internal.runner.junit3.AndroidTestResult.run(AndroidTestResult.java:49)
at junit.framework.TestCase.run(TestCase.java:124)
at android.support.test.internal.runner.junit3.NonLeakyTestSuite$NonLeakyTest.run(NonLeakyTestSuite.java:63)
at junit.framework.TestSuite.runTest(TestSuite.java:243)
at junit.framework.TestSuite.run(TestSuite.java:238)
at android.support.test.internal.runner.junit3.DelegatingTestSuite.run(DelegatingTestSuite.java:103)
at android.support.test.internal.runner.junit3.AndroidTestSuite.run(AndroidTestSuite.java:63)
at android.support.test.internal.runner.junit3.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
at org.junit.runners.Suite.runChild(Suite.java:128)
at org.junit.runners.Suite.runChild(Suite.java:27)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:54)
at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:228)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1853)
```

Here is a print screen before the fix
![screen shot 2015-11-05 at 19 01 33](https://cloud.githubusercontent.com/assets/665045/10982382/0fb510b2-83f4-11e5-9a25-769772ce4ecf.png)

And finally, after fixing it
![screen shot 2015-11-05 at 19 19 39](https://cloud.githubusercontent.com/assets/665045/10982411/361d345a-83f4-11e5-9365-03a7088901d6.png)
