### PR TITLE
Make start and stop (end) times for cell accessible via javascript

### DIFF
--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -77,6 +77,8 @@
             {% set class = summaryValue | format_values(row.item.cssClass) %}
             {% set style = summaryValue | format_values(row.item.cssStyle) %}
             <td id="cell-{{id}}-{{column.start.millis}}"
+              data-start="{{column.start.millis}}"
+              data-stop="{{column.stop.millis}}"
               class="{{column.start == nowColumnStart ? 'now' : ''}} {{class}}"
               style="{{style}}"
               onclick="{% if points is not empty%}


### PR DESCRIPTION
In order to make the 5g/kg/day line work, the row script in the profile relies on being able to access the start and stop times for each grid cell. This makes those accessible via cell.dataset.start and cell.dataset.stop.
