### PR TITLE
Remove obsolete developer settings.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/AppSettings.java
+++ b/app/src/main/java/org/projectbuendia/client/AppSettings.java
@@ -60,24 +60,6 @@ public class AppSettings {
     }
 
     /**
-     * Gets the flag that controls whether to immediately apply edits
-     * to the local database when an XForm is submitted to the server.
-     */
-    public boolean getXformUpdateClientCache() {
-        return mSharedPreferences.getBoolean("xform_update_client_cache",
-            mResources.getBoolean(R.bool.xform_update_client_cache_default));
-    }
-
-    /**
-     * Gets the flag that controls whether to update observations with
-     * an incremental fetch instead of fetching all the observations.
-     */
-    public boolean getIncrementalObservationUpdate() {
-        return mSharedPreferences.getBoolean("incremental_observation_update",
-            mResources.getBoolean(R.bool.incremental_observation_update_default));
-    }
-
-    /**
      * Gets the minimum period between checks for APK updates, in seconds.
      * Repeated calls to UpdateManager.checkForUpdate() within this period
      * will not check the package server for new updates.

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/AddPatientTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/AddPatientTask.java
@@ -111,7 +111,7 @@ public class AddPatientTask extends AsyncTask<Void, Void, PatientAddFailedEvent>
             Contracts.Patients.CONTENT_URI, patient.toContentValues());
 
         // Perform incremental observation sync so we get admission date.
-        SyncAccountService.startIncrementalObsSync();
+        SyncAccountService.startObservationsSync();
 
         if (uri == null || uri.equals(Uri.EMPTY)) {
             return new PatientAddFailedEvent(

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
@@ -91,8 +91,8 @@ public class SyncAccountService extends Service {
         return new Account(ACCOUNT_NAME, BuildConfig.ACCOUNT_TYPE);
     }
 
-    /** Starts an incremental sync of just the observations. */
-    public static void startIncrementalObsSync() {
+    /** Starts an sync of just the observations. */
+    public static void startObservationsSync() {
         // Start by canceling any existing syncs, which may delay this one.
         ContentResolver.cancelSync(getAccount(), Contracts.CONTENT_AUTHORITY);
 

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
@@ -79,14 +79,9 @@ public class SyncManager {
         SyncAccountService.startFullSync();
     }
 
-    /**
-     * Starts an incremental sync of observations.
-     * Does nothing if incremental observation update is disabled.
-     */
-    public void startIncrementalObsSync() {
-        if (mSettings == null || mSettings.getIncrementalObservationUpdate()) {
-            SyncAccountService.startIncrementalObsSync();
-        }
+    /** Starts a sync of only observations. */
+    public void startObservationsSync() {
+        SyncAccountService.startObservationsSync();
     }
 
     /**

--- a/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
@@ -33,15 +33,11 @@ import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONObject;
 import org.odk.collect.android.activities.FormEntryActivity;
-import org.odk.collect.android.activities.FormHierarchyActivity;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.listeners.FormLoaderListener;
-import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.model.Preset;
 import org.odk.collect.android.provider.FormsProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.tasks.DeleteInstancesTask;
-import org.odk.collect.android.tasks.FormLoaderTask;
 import org.odk.collect.android.utilities.FileUtils;
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.AppSettings;
@@ -74,10 +70,7 @@ import javax.annotation.Nullable;
 import de.greenrobot.event.EventBus;
 
 import static android.provider.BaseColumns._ID;
-import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.CONTENT_URI;
-import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns
-    .INSTANCE_FILE_PATH;
-import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.JR_FORM_ID;
+import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH;
 
 /** Convenience class for launching ODK to display an Xform. */
 public class OdkActivityLauncher {
@@ -197,8 +190,6 @@ public class OdkActivityLauncher {
      * @param context           the application context
      * @param settings          the application settings
      * @param patientUuid       the patient to add an observation to, or null to create a new patient
-     * @param updateClientCache true if we should update the client database with temporary
-     *                          observations
      * @param resultCode        the result code sent from Android activity transition
      * @param data              the incoming intent
      */
@@ -206,7 +197,6 @@ public class OdkActivityLauncher {
         final Context context,
         final AppSettings settings,
         @Nullable final String patientUuid,
-        final boolean updateClientCache,
         int resultCode,
         Intent data) {
 
@@ -272,7 +262,7 @@ public class OdkActivityLauncher {
                             + response.toString());
 
                         // Only locally cache new observations, not new patients.
-                        if (patientUuid != null && updateClientCache) {
+                        if (patientUuid != null) {
                             updateClientCache(
                                 patientUuid, savedRoot, context.getContentResolver());
                         }
@@ -502,102 +492,5 @@ public class OdkActivityLauncher {
             LOG.w("Strangely formatted id String " + idString);
             return null;
         }
-    }
-
-    /**
-     * Show the ODK activity for viewing a saved form.
-     * @param caller the calling activity.
-     */
-    public static void showSavedXform(final Activity caller) {
-
-        // This has to be at the start of anything that uses the ODK file system.
-        Collect.getInstance().createODKDirs();
-
-        final String selection = InstanceProviderAPI.InstanceColumns.STATUS + " != ?";
-        final String[] selectionArgs = {InstanceProviderAPI.STATUS_SUBMITTED};
-        final String sortOrder = InstanceProviderAPI.InstanceColumns.STATUS + " DESC, "
-            + InstanceProviderAPI.InstanceColumns.DISPLAY_NAME + " ASC";
-
-        final Uri instanceUri;
-        final String instancePath;
-        final String jrFormId;
-        Cursor instanceCursor = null;
-        try {
-            instanceCursor = caller.getContentResolver().query(
-                CONTENT_URI, new String[] {_ID, INSTANCE_FILE_PATH, JR_FORM_ID}, selection,
-                selectionArgs, sortOrder);
-            if (instanceCursor.getCount() == 0) return;
-            instanceCursor.moveToFirst();
-
-            // The URI code mostly copied from InstanceChooserList.onListItemClicked()
-            instanceUri =
-                ContentUris.withAppendedId(CONTENT_URI,
-                    instanceCursor.getLong(instanceCursor.getColumnIndex(_ID)));
-            instancePath =
-                instanceCursor.getString(instanceCursor.getColumnIndex(INSTANCE_FILE_PATH));
-            jrFormId = instanceCursor.getString(instanceCursor.getColumnIndex(JR_FORM_ID));
-        } finally {
-            if (instanceCursor != null) {
-                instanceCursor.close();
-            }
-        }
-
-        // It looks like we need to load the form as well. Which is odd, because
-        // the main menu doesn't seem to do this, but without the FormLoaderTask run
-        // there is no form manager for the HierarchyActivity.
-        FormLoaderTask loaderTask = new FormLoaderTask(instancePath, null, null);
-
-        final String formPath;
-        Cursor formCursor = null;
-        try {
-            formCursor = caller.getContentResolver().query(
-                FormsProviderAPI.FormsColumns.CONTENT_URI,
-                new String[] {FormsProviderAPI.FormsColumns.FORM_FILE_PATH},
-                FormsProviderAPI.FormsColumns.JR_FORM_ID + " = ?",
-                new String[] {jrFormId}, null);
-            if (formCursor.getCount() == 0) {
-                LOG.e("Loading forms for displaying " + jrFormId + " and got no forms,");
-                return;
-            }
-            if (formCursor.getCount() != 1) {
-                LOG.e("Loading forms for displaying instance, expected only 1. "
-                    + "Got multiple so using first.");
-            }
-            formCursor.moveToFirst();
-            formPath = formCursor.getString(
-                formCursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH));
-        } finally {
-            if (formCursor != null) {
-                formCursor.close();
-            }
-        }
-
-        loaderTask.setFormLoaderListener(new FormLoaderListener() {
-            @Override public void loadingComplete(FormLoaderTask task) {
-                // This was extracted from FormEntryActivity.loadingComplete()
-                FormController formController = task.getFormController();
-                Collect.getInstance().setFormController(formController);
-
-                Intent intent = new Intent(caller, FormHierarchyActivity.class);
-                intent.setData(instanceUri);
-                intent.setAction(Intent.ACTION_PICK);
-                caller.startActivity(intent);
-            }
-
-            @Override public void loadingError(String errorMsg) {
-            }
-
-            @Override public void onProgressStep(String stepMessage) {
-            }
-        });
-        loaderTask.execute(formPath);
-    }
-
-    private static Response.ErrorListener getErrorListenerForTag(final String tag) {
-        return new Response.ErrorListener() {
-            @Override public void onErrorResponse(VolleyError error) {
-                LOG.e(error.toString());
-            }
-        };
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
@@ -143,7 +143,6 @@ public class SettingsActivity extends PreferenceActivity {
     }
 
     /** When the UI has two panes, this fragment shows just the general settings. */
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static class GeneralPreferenceFragment extends PreferenceFragment {
         @Override public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
@@ -153,7 +152,6 @@ public class SettingsActivity extends PreferenceActivity {
     }
 
     /** When the UI has two panes, this fragment shows just the advanced settings. */
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static class AdvancedPreferenceFragment extends PreferenceFragment {
         @Override public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
@@ -163,7 +161,6 @@ public class SettingsActivity extends PreferenceActivity {
     }
 
     /** When the UI has two panes, this fragment shows just the developer settings. */
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static class DeveloperPreferenceFragment extends PreferenceFragment {
         @Override public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
@@ -247,9 +244,7 @@ public class SettingsActivity extends PreferenceActivity {
      * "simplified" settings UI should be shown.
      */
     private static boolean isSimplePreferences(Context context) {
-        return ALWAYS_SIMPLE_PREFS
-            || Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB
-            || !isXLargeTablet(context);
+        return !isXLargeTablet(context);
     }
 
     /** Sets up all the preferences in an activity. */

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -221,7 +221,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             @Override public void sendOdkResultToServer(String patientUuid, int resultCode, Intent data) {
                 OdkActivityLauncher.sendOdkResultToServer(
                     PatientChartActivity.this, mSettings,
-                    patientUuid, mSettings.getXformUpdateClientCache(), resultCode, data);
+                    patientUuid, resultCode, data);
             }
         };
         final MinimalHandler minimalHandler = new MinimalHandler() {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -249,7 +249,7 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
                 // controller is suspended the cycle stops; and also since mCurrentPhaseId can
                 // only have one value, only one such cycle can be active at any given time.
                 if (mCurrentPhaseId == phaseId) {
-                    mSyncManager.startIncrementalObsSync();
+                    mSyncManager.startObservationsSync();
                     handler.postDelayed(this, OBSERVATION_SYNC_PERIOD_MILLIS);
                 }
             }

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
@@ -112,7 +112,7 @@ public class GoToPatientDialogFragment extends DialogFragment {
 
             // Perform incremental observation sync to get the patient's admission date
             // and any other recent observations.
-            SyncAccountService.startIncrementalObsSync();
+            SyncAccountService.startObservationsSync();
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
@@ -28,13 +28,10 @@ import javax.inject.Inject;
 
 /** A list of patients with a choice of several filters in a dropdown menu. */
 public class FilteredPatientListActivity extends BaseSearchablePatientListActivity {
-
-    private static final int ODK_ACTIVITY_REQUEST = 1;
     private static final String SELECTED_FILTER_KEY = "selected_filter";
 
     private PatientFilterController mFilterController;
     private int mSelectedFilter = 0;
-    @Inject AppSettings mSettings;
 
     public static void start(Context caller) {
         caller.startActivity(new Intent(caller, FilteredPatientListActivity.class));
@@ -61,13 +58,6 @@ public class FilteredPatientListActivity extends BaseSearchablePatientListActivi
     @Override protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(SELECTED_FILTER_KEY, getActionBar().getSelectedNavigationIndex());
-    }
-
-    @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode != ODK_ACTIVITY_REQUEST) return;
-        OdkActivityLauncher.sendOdkResultToServer(
-            this, mSettings, /* create a new patient */ null,
-            false, resultCode, data);
     }
 
     private final class FilterUi implements PatientFilterController.Ui {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -309,10 +309,6 @@ S\'il vous plaît patienter pendant que les données du patient et l\'emplacemen
   <string name="pref_title_apk_update_interval_secs">APK mise à jour intervalle de vérification (secondes)</string>
   <string name="pref_title_store_form_instances">Instances de formulaire de stocker localement</string>
   <string name="pref_desc_store_form_instances">Normalement formes seront supprimés après avoir été envoyé au serveur. Sélectionnez cette option pour les garder pour le débogage.</string>
-  <string name="pref_title_xform_update_client_cache">Mettre à jour des observations locales sur la soumission</string>
-  <string name="pref_desc_xform_update_client_cache">Cela donne une meilleure expérience de l\'expérience de l\'utilisateur, mais est une fonctionnalité expérimentale.</string>
-  <string name="pref_title_incremental_observation_update">Synchronisation des observations incrémentielle</string>
-  <string name="pref_desc_incremental_observation_update">Cela est beaucoup plus rapide, mais encore au stade expérimental.</string>
   <string name="pref_title_require_wifi">Exiger connexion wifi</string>
   <string name="pref_desc_require_wifi">Désactivez cette option pour permettre l\'application de travailler avec des non-wifi (ou émulé captif Bluetooth) en réseau.</string>
 

--- a/app/src/main/res/values/default_settings.xml
+++ b/app/src/main/res/values/default_settings.xml
@@ -18,10 +18,4 @@
 
     <!-- Default setting for whether to keep XForm instances locally -->
     <bool name="keep_form_instances_locally_default">false</bool>
-
-    <!-- Default setting for whether XForm submission should update the client cache -->
-    <bool name="xform_update_client_cache_default">true</bool>
-
-    <!-- Default setting for whether observations should sync incrementally -->
-    <bool name="incremental_observation_update_default">true</bool>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,10 +316,6 @@
   <string name="pref_title_apk_update_interval_secs">APK update check interval (seconds)</string>
   <string name="pref_title_store_form_instances">Store form instances locally</string>
   <string name="pref_desc_store_form_instances">Normally forms will be deleted after being sent to the server. Select this to keep them for debugging.</string>
-  <string name="pref_title_xform_update_client_cache">Update local observations on submission</string>
-  <string name="pref_desc_xform_update_client_cache">This gives a better UI experience but is an experimental feature.</string>
-  <string name="pref_title_incremental_observation_update">Sync observations incrementally</string>
-  <string name="pref_desc_incremental_observation_update">This is much quicker but still experimental.</string>
   <string name="pref_title_require_wifi">Require wifi connection</string>
   <string name="pref_desc_require_wifi">Turn this off to allow the app to work with non-wifi (emulated or Bluetooth tethered) networking.</string>
 

--- a/app/src/main/res/xml/pref_developer.xml
+++ b/app/src/main/res/xml/pref_developer.xml
@@ -9,20 +9,6 @@
         android:summary="@string/pref_desc_store_form_instances"
         android:defaultValue="@bool/keep_form_instances_locally_default" />
 
-    <!-- Whether to instantly update the local cache when an xform is submitted locally -->
-    <CheckBoxPreference
-        android:key="xform_update_client_cache"
-        android:title="@string/pref_title_xform_update_client_cache"
-        android:summary="@string/pref_desc_xform_update_client_cache"
-        android:defaultValue="@bool/xform_update_client_cache_default" />
-
-    <!-- Whether to instantly update the observations cache incrementally -->
-    <CheckBoxPreference
-        android:key="incremental_observation_update"
-        android:title="@string/pref_title_incremental_observation_update"
-        android:summary="@string/pref_desc_incremental_observation_update"
-        android:defaultValue="@bool/incremental_observation_update_default" />
-
     <!-- Whether to assume that no wifi means no network at all -->
     <CheckBoxPreference
         android:key="require_wifi"


### PR DESCRIPTION
Remove "Update local observations on submission" and "Sync observations incrementally" settings.

These settings have been 'on' by default for a long time, and we're relying on the behaviour of both
of them extensively.

Also:
- rename some methods named `startIncrementalObsSync` to `startObservationsSync`, because all
  observations syncs are incremental syncs now.
- delete unused `OdkActivityLauncher#showSavedXform()` method.
