### PR TITLE
Send user's provider UUID with completed Xforms.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsXformsConnection.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsXformsConnection.java
@@ -134,6 +134,7 @@ public class OpenMrsXformsConnection {
      */
     public void postXformInstance(
         @Nullable String patientUuid,
+        String entererUuid,
         String xform,
         final Response.Listener<JSONObject> resultListener,
         Response.ErrorListener errorListener) {
@@ -149,8 +150,7 @@ public class OpenMrsXformsConnection {
         if (patientUuid != null) {
             post.addProperty("patient_uuid", patientUuid);
         }
-        // TODO: get the enterer from the user login
-        post.addProperty("enterer_id", 1);
+        post.addProperty("enterer_uuid", entererUuid);
 
         post.addProperty("date_entered", ISODateTimeFormat.dateTime().print(new DateTime()));
         JSONObject postBody = null;

--- a/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
@@ -44,6 +44,7 @@ import org.projectbuendia.client.events.FetchXformFailedEvent;
 import org.projectbuendia.client.events.SubmitXformFailedEvent;
 import org.projectbuendia.client.events.SubmitXformSucceededEvent;
 import org.projectbuendia.client.exception.ValidationException;
+import org.projectbuendia.client.json.JsonUser;
 import org.projectbuendia.client.net.OdkDatabase;
 import org.projectbuendia.client.net.OdkXformSyncTask;
 import org.projectbuendia.client.net.OpenMrsXformIndexEntry;
@@ -72,8 +73,7 @@ import de.greenrobot.event.EventBus;
 
 import static android.provider.BaseColumns._ID;
 import static java.lang.String.format;
-import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns
-    .CONTENT_ITEM_TYPE;
+import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.CONTENT_ITEM_TYPE;
 import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH;
 
 /** Convenience class for launching ODK to display an Xform. */
@@ -474,7 +474,9 @@ public class OdkActivityLauncher {
                                          Response.ErrorListener errorListener) {
         OpenMrsXformsConnection connection =
             new OpenMrsXformsConnection(App.getConnectionDetails());
-        connection.postXformInstance(patientUuid, xml, successListener, errorListener);
+        JsonUser activeUser = App.getUserManager().getActiveUser();
+        connection.postXformInstance(
+                patientUuid, activeUser.id, xml, successListener, errorListener);
     }
 
     private static void handleSubmitError(VolleyError error) {


### PR DESCRIPTION
This allows observations to be properly attributed on the server side.

Partial fix for #214, see also corresponding server change.
