### PR TITLE
Send orderer UUID with each new order request from the client.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
@@ -289,6 +289,10 @@ public class OpenMrsServer implements Server {
         JSONObject json;
         try {
             json = order.toJson();
+            JsonUser user = App.getUserManager().getActiveUser();
+            if (user != null) {
+                json.put("orderer_uuid", user.id);
+            }
         } catch (Exception e) {
             errorListener.onErrorResponse(new VolleyError("failed to serialize request", e));
             return;


### PR DESCRIPTION
This allows orders to be attributed to the user that created or edited them.
