### PR TITLE
Fixing Server Unreachable Message

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/diagnostics/BuendiaApiHealthCheck.java
+++ b/app/src/main/java/org/projectbuendia/client/diagnostics/BuendiaApiHealthCheck.java
@@ -164,6 +164,9 @@ public class BuendiaApiHealthCheck extends HealthCheck {
                                 reportIssue(HealthIssue.SERVER_NOT_RESPONDING);
                                 break;
                         }
+                        if (hasIssue(HealthIssue.SERVER_HOST_UNREACHABLE)){
+                            resolveIssue(HealthIssue.SERVER_HOST_UNREACHABLE);
+                        }
                         return;
                     }
                 } catch (UnknownHostException | IllegalArgumentException e) {

--- a/app/src/main/java/org/projectbuendia/client/diagnostics/HealthCheck.java
+++ b/app/src/main/java/org/projectbuendia/client/diagnostics/HealthCheck.java
@@ -41,7 +41,7 @@ public abstract class HealthCheck {
     private final Object mLock = new Object();
 
     protected final Application mApplication;
-    protected final Set<HealthIssue> mActiveIssues;
+    protected final HashSet<HealthIssue> mActiveIssues;
 
     @Nullable private EventBus mHealthEventBus;
 
@@ -161,5 +161,14 @@ public abstract class HealthCheck {
         if (wasIssueActive) {
             eventBus.post(healthIssue.resolved);
         }
+    }
+
+    protected final boolean hasIssue(HealthIssue healthIssue) {
+        for (HealthIssue issue : mActiveIssues) {
+            if (issue.equals(healthIssue)){
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
The problem was that the Health system only report problem solved if all the problems are solved.
It now reports server connectivity problem when they are solved.
This fixes #189
