### PR TITLE
Fix GsonRequest's use of generics.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/net/GsonRequest.java
+++ b/app/src/main/java/org/projectbuendia/client/net/GsonRequest.java
@@ -11,8 +11,6 @@
 
 package org.projectbuendia.client.net;
 
-import android.util.Log;
-
 import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;
 import com.android.volley.ParseError;
@@ -21,40 +19,40 @@ import com.android.volley.Response;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
 import org.apache.http.protocol.HTTP;
 
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import javax.annotation.Nullable;
 
 /** A {@link Request} with a JSON response parsed by {@link Gson}. */
 public class GsonRequest<T> extends Request<T> {
-
     private final GsonBuilder mGson = new GsonBuilder();
-    private final Class<T> mClazz;
+    private final Type mType;
     private final Map<String, String> mHeaders;
     private final Response.Listener<T> mListener;
-    private final boolean mIsArray;
     private Map<String, String> mBody = null;
 
     /**
      * Makes a GET request and returns a parsed object from JSON.
      * @param url           URL of the request to make
-     * @param clazz         Relevant class object, for Gson's reflection
+     * @param type          The type of the base response JSON object. Gson reflects on this
+     *                      parameter to create the response object. Note that in most situations,
+     *                      using {@code MyJsonResponseType.class} will work, but if your response
+     *                      object makes use of generics, you will need to generate a type from a
+     *                      {@link com.google.gson.reflect.TypeToken TypeToken}, using something
+     *                      like {@code new TypeToken<MyJsonResponseType<SubType>>{}.getType()}.
      * @param headers       Map of request headers
      * @param listener      a {@link Response.Listener} that handles successful requests
      * @param errorListener a {@link Response.ErrorListener} that handles failed requests
      */
-    public GsonRequest(String url, Class<T> clazz, boolean array, Map<String, String> headers,
+    public GsonRequest(String url, Type type, Map<String, String> headers,
                        Response.Listener<T> listener, Response.ErrorListener errorListener) {
-        this(Method.GET, null, url, clazz, array, headers, listener, errorListener);
+        this(Method.GET, null, url, type, headers, listener, errorListener);
     }
 
     /**
@@ -62,38 +60,25 @@ public class GsonRequest<T> extends Request<T> {
      * @param method        the request method
      * @param body          the request body
      * @param url           URL of the request to make
-     * @param clazz         Relevant class object, for Gson's reflection
-     * @param isArray       true if the response is expected to contain an array of items
+     * @param type          The type of the base response JSON object. Gson reflects on this
+     *                      parameter to create the response object. Note that in most situations,
+     *                      using {@code MyJsonResponseType.class} will work, but if your response
+     *                      object makes use of generics, you will need to generate a type from a
+     *                      {@link com.google.gson.reflect.TypeToken TypeToken}, using something
+     *                      like {@code new TypeToken<MyJsonResponseType<SubType>>{}.getType()}.
      * @param headers       Map of request headers
      * @param listener      a {@link Response.Listener} that handles successful requests
      * @param errorListener a {@link Response.ErrorListener} that handles failed requests
      */
     public GsonRequest(int method,
                        @Nullable Map<String, String> body,
-                       String url, Class<T> clazz, boolean isArray, Map<String, String> headers,
+                       String url, Type type, Map<String, String> headers,
                        Response.Listener<T> listener, Response.ErrorListener errorListener) {
         super(method, url, errorListener);
         this.mBody = body;
-        this.mClazz = clazz;
+        this.mType = type;
         this.mHeaders = headers;
         this.mListener = listener;
-        this.mIsArray = isArray;
-    }
-
-    /**
-     * Creates an instance of {@link GsonRequest} that expects an array of Gson objects as a
-     * response.
-     */
-    public static <T> GsonRequest<List<T>> withArrayResponse(
-        String url,
-        Class<T> clazz,
-        Map<String, String> headers,
-        Response.Listener<List<T>> listener,
-        Response.ErrorListener errorListener) {
-        // TODO: This current class does not handle arrays well because it doesn't properly
-        // use Java generics. Until we can fix it, we'll just cast a lot to make Java happy.
-        return (GsonRequest<List<T>>) new GsonRequest<>(
-            url, clazz, true, headers, (Response.Listener<T>) listener, errorListener);
     }
 
     @Override public Map<String, String> getHeaders() throws AuthFailureError {
@@ -118,22 +103,10 @@ public class GsonRequest<T> extends Request<T> {
                 response.data,
                 HTTP.UTF_8);  // TODO: HttpHeaderParser.parseCharset(response.mHeaders).
             Gson gsonParser = mGson.create();
-            Log.d("SyncAdapter", "parsing response");
-            if (mIsArray) {
-                JsonParser parser = new JsonParser();
-                JsonArray array = (JsonArray) parser.parse(json);
-                ArrayList<T> elements = new ArrayList<>();
-                for (int i = 0; i < array.size(); i++) {
-                    elements.add(gsonParser.fromJson(array.get(i).toString(), mClazz));
-                }
-                return (Response<T>) Response.success(
-                    elements,
-                    HttpHeaderParser.parseCacheHeaders(response));
-            } else {
-                return Response.success(
-                    gsonParser.fromJson(json, mClazz),
-                    HttpHeaderParser.parseCacheHeaders(response));
-            }
+            //noinspection unchecked
+            return (Response<T>) Response.success(
+                gsonParser.fromJson(json, mType),
+                HttpHeaderParser.parseCacheHeaders(response));
         } catch (UnsupportedEncodingException e) {
             return Response.error(new ParseError(e));
         } catch (JsonSyntaxException e) {

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
@@ -56,7 +56,7 @@ public class OpenMrsChartServer {
                               Response.ErrorListener errorListener) {
         GsonRequest<JsonPatientRecord> request = new GsonRequest<>(
             mConnectionDetails.getBuendiaApiUrl() + "/encounters?patientUuid=" + patientUuid,
-            JsonPatientRecord.class, false,
+            JsonPatientRecord.class,
             mConnectionDetails.addAuthHeader(new HashMap<String, String>()),
             successListener, errorListener);
         Serializers.registerTo(request.getGson());
@@ -80,7 +80,7 @@ public class OpenMrsChartServer {
         Response.ErrorListener errorListener) {
         GsonRequest<JsonPatientRecordResponse> request = new GsonRequest<>(
             url,
-            JsonPatientRecordResponse.class, false,
+            JsonPatientRecordResponse.class,
             mConnectionDetails.addAuthHeader(new HashMap<String, String>()),
             successListener, errorListener);
         Serializers.registerTo(request.getGson());
@@ -114,7 +114,7 @@ public class OpenMrsChartServer {
                             Response.ErrorListener errorListener) {
         GsonRequest<JsonConceptResponse> request = new GsonRequest<JsonConceptResponse>(
             mConnectionDetails.getBuendiaApiUrl() + "/concepts",
-            JsonConceptResponse.class, false,
+            JsonConceptResponse.class,
             mConnectionDetails.addAuthHeader(new HashMap<String, String>()),
             successListener, errorListener) {
         };
@@ -133,7 +133,7 @@ public class OpenMrsChartServer {
         Response.ErrorListener errorListener) {
         GsonRequest<JsonChart> request = new GsonRequest<JsonChart>(
             mConnectionDetails.getBuendiaApiUrl() + "/charts/" + uuid + "?v=full",
-            JsonChart.class, false,
+            JsonChart.class,
             mConnectionDetails.addAuthHeader(new HashMap<String, String>()),
             successListener, errorListener) {
         };

--- a/app/src/main/java/org/projectbuendia/client/updater/PackageServer.java
+++ b/app/src/main/java/org/projectbuendia/client/updater/PackageServer.java
@@ -13,6 +13,7 @@ package org.projectbuendia.client.updater;
 
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Response;
+import com.google.gson.reflect.TypeToken;
 
 import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.net.Common;
@@ -49,9 +50,9 @@ public class PackageServer {
         Response.Listener<List<JsonUpdateInfo>> listener,
         Response.ErrorListener errorListener) {
         mVolley.addToRequestQueue(
-            GsonRequest.withArrayResponse(
+            new GsonRequest<>(
                 mSettings.getPackageServerUrl("/" + MODULE_NAME + ".json"),
-                JsonUpdateInfo.class,
+                new TypeToken<List<JsonUpdateInfo>>() {}.getType(),
                 null /* headers */,
                 listener,
                 errorListener


### PR DESCRIPTION
Previously, GsonRequest didn't support parameterized types. i.e.
- `GsonRequest<MyJsonResponse>` worked, but
- `GsonRequest<MyJsonResponse<OfX>>` didn't.

As a workaround, there was an `isArray` parameter you could pass to the constructor that, if set to true, would cause the type parameter to be interpreted as an array instead of as the base response type. Gross.

This change fixes that problem by moving to using `java.lang.reflect.Type` for the constructor parameter and recommending Gson's `TypeToken` paradigm for this use case. Note that passing `MyJsonResponse.class` to the `type` argument still works.

This change does sacrifice some type-safety, however - `Class<T>` implements `Type`, and so it's entirely possible for code that uses this class to pass the wrong base type for the generic. It would be possible to make this harder by having an overload that accepts `Class<T>`, but unless that parameter was in a different position to the `Type` parameter, this wouldn't achieve much - the `Class<T>` overload would be used _unless_ the wrong class was specified, in which case the wrong class parameter would be interpreted as as `Type`. I didn't think that the extra complication was worth creating an extra overload for, but I'm definitely open to ideas here :)
