### PR TITLE
Add a notes panel to the patient chart screen.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     compile 'com.mitchellbosecke:pebble:1.5.1' // HTML templating
     compile 'org.slf4j:slf4j-simple:1.7.12' // HTML templating dependency
     compile 'org.apache.commons:commons-lang3:3.4'
+    // Magic sliding panel that we use for the notes view.
+    compile 'com.sothree.slidinguppanel:library:3.2.1'
 
     // Testing
     androidTestCompile 'com.android.support.test:runner:0.3'

--- a/app/src/main/java/org/projectbuendia/client/events/data/EncounterAddFailedEvent.java
+++ b/app/src/main/java/org/projectbuendia/client/events/data/EncounterAddFailedEvent.java
@@ -12,6 +12,7 @@
 package org.projectbuendia.client.events.data;
 
 import org.projectbuendia.client.events.DefaultCrudEventBus;
+import org.projectbuendia.client.models.Encounter;
 
 /**
  * An event bus event indicating that adding an encounter failed.
@@ -21,6 +22,7 @@ import org.projectbuendia.client.events.DefaultCrudEventBus;
 public class EncounterAddFailedEvent {
     public final Reason reason;
     public final Exception exception;
+    public final Encounter encounter;
 
     public enum Reason {
         UNKNOWN,
@@ -33,7 +35,8 @@ public class EncounterAddFailedEvent {
         FAILED_TO_FETCH_SAVED_OBSERVATION
     }
 
-    public EncounterAddFailedEvent(Reason reason, Exception exception) {
+    public EncounterAddFailedEvent(Encounter encounter, Reason reason, Exception exception) {
+        this.encounter = encounter;
         this.reason = reason;
         this.exception = exception;
     }

--- a/app/src/main/java/org/projectbuendia/client/json/JsonEncounter.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonEncounter.java
@@ -13,15 +13,13 @@ package org.projectbuendia.client.json;
 
 import org.joda.time.DateTime;
 
-import java.util.Map;
+import java.util.List;
 
 /** JSON representation of an OpenMRS Encounter; call Serializers.registerTo before use. */
 public class JsonEncounter {
     public String patient_uuid;
     public String uuid;
     public DateTime timestamp;
-    public String enterer_id;
-    /** A {conceptUuid: value} map, where value can be a number, string, or answer UUID. */
-    public Map<Object, Object> observations;
+    public List<JsonObservation> observations;
     public String[] order_uuids;  // orders executed during this encounter
 }

--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -36,6 +36,8 @@ import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.utils.Logger;
 import org.projectbuendia.client.utils.Utils;
 
+import javax.annotation.Nullable;
+
 import de.greenrobot.event.NoSubscriberEvent;
 
 /**
@@ -194,10 +196,10 @@ public class AppModel {
      * Asynchronously adds an encounter that records an order as executed, posting a
      * {@link ItemCreatedEvent} when complete.
      */
