### PR TITLE
Remember chart scroll position

### DIFF
--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -184,8 +184,13 @@
 
   $(document).ready(function() {
     $('#grid').freezeHeader({top: true, left: true});
-    $('#grid-scroller').scrollLeft(1e6);
   });
+
+  $( window ).unload(function() {
+      console.log("Window => v=" + $(window).scrollTop() + " - h=" + $(window).scrollLeft());
+      console.log("grid-scroller => v=" + $('#grid-scroller').scrollTop() + " - h=" + $('#grid-scroller').scrollLeft());
+      controller.onPageUnload($('#grid-scroller').scrollLeft(), $(window).scrollTop());
+    });
 </script>
 </body>
 </html>

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -187,10 +187,8 @@
   });
 
   $( window ).unload(function() {
-      console.log("Window => v=" + $(window).scrollTop() + " - h=" + $(window).scrollLeft());
-      console.log("grid-scroller => v=" + $('#grid-scroller').scrollTop() + " - h=" + $('#grid-scroller').scrollLeft());
-      controller.onPageUnload($('#grid-scroller').scrollLeft(), $(window).scrollTop());
-    });
+    controller.onPageUnload($('#grid-scroller').scrollLeft(), $(window).scrollTop());
+  });
 </script>
 </body>
 </html>

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -89,7 +89,6 @@ public class ChartRenderer {
         mView.getSettings().setJavaScriptEnabled(true);
         mView.addJavascriptInterface(controllerInterface, "controller");
         mView.setWebChromeClient(new WebChromeClient());
-
         String html = new GridHtmlGenerator(chart, latestObservations, observations, orders,
                                             admissionDate, firstSymptomsDate).getHtml();
         mView.loadDataWithBaseURL("file:///android_asset/", html,

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -4,6 +4,7 @@ import android.content.res.Resources;
 import android.util.DisplayMetrics;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 import com.google.common.collect.Lists;
 import com.mitchellbosecke.pebble.PebbleEngine;
@@ -86,6 +87,16 @@ public class ChartRenderer {
         mView.getSettings().setJavaScriptEnabled(true);
         mView.addJavascriptInterface(controllerInterface, "controller");
         mView.setWebChromeClient(new WebChromeClient());
+
+        // Remembering scroll position and applying it after the chart finished loading.
+        final int x = mView.getScrollX();
+        final int y = mView.getScrollY();
+        mView.setWebViewClient(new WebViewClient() {
+            public void onPageFinished(WebView view, String url) {
+                view.scrollTo(x, y);
+            }
+        });
+
         String html = new GridHtmlGenerator(chart, latestObservations, observations, orders,
                                             admissionDate, firstSymptomsDate).getHtml();
         mView.loadDataWithBaseURL("file:///android_asset/", html,

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -4,7 +4,6 @@ import android.content.res.Resources;
 import android.util.DisplayMetrics;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
-import android.webkit.WebViewClient;
 
 import com.google.common.collect.Lists;
 import com.mitchellbosecke.pebble.PebbleEngine;
@@ -59,6 +58,9 @@ public class ChartRenderer {
 
         @android.webkit.JavascriptInterface
         void onOrderCellPressed(String orderUuid, long startMillis);
+
+        @android.webkit.JavascriptInterface
+        void onPageUnload(int scrollX, int scrollY);
     }
 
     public ChartRenderer(WebView view, Resources resources) {
@@ -87,15 +89,6 @@ public class ChartRenderer {
         mView.getSettings().setJavaScriptEnabled(true);
         mView.addJavascriptInterface(controllerInterface, "controller");
         mView.setWebChromeClient(new WebChromeClient());
-
-        // Remembering scroll position and applying it after the chart finished loading.
-        final int x = mView.getScrollX();
-        final int y = mView.getScrollY();
-        mView.setWebViewClient(new WebViewClient() {
-            public void onPageFinished(WebView view, String url) {
-                view.scrollTo(x, y);
-            }
-        });
 
         String html = new GridHtmlGenerator(chart, latestObservations, observations, orders,
                                             admissionDate, firstSymptomsDate).getHtml();

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -14,6 +14,7 @@ package org.projectbuendia.client.ui.chart;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Point;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.Menu;
@@ -22,6 +23,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.TextView;
 
 import com.google.common.base.Joiner;
@@ -215,6 +217,16 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
         mFormSubmissionDialog.setIndeterminate(true);
         mFormSubmissionDialog.setCancelable(false);
 
+        // Remembering scroll position and applying it after the chart finished loading.
+        mGridWebView.setWebViewClient(new WebViewClient() {
+            public void onPageFinished(WebView view, String url) {
+                Point scrollPosition = mController.getLastScrollPosition();
+                if (scrollPosition != null) {
+                    view.loadUrl("javascript:$('#grid-scroller').scrollLeft(" + scrollPosition.x + ");");
+                    view.loadUrl("javascript:$(window).scrollTop(" + scrollPosition.y + ");");
+                }
+            }
+        });
         mChartRenderer = new ChartRenderer(mGridWebView, getResources());
 
         final OdkResultSender odkResultSender = new OdkResultSender() {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -14,6 +14,7 @@ package org.projectbuendia.client.ui.chart;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Point;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -119,6 +120,12 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
     // the form is closed.
     List<FormRequest> mFormRequests = new ArrayList<>();
 
+    // Store chart's last scroll position
+    private Point mLastScrollPosition;
+    public Point getLastScrollPosition() {
+        return mLastScrollPosition;
+    }
+
     public interface Ui {
         /** Sets the activity title. */
         void setTitle(String title);
@@ -209,6 +216,7 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
         }
         mSyncManager = syncManager;
         mMainThreadHandler = mainThreadHandler;
+        mLastScrollPosition = new Point(Integer.MAX_VALUE, 0);
     }
 
     /**
@@ -415,6 +423,11 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
             }
         }
         mUi.showOrderExecutionDialog(order, interval, executionTimes);
+    }
+
+    @android.webkit.JavascriptInterface
+    public void onPageUnload(int scrollX, int scrollY) {
+        mLastScrollPosition.set(scrollX, scrollY);
     }
 
     public void showAssignGeneralConditionDialog(


### PR DESCRIPTION
Remembering scroll position and applying it after the chart finished loading.

**Obs: The previous behavior is maintained. (The chart is being scrolled to the right after loading).**
So, for now, only the Vertical position is restored because the horizontal is being updated elsewhere (javascript).
@dancunningham Do we need to remember the horizontal scroll position as well?
