### PR TITLE
Tidy up `Gson` serializers/deserializers.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/json/DateTimeSerializer.java
+++ b/app/src/main/java/org/projectbuendia/client/json/DateTimeSerializer.java
@@ -15,6 +15,9 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
 import org.joda.time.DateTime;
 
@@ -24,8 +27,15 @@ import java.lang.reflect.Type;
  * Utility class for serializing JODA DateTime objects from JSON returned by the OpenMRS Buendia
  * module.
  */
-public class DateTimeDeserializer implements JsonDeserializer<DateTime> {
-    @Override public DateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+public class DateTimeSerializer implements JsonSerializer<DateTime>, JsonDeserializer<DateTime> {
+
+    @Override
+    public JsonElement serialize(DateTime src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(src.toString());
+    }
+
+    @Override
+    public DateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
         return DateTime.parse(json.getAsString());
     }

--- a/app/src/main/java/org/projectbuendia/client/json/Serializers.java
+++ b/app/src/main/java/org/projectbuendia/client/json/Serializers.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 
 import java.lang.reflect.Type;
 
@@ -32,23 +33,6 @@ public class Serializers {
 
     public static void registerTo(GsonBuilder gson) {
         gson.registerTypeAdapter(DateTime.class, new DateTimeSerializer());
-        gson.registerTypeAdapter(DateTime.class, new DateTimeDeserializer());
-    }
-
-    private static class DateTimeSerializer implements JsonSerializer<DateTime> {
-        public JsonElement serialize(
-            DateTime src,
-            Type typeOfSrc,
-            JsonSerializationContext context) {
-            return new JsonPrimitive(src.toString());
-        }
-    }
-
-    private static class DateTimeDeserializer implements JsonDeserializer<DateTime> {
-        public DateTime deserialize(
-            JsonElement json, Type typeOfT, JsonDeserializationContext context)
-            throws JsonParseException {
-            return new DateTime(json.getAsJsonPrimitive().getAsString());
-        }
+        gson.registerTypeAdapter(LocalDate.class, new LocalDateSerializer());
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/net/NetModule.java
+++ b/app/src/main/java/org/projectbuendia/client/net/NetModule.java
@@ -19,8 +19,9 @@ import com.google.gson.GsonBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.projectbuendia.client.AppSettings;
-import org.projectbuendia.client.json.DateTimeDeserializer;
+import org.projectbuendia.client.json.DateTimeSerializer;
 import org.projectbuendia.client.json.LocalDateSerializer;
+import org.projectbuendia.client.json.Serializers;
 
 import javax.inject.Singleton;
 
@@ -56,10 +57,9 @@ public class NetModule {
 
     @Provides
     @Singleton Gson provideGson() {
-        return new GsonBuilder()
-            .registerTypeAdapter(LocalDate.class, new LocalDateSerializer())
-            .registerTypeAdapter(DateTime.class, new DateTimeDeserializer())
-            .create();
+        GsonBuilder builder = new GsonBuilder();
+        Serializers.registerTo(builder);
+        return builder.create();
     }
 
     @Provides


### PR DESCRIPTION
- Removed duplicate serializers (for Joda `DateTime`), renamed `DateTimeDeserializer` to `DateTimeSerializer`.
- Moved `NetModule`'s `Gson` provider method to use `Serializers#registerTo` class, which makes all usages consistent across the app.

Ideally, we'd move the things that aren't using the injected Gson to using the injected one, but that's a larger change, so we'll put it off.
