### PR TITLE
Cleaning up OdkActivityLauncher class

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/exception/ValidationException.java
+++ b/app/src/main/java/org/projectbuendia/client/exception/ValidationException.java
@@ -1,0 +1,35 @@
+// Copyright 2015 The Project Buendia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distrib-
+// uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+// specific language governing permissions and limitations under the License.
+
+package org.projectbuendia.client.exception;
+
+/**
+ * The base class for all validation exceptions.
+ *
+ * @author Vinicius Boson
+ */
+public class ValidationException extends Exception {
+    public ValidationException(String message) {
+        super( message );
+    }
+
+    public ValidationException() {
+        super();
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super( message, cause );
+    }
+
+    public ValidationException(Throwable cause) {
+        super( cause );
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
@@ -295,8 +295,8 @@ public class OdkActivityLauncher {
         if(!assertThatContentUriHasValidType(context, uri, CONTENT_ITEM_TYPE)) return;
 
         final String filePath = getFormFilePath(context, uri);
-        final Long idToDelete = getIdToDeleteAfterUpload(context, uri);
-        if(filePath == null || idToDelete == null) return; // SubmitXformFailedEvent was already triggered
+        final Long formIdToDelete = getIdToDeleteAfterUpload(context, uri);
+        if(filePath == null || formIdToDelete == null) return; // SubmitXformFailedEvent was already triggered
 
         // Temporary code for messing about with xform instance, reading values.
         byte[] fileBytes = FileUtils.getFileAsBytes(new File(filePath));
@@ -318,11 +318,10 @@ public class OdkActivityLauncher {
                     }
 
                     if (!settings.getKeepFormInstancesLocally()) {
-                        deleteFormInstances(idToDelete);
+                        deleteLocalFormInstances(formIdToDelete);
                     }
                     EventBus.getDefault().post(new SubmitXformSucceededEvent());
                 }
-
             }, new Response.ErrorListener() {
                 @Override public void onErrorResponse(VolleyError error) {
                     LOG.e(error, "Error submitting form to server");
@@ -331,7 +330,7 @@ public class OdkActivityLauncher {
             });
     }
 
-    private static void deleteFormInstances(Long formIdToDelete) {
+    private static void deleteLocalFormInstances(Long formIdToDelete) {
         //Code largely copied from InstanceUploaderTask to delete on upload
         DeleteInstancesTask dit = new DeleteInstancesTask();
         dit.setContentResolver(

--- a/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
@@ -389,6 +389,12 @@ public class OdkActivityLauncher {
         }
     }
 
+    /**
+     * Returns the form {@link Cursor} ready to be used. If no form was found, it triggers a
+     * {@link SubmitXformFailedEvent} event and returns <code>null</code>.
+     * @param context           the application context
+     * @param uri               the URI to be queried
+     */
     private static Cursor getCursorAtRightPosition(final Context context, final Uri uri) {
         Cursor instanceCursor = context.getContentResolver().query(uri, null, null, null, null);
         if (instanceCursor.getCount() != 1) {

--- a/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
@@ -369,7 +369,7 @@ public class OdkActivityLauncher {
      * Validates the id to be deleted after the form upload. If id is valid, it returns
      * <code>true</code>. Otherwise, it triggers * {@link SubmitXformFailedEvent} event and
      * returns <code>false</code>.
-     * @param context           the application context
+     * @param id           the id to be deleted
      * @param uri               the URI containing the id to be deleted
      */
     private static boolean validateIdToDeleteAfterUpload(final Long id, Uri uri) {


### PR DESCRIPTION
I've cleaned up the `OdkActivityLauncher` class to be more readable and maintainable. 

There were many methods too long and they were doing to many things that it was necessary to debug them paying very close attention to understand what they were supposed to do.

Theses changes don't have any intention to cause side-effects. This is just a janitor PR which will be useful for future changes.    