-    public void addOrderExecutedEncounter(CrudEventBus bus, Patient patient, String orderUuid) {
+    public void addOrderExecutedEncounter(
+            CrudEventBus bus, Patient patient, String orderUuid, @Nullable String userUuid) {
         addEncounter(bus, patient, new Encounter(
-                patient.uuid, null, DateTime.now(), null, new String[]{orderUuid}
-        ));
+                patient.uuid, null, DateTime.now(), null, new String[]{orderUuid}, userUuid));
     }
 
     /**

--- a/app/src/main/java/org/projectbuendia/client/models/PatientDelta.java
+++ b/app/src/main/java/org/projectbuendia/client/models/PatientDelta.java
@@ -15,13 +15,12 @@ import android.content.ContentValues;
 
 import com.google.common.base.Optional;
 
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.projectbuendia.client.net.Server;
 import org.projectbuendia.client.json.JsonPatient;
+import org.projectbuendia.client.net.Server;
 import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.utils.Logger;
 import org.projectbuendia.client.utils.Utils;
@@ -103,24 +102,24 @@ public class PatientDelta {
 
             JSONArray observations = new JSONArray();
             if (admissionDate.isPresent()) {
-                JSONObject observation = new JSONObject();
-                observation.put(Server.OBSERVATION_QUESTION_UUID, ConceptUuids.ADMISSION_DATE_UUID);
-                observation.put(
-                    Server.OBSERVATION_ANSWER_DATE,
-                    Utils.toString(admissionDate.get()));
-                observations.put(observation);
+                JSONObject jsonObs =
+                        new Encounter.Observation(
+                                ConceptUuids.ADMISSION_DATE_UUID,
+                                Utils.toString(admissionDate.get()))
+                        .toJson();
+
+                observations.put(jsonObs);
             }
             if (firstSymptomDate.isPresent()) {
-                JSONObject observation = new JSONObject();
-                observation.put(Server.OBSERVATION_QUESTION_UUID, ConceptUuids.FIRST_SYMPTOM_DATE_UUID);
-                observation.put(
-                    Server.OBSERVATION_ANSWER_DATE,
-                    Utils.toString(firstSymptomDate.get()));
-                observations.put(observation);
+                JSONObject jsonObs =
+                        new Encounter.Observation(
+                                ConceptUuids.FIRST_SYMPTOM_DATE_UUID,
+                                Utils.toString(firstSymptomDate.get()))
+                        .toJson();
+
+                observations.put(jsonObs);
             }
-            if (observations != null) {
-                json.put(Server.ENCOUNTER_OBSERVATIONS_KEY, observations);
-            }
+            json.put(Server.ENCOUNTER_OBSERVATIONS_KEY, observations);
 
             if (assignedLocationUuid.isPresent()) {
                 json.put(
@@ -140,9 +139,5 @@ public class PatientDelta {
         JSONObject location = new JSONObject();
         location.put("uuid", assignedLocationUuid);
         return location;
-    }
-
-    private static long getTimestamp(DateTime dateTime) {
-        return dateTime.toInstant().getMillis()/1000;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/net/Server.java
+++ b/app/src/main/java/org/projectbuendia/client/net/Server.java
@@ -42,9 +42,9 @@ public interface Server {
     public static final String ENCOUNTER_OBSERVATIONS_KEY = "observations";
     public static final String ENCOUNTER_TIMESTAMP = "timestamp";
     public static final String ENCOUNTER_ORDER_UUIDS = "order_uuids";
+    public static final String ENCOUNTER_USER_UUID = "enterer_uuid";
     public static final String OBSERVATION_QUESTION_UUID = "question_uuid";
-    public static final String OBSERVATION_ANSWER_DATE = "answer_date";
-    public static final String OBSERVATION_ANSWER_UUID = "answer_uuid";
+    public static final String OBSERVATION_ANSWER = "answer_value";
 
     /**
      * Logs an event by sending a dummy request to the server.  (The server logs

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientObservationsListAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientObservationsListAdapter.java
@@ -1,0 +1,142 @@
+package org.projectbuendia.client.ui.chart;
+
+import android.app.LoaderManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.CursorLoader;
+import android.content.Loader;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CursorAdapter;
+import android.widget.TextView;
+
+import org.projectbuendia.client.R;
+import org.projectbuendia.client.providers.Contracts;
+import org.projectbuendia.client.providers.Contracts.Observations;
+
+import java.util.Date;
+
+/**
+ * A {@link android.widget.ListAdapter} that displays observations for a given patient, matching a
+ * given concept UUID.
+ * <p>
+ * TODO: This adapter currently does some database queries on the main thread - we should
+ * offload these to a background thread for performance reasons.
+ */
+public class PatientObservationsListAdapter extends CursorAdapter {
+
+    private static final String[] PROJECTION = new String[] {
+            "rowid AS _id",
+            Observations.ENTERER_UUID,
+            Observations.ENCOUNTER_MILLIS,
+            Observations.VALUE,
+    };
+
+    private final ContentResolver mContentResolver;
+
+    public PatientObservationsListAdapter(Context context) {
+        super(context, null, 0);
+        mContentResolver = context.getContentResolver();
+    }
+
+    @Override
+    public View newView(Context context, Cursor cursor, ViewGroup parent) {
+        LayoutInflater inflater = LayoutInflater.from(context);
+        return inflater.inflate(R.layout.notes_list_adapter_note_template, parent, false);
+    }
+
+    @Override
+    public void bindView(View view, Context context, Cursor cursor) {
+        // Obtain data from cursor
+        Date encounterTimestamp = new Date(cursor.getLong(
+                cursor.getColumnIndexOrThrow(Observations.ENCOUNTER_MILLIS)));
+        String value = cursor.getString(
+                cursor.getColumnIndexOrThrow(Observations.VALUE));
+        String entererUuid = cursor.getString(
+                cursor.getColumnIndexOrThrow(Observations.ENTERER_UUID));
+        String enterer = getUsersNameFromUuid(entererUuid);
+
+        // Obtain view references
+        ViewGroup viewGroup = (ViewGroup) view;
+        TextView metaLine = (TextView) viewGroup.findViewById(R.id.meta);
+        TextView content = (TextView) viewGroup.findViewById(R.id.observation_content);
+
+        // Set content
+        metaLine.setText(context.getResources().getString(
+                enterer == null
+                        ? R.string.notes_list_metadata_format_no_user_info
+                        : R.string.notes_list_metadata_format,
+                encounterTimestamp, enterer));
+        content.setText(value);
+    }
+
+    /**
+     * Returns the users' full name from a UUID. Note that this performs a database query, and so
+     * ideally calls should be kept off the main thread. It does not perform a network request to
+     * check for new users on the server.
+     *
+     * @param uuid The uuid of the user whose name to return. Note that if {@code null} is passed,
+     *             {@code null} will be returned.
+     * @return the users' name, if a user was found matching this UUID. {@code null} otherwise.
+     */
+    public @Nullable String getUsersNameFromUuid(@Nullable String uuid) {
+        if (uuid == null) {
+            return null;
+        }
+        try (Cursor cursor = mContentResolver.query(
+                Contracts.Users.CONTENT_URI.buildUpon().appendPath(uuid).build(),
+                new String[]{Contracts.Users.FULL_NAME},
+                null,
+                null,
+                null)) {
+            if (cursor == null || !cursor.moveToFirst()) {
+                // Either there wasn't a cursor, or the result set was empty.
+                // This is a user we don't know about.
+                return null;
+            }
+            return cursor.getString(0);
+        }
+    }
+
+    public static class ObservationsListLoaderCallbacks
+            implements LoaderManager.LoaderCallbacks<Cursor> {
+
+        private final Context mContext;
+        private final String mPatientUuid;
+        private final String mConceptUuid;
+        private final CursorAdapter mAdapter;
+
+        public ObservationsListLoaderCallbacks(
+                Context context, String patientUuid, String conceptUuid, CursorAdapter adapter) {
+            mContext = context;
+            mPatientUuid = patientUuid;
+            mConceptUuid = conceptUuid;
+            mAdapter = adapter;
+        }
+
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+            return new CursorLoader(mContext,
+                    Observations.CONTENT_URI,
+                    PROJECTION,
+                    Observations.PATIENT_UUID + " = ? AND "
+                            + Observations.CONCEPT_UUID + " = ? ",
+                    new String[]{mPatientUuid, mConceptUuid},
+                    Observations.ENCOUNTER_MILLIS);
+        }
+
+        @Override
+        public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
+            mAdapter.swapCursor(data);
+        }
+
+        @Override
+        public void onLoaderReset(Loader<Cursor> loader) {
+            mAdapter.swapCursor(null);
+        }
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -12,6 +12,7 @@
 package org.projectbuendia.client.ui.lists;
 
 import android.os.Bundle;
