### PR TITLE
Add support for paginated observation sync.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/json/JsonObservationsResponse.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonObservationsResponse.java
@@ -14,7 +14,6 @@ package org.projectbuendia.client.json;
 /** JSON representation of a set of observations returned by the server. */
 public class JsonObservationsResponse {
     public JsonObservation[] results;
-    // TODO(capnfabs): Rename this to syncToken.
-    /** In ISO 8601 date format. */
-    public String snapshotTime;
+    public String syncToken;
+    public boolean more;
 }

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
@@ -11,6 +11,7 @@
 
 package org.projectbuendia.client.net;
 
+import android.net.Uri;
 import android.support.annotation.Nullable;
 
 import com.android.volley.DefaultRetryPolicy;
@@ -71,10 +72,12 @@ public class OpenMrsChartServer {
             @Nullable String lastSyncToken,
             Response.Listener<JsonObservationsResponse> successListener,
             Response.ErrorListener errorListener) {
-        // TODO: URL-encode the sync token?
-        doObservationsRequest(mConnectionDetails.getBuendiaApiUrl() + "/observations" +
-                        (lastSyncToken != null ? "?since=" + lastSyncToken : ""),
-                successListener, errorListener);
+        Uri.Builder url = Uri.parse(mConnectionDetails.getBuendiaApiUrl()).buildUpon();
+        url.appendPath("observations");
+        if (lastSyncToken != null) {
+            url.appendQueryParameter("since", lastSyncToken);
+        }
+        doObservationsRequest(url.build().toString(), successListener, errorListener);
     }
 
     /**


### PR DESCRIPTION
- Use logic similar to PatientSyncPhaseRunnable in ObservationSyncPhaseRunnable. These will be
  unified into a generic, shared-code system later.
- Fix the source of slowness in Observation sync by executing the DB ops in a single bulk
  transaction.
