### PR TITLE
Generalize sync token storage.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -77,9 +77,8 @@ public class AppModel {
             if (c.moveToNext()) {
                 DateTime fullSyncStart = Utils.getDateTime(c, Contracts.Misc.FULL_SYNC_START_MILLIS);
                 DateTime fullSyncEnd = Utils.getDateTime(c, Contracts.Misc.FULL_SYNC_END_MILLIS);
-                DateTime obsSyncEnd = Utils.getDateTime(c, Contracts.Misc.OBS_SYNC_END_MILLIS);
-                LOG.i("full_sync_start_millis = %s, full_sync_end_millis = %s, obs_sync_end_millis = %s",
-                    fullSyncStart, fullSyncEnd, obsSyncEnd);
+                LOG.i("full_sync_start_millis = %s, full_sync_end_millis = %s",
+                    fullSyncStart, fullSyncEnd);
                 if (fullSyncStart != null && fullSyncEnd != null && fullSyncEnd.isAfter(fullSyncStart)) {
                     return fullSyncEnd;
                 }

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
@@ -16,7 +16,6 @@ import android.support.annotation.Nullable;
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Response;
 
-import org.joda.time.Instant;
 import org.projectbuendia.client.json.JsonChart;
 import org.projectbuendia.client.json.JsonConceptResponse;
 import org.projectbuendia.client.json.JsonEncountersResponse;
@@ -64,18 +63,17 @@ public class OpenMrsChartServer {
     /**
      * Get all observations that happened in an encounter after or on {@code minCreationTime}.
      * Allows a client to do incremental cache updating.
-     * @param minCreationTime a joda instant representing the start time for new observations
-     *                        (inclusive). if null, will fetch all encounters since the dawn of
-     *                        time.
+     * @param lastSyncToken   a sync token provided by the server on a previous sync.
      * @param successListener a listener to get the results on the event of success
      * @param errorListener   a (Volley) listener to get any errors
      */
     public void getIncrementalEncounters(
-        @Nullable Instant minCreationTime,
+        @Nullable String lastSyncToken,
         Response.Listener<JsonEncountersResponse> successListener,
         Response.ErrorListener errorListener) {
+        // TODO: URL-encode the sync token?
         doEncountersRequest(mConnectionDetails.getBuendiaApiUrl() + "/encounters" +
-                (minCreationTime != null ? "?since=" + minCreationTime.toString() : ""),
+                (lastSyncToken != null ? "?since=" + lastSyncToken : ""),
                 successListener, errorListener);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
@@ -154,7 +154,7 @@ public class BuendiaProvider extends DelegatingProvider<Database> {
                 new ItemProviderDelegate(
                         Contracts.SyncTokens.ITEM_CONTENT_TYPE,
                         Table.SYNC_TOKENS,
-                        Contracts.SyncTokens.TYPE));
+                        Contracts.SyncTokens.TABLE_NAME));
 
         return registry;
     }

--- a/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
@@ -144,6 +144,18 @@ public class BuendiaProvider extends DelegatingProvider<Database> {
                 Table.MISC,
                 "rowid"));
 
+        registry.registerDelegate(
+            Contracts.SyncTokens.CONTENT_URI.getPath(),
+            new GroupProviderDelegate(
+                Contracts.SyncTokens.ITEM_CONTENT_TYPE,
+                Table.SYNC_TOKENS));
+        registry.registerDelegate(
+                Contracts.SyncTokens.CONTENT_URI.getPath() + "/*",
+                new ItemProviderDelegate(
+                        Contracts.SyncTokens.ITEM_CONTENT_TYPE,
+                        Table.SYNC_TOKENS,
+                        Contracts.SyncTokens.TYPE));
+
         return registry;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
@@ -154,7 +154,7 @@ public class Contracts {
     public interface SyncTokens {
         Uri CONTENT_URI = buildContentUri("sync-tokens");
         String ITEM_CONTENT_TYPE = buildItemType("sync-token");
-        String TYPE = "type";
+        String TABLE_NAME = "table_name";
         String SYNC_TOKEN = "sync_token";
     }
 

--- a/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
@@ -35,7 +35,8 @@ public class Contracts {
         OBSERVATIONS("observations"),
         ORDERS("orders"),
         PATIENTS("patients"),
-        USERS("users");
+        USERS("users"),
+        SYNC_TOKENS("sync_tokens");
 
         public String name;
 
@@ -148,14 +149,13 @@ public class Contracts {
          */
         String FULL_SYNC_END_MILLIS = "full_sync_end_millis";
 
-        /**
-         * The "snapshot time" of the last observation sync operation, according
-         * to the server's clock.  This is used to request an incremental update
-         * of observations from the server.
-         * <p/>
-         * <p>Updated after observation sync to the snapshot time reported by the server.
-         */
-        String OBS_SYNC_END_MILLIS = "obs_sync_end_millis";
+    }
+
+    public interface SyncTokens {
+        Uri CONTENT_URI = buildContentUri("sync-tokens");
+        String ITEM_CONTENT_TYPE = buildItemType("sync-token");
+        String TYPE = "type";
+        String SYNC_TOKEN = "sync_token";
     }
 
     public interface Observations {

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -154,7 +154,7 @@ public class Database extends SQLiteOpenHelper {
             + "full_sync_end_millis INTEGER");
 
         SCHEMAS.put(Table.SYNC_TOKENS, ""
-            + "type TEXT PRIMARY KEY NOT NULL,"
+            + "table_name TEXT PRIMARY KEY NOT NULL,"
             + "sync_token TEXT NOT NULL");
     }
 

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -151,8 +151,11 @@ public class Database extends SQLiteOpenHelper {
         // and a value column, not all values in one row with an ever-growing number of columns.
         SCHEMAS.put(Table.MISC, ""
             + "full_sync_start_millis INTEGER,"
-            + "full_sync_end_millis INTEGER,"
-            + "obs_sync_end_millis INTEGER");
+            + "full_sync_end_millis INTEGER");
+
+        SCHEMAS.put(Table.SYNC_TOKENS, ""
+            + "type TEXT PRIMARY KEY NOT NULL,"
+            + "sync_token TEXT NOT NULL");
     }
 
     public Database(Context context) {


### PR DESCRIPTION
Previously, a server-supplied timestamp was stored for each incremental observation sync. This
timestamp was stored in a field in the "misc" SQLite table.

There are two problems with this:
- Our design (http://j.mp/buendia-sync) advocates the client treating the server-supplied token as
  an opaque sync token instead of as a timestamp
- Soon we'll be storing sync tokens for patients as well.

This change refactors the incremental observation timestamp storage into a more general "sync token"
storage, which can be used by multiple sync phases.