+import android.os.Debug;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/res/layout/fragment_patient_chart.xml
+++ b/app/src/main/res/layout/fragment_patient_chart.xml
@@ -9,69 +9,173 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<RelativeLayout
+<com.sothree.slidinguppanel.SlidingUpPanelLayout
     android:id="@+id/patient_chart_root"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
+    android:gravity="bottom"
+    app:umanoPanelHeight="@dimen/notes_panel_collapsed_height"
+    app:umanoShadowHeight="8dp"
+    app:umanoScrollableView="@+id/notes_panel_list"
+    app:umanoFadeColor="@color/overlay_fade_color_notes_panel"
     tools:context="org.projectbuendia.client.ui.chart.PatientChartFragment">
 
-  <LinearLayout
-      android:id="@+id/patient_chart_status_section"
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="16dp"
-      android:orientation="horizontal">
+    <!-- The actual patient chart. -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/attribute_admission_days"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/since_admission"
-        app:attributeValue="–"/>
+        <LinearLayout
+            android:id="@+id/patient_chart_status_section"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:orientation="horizontal">
 
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/attribute_symptoms_onset_days"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/since_symptom_onset"
-        app:attributeValue="–"/>
+            <org.projectbuendia.client.widgets.PatientAttributeView
+                android:id="@+id/attribute_admission_days"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.2"
+                app:attributeName="@string/since_admission"
+                app:attributeValue="–"/>
 
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/attribute_location"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/location"
-        app:attributeValue="–"/>
+            <org.projectbuendia.client.widgets.PatientAttributeView
+                android:id="@+id/attribute_symptoms_onset_days"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.2"
+                app:attributeName="@string/since_symptom_onset"
+                app:attributeValue="–"/>
 
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/attribute_pcr"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/latest_pcr_label"
-        app:attributeValue="–"/>
+            <org.projectbuendia.client.widgets.PatientAttributeView
+                android:id="@+id/attribute_location"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.2"
+                app:attributeName="@string/location"
+                app:attributeValue="–"/>
 
