### PR TITLE
Fix tests that use mockito.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     // Mockito
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.0'
-    androidTestCompile 'org.mockito:mockito-core:1.10.17'
+    androidTestCompile 'org.mockito:mockito-core:1.9.5'
 }
 
 apply plugin: 'spoon'


### PR DESCRIPTION
PR #142 (accidentally?) upgraded Mockito to 1.10.17, which doesn't work with with versions of dexmaker in use, and throws `NullPointerException`s when initializing mocks.

This commit rolls back that single line from PR #142 so the tests work again.
