### PR TITLE
Fix Issue #144

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
@@ -163,18 +163,18 @@ public class Contracts {
         String GROUP_CONTENT_TYPE = buildGroupType("observation");
         String ITEM_CONTENT_TYPE = buildItemType("observation");
 
+        /**
+         * UUID is populated if the record was retrieved from the server. If this observation was
+         * written locally as a cached value from a submitted XForm, UUID is null. As part of every
+         * successful sync, all observations with null UUIDs are deleted, on the basis that an
+         * authoritative version for each has been obtained from the server.
+         */
         String UUID = "uuid";
         String PATIENT_UUID = "patient_uuid";
         String ENCOUNTER_UUID = "encounter_uuid";
         String ENCOUNTER_MILLIS = "encounter_millis";  // milliseconds since epoch
         String CONCEPT_UUID = "concept_uuid";
         String VALUE = "value";  // concept value or order UUID
-
-        /**
-         * temp_cache is 1 if this observation was written locally as a cached
-         * value from a submitted XForm, or 0 if it was loaded from the server.
-         */
-        String TEMP_CACHE = "temp_cache";
     }
 
     public interface Orders {

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -122,7 +122,6 @@ public class Database extends SQLiteOpenHelper {
             + "encounter_millis INTEGER,"
             + "concept_uuid INTEGER,"
             + "value STRING,"
-            + "temp_cache INTEGER,"  // 0 or 1
             + "UNIQUE (patient_uuid, encounter_uuid, concept_uuid)");
 
         SCHEMAS.put(Table.ORDERS, ""

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -112,7 +112,11 @@ public class Database extends SQLiteOpenHelper {
             + "UNIQUE (location_uuid, locale)");
 
         SCHEMAS.put(Table.OBSERVATIONS, ""
-            + "uuid TEXT PRIMARY KEY NOT NULL,"
+            // uuid intentionally allows null values, because temporary observations inserted
+            // locally after submitting a form don't have UUIDs. Note that PRIMARY KEY in SQLite
+            // (and many other databases) treats all NULL values as different from all other values,
+            // so it's still ok to insert multiple records with a NULL UUID.
+            + "uuid TEXT PRIMARY KEY,"
             + "patient_uuid TEXT,"
             + "encounter_uuid TEXT,"
             + "encounter_millis INTEGER,"

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAdapter.java
@@ -444,7 +444,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
         checkCancellation("before deleting temporary observations");
         // Remove all temporary observations now we have the real ones
         provider.delete(Observations.CONTENT_URI,
-            Observations.TEMP_CACHE + "!=0",
+            Observations.UUID + " IS NULL",
             new String[0]);
         timingLogger.addSplit("delete temp observations");
         timingLogger.dumpToLog();

--- a/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
@@ -380,6 +380,9 @@ public class OdkActivityLauncher {
         //      <value>1066^NO^99DCT</value>
 
         ContentValues common = new ContentValues();
+        // It's critical that UUID is {@code null} for temporary observations, so we make it
+        // explicit here. See {@link Contracts.Observations.UUID} for details.
+        common.put(Contracts.Observations.UUID, (String) null);
         common.put(Contracts.Observations.PATIENT_UUID, patientUuid);
 
         TreeElement encounter = savedRoot.getChild("encounter", 0);
@@ -401,7 +404,6 @@ public class OdkActivityLauncher {
                 ISODateTimeFormat.dateTime().parseDateTime((String) dateTimeValue.getValue());
             common.put(Contracts.Observations.ENCOUNTER_MILLIS, encounterTime.getMillis());
             common.put(Contracts.Observations.ENCOUNTER_UUID, UUID.randomUUID().toString());
-            common.put(Contracts.Observations.TEMP_CACHE, 1);
         } catch (IllegalArgumentException e) {
             LOG.e("Could not parse datetime" + dateTimeValue.getValue());
             return;


### PR DESCRIPTION
- Relax `NOT NULL` constraint on local Observation UUIDs.
- Remove `temp_cache` database column in favor of using NULL uuids for locally inserted observations.