-    <TextView
-        android:id="@+id/patient_chart_pregnant"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        android:gravity="end"
-        android:textColor="@color/red"
-        tools:text="Pregnant&#10;IV Fitted"/>
-  </LinearLayout>
+            <org.projectbuendia.client.widgets.PatientAttributeView
+                android:id="@+id/attribute_pcr"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.2"
+                app:attributeName="@string/latest_pcr_label"
+                app:attributeValue="–"/>
 
-  <WebView
-      android:id="@+id/chart_webview"
-      android:layout_width="match_parent"
-      android:layout_height="fill_parent"
-      android:layout_below="@+id/patient_chart_status_section" />
+            <TextView
+                android:id="@+id/patient_chart_pregnant"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.2"
+                android:gravity="end"
+                android:textColor="@color/red"
+                tools:text="Pregnant&#10;IV Fitted"/>
+        </LinearLayout>
 
-</RelativeLayout>
+        <WebView
+            android:id="@+id/chart_webview"
+            android:layout_width="match_parent"
+            android:layout_height="fill_parent"
+            android:layout_below="@+id/patient_chart_status_section" />
+
+    </RelativeLayout>
+    <!-- The slide-up notes panel -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="0.7"
+        android:orientation="vertical"
+        android:padding="@dimen/padding_standard"
+        android:background="@color/chart_background_light" >
+
+        <TextView
+            android:id="@+id/notes_panel_title"
+            style="@style/TextAppearance.AppCompat.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/notes_panel_header_height"
+            android:layout_marginBottom="@dimen/notes_panel_padding"
+            android:gravity="center_vertical"
+            android:text="@string/notes_panel_title"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:textAllCaps="true"/>
+
+        <!--
+        The actual observations.
+        Note we set listSelector to transparent to remove the highlight when tapping on entries.
+        -->
+        <ListView
+            android:id="@+id/notes_panel_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:layout_marginBottom="@dimen/notes_panel_padding"
+            android:listSelector="@android:color/transparent"
+            android:fadeScrollbars="false"
+            android:divider="@null"
+            android:dividerHeight="@dimen/notes_panel_vert_3x_spacer" />
+
+        <!-- This will be shown if the ListView is empty. -->
+        <TextView
+            android:id="@+id/notes_panel_list_empty"
+            style="@style/text.large"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:gravity="top"
+            android:text="@string/notes_list_empty" />
+
+        <!--
+        We set clickable on this so that mis-clicks on the textbox don't close the sliding panel.
+        Note: this is a quick solution, not a robust one - a better solution would be to remove the
+        padding from the panel and create a view that extends right to the edges that fulfils the
+        same function.
+        That's fiddly and complex implementation-wise, however, so we'll avoid it unless our users
+        are finding it difficult the way things are at the moment.
+        -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:background="@color/white"
+            android:clickable="true"
+            android:padding="8dp">
+
+            <EditText
+                android:id="@+id/notes_panel_text_entry"
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:padding="@dimen/notes_panel_entry_padding"
+                android:background="@android:color/transparent"
+                android:hint="@string/add_note_hint" />
+
+            <FrameLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent">
+
+                <ProgressBar
+                    android:id="@+id/notes_panel_submit_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:indeterminate="true" />
+
+                <Button
+                    android:id="@+id/notes_panel_btn_save"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="@dimen/notes_panel_horiz_spacer"
+                    android:padding="@dimen/notes_panel_entry_padding"
+                    android:text="@string/notes_panel_button_add" />
+            </FrameLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.sothree.slidinguppanel.SlidingUpPanelLayout>

--- a/app/src/main/res/layout/notes_list_adapter_note_template.xml
+++ b/app/src/main/res/layout/notes_list_adapter_note_template.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/notes_panel_vert_2x_spacer">
+    <TextView
+        android:id="@+id/meta"
+        style="@style/text.caps"
+        android:textColor="@color/gray_600"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/notes_panel_vert_spacer"
+        tools:text="Wednesday, 12 August • 07:15 • Fabian Tamp" />
+    <TextView
+        android:id="@+id/observation_content"
+        style="@style/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Alert and mobile\nGood appetite for PPN"/>
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -56,6 +56,7 @@
 
     <color name="gray_400">#BDBDBD</color>
     <color name="gray_600">#757575</color>
+    <color name="gray_800">#424242</color>
 
     <color name="chart_background_light">#e1e1e1</color>
     <color name="chart_background_dark">#cccccc</color>
@@ -65,4 +66,7 @@
 
     <!-- SnackBar -->
     <color name="snackbar_action_pressed">#4C4C4C</color>
+
+    <!-- Default is #99000000 -->
+    <color name="overlay_fade_color_notes_panel">#66000000</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="notes_panel_collapsed_height">68dp</dimen>
+    <dimen name="notes_panel_padding">16dp</dimen>
+    <!-- 68 (notes_panel_collapsed_height) - 16x2 (padding) = 36 -->
+    <dimen name="notes_panel_header_height">36dp</dimen>
+
+    <dimen name="notes_panel_horiz_spacer">8dp</dimen>
+    <dimen name="notes_panel_entry_padding">8dp</dimen>
+
+    <dimen name="notes_panel_vert_spacer">8dp</dimen>
+    <dimen name="notes_panel_vert_2x_spacer">16dp</dimen>
+    <dimen name="notes_panel_vert_3x_spacer">24dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,4 +346,16 @@
   <string name="string_with_paren">%1$s (%2$s)</string>
   <string name="voiding">Void</string>
   <string name="void_observations">Void Observations</string>
+
+  <!-- Notes panel -->
+  <string name="notes_panel_title">Notes</string>
+  <string name="add_note_hint">Add note…</string>
+  <string name="notes_panel_button_add">Save</string>
+  <!--
+    %1: the timestamp of the observation.
+    %2: the initials of the user who entered the observation.
+  -->
+  <string name="notes_list_metadata_format">%1$tA, %1$td %1$tB • %1$tR • %2$s</string>
+  <string name="notes_list_metadata_format_no_user_info">%1$tA, %1$td %1$tB • %1$tR</string>
+  <string name="notes_list_empty">No recorded observations.</string>
 </resources>


### PR DESCRIPTION
- Clean up adding encounters.
  - Previously, there was functionality to try and "guess" the type of observation. Remove this,
    the server has knowledge of concept type and can figure it out from the question UUID, and
    value type isn't used on the client.
  - Allow an `enterer_uuid` to be specified when an encounter is created, which allows the
    encounter to be attributed to a user.
  - Change representation of observations in an encounter from a Map of Question UUIDs --> Values
    to a List of JsonObservations. This means that we can process them consistently to the way
    the Observation syncing code does.
- Add a notes panel, which slides up from the bottom of the patient chart activity and allows notes
  to be entered by the user.
