### PR TITLE
Tweak notes panel to take up less space

### DIFF
--- a/app/src/main/res/layout/fragment_patient_chart.xml
+++ b/app/src/main/res/layout/fragment_patient_chart.xml
@@ -21,11 +21,11 @@
     app:umanoShadowHeight="8dp"
     app:umanoScrollableView="@+id/notes_panel_list"
     app:umanoFadeColor="@android:color/transparent"
-    app:umanoOverlay="true"
     tools:context="org.projectbuendia.client.ui.chart.PatientChartFragment">
 
     <!-- The actual patient chart. -->
     <RelativeLayout
+        android:id="@+id/patient_chart_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -81,7 +81,7 @@
         <WebView
             android:id="@+id/chart_webview"
             android:layout_width="match_parent"
-            android:layout_height="fill_parent"
+            android:layout_height="match_parent"
             android:layout_below="@+id/patient_chart_status_section" />
 
     </RelativeLayout>

--- a/app/src/main/res/layout/fragment_patient_chart.xml
+++ b/app/src/main/res/layout/fragment_patient_chart.xml
@@ -20,7 +20,8 @@
     app:umanoPanelHeight="@dimen/notes_panel_collapsed_height"
     app:umanoShadowHeight="8dp"
     app:umanoScrollableView="@+id/notes_panel_list"
-    app:umanoFadeColor="@color/overlay_fade_color_notes_panel"
+    app:umanoFadeColor="@android:color/transparent"
+    app:umanoOverlay="true"
     tools:context="org.projectbuendia.client.ui.chart.PatientChartFragment">
 
     <!-- The actual patient chart. -->
@@ -86,9 +87,9 @@
     </RelativeLayout>
     <!-- The slide-up notes panel -->
     <LinearLayout
+        android:id="@+id/slide_up_notes_panel"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_weight="0.7"
         android:orientation="vertical"
         android:padding="@dimen/padding_standard"
         android:background="@color/chart_background_light" >

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -66,7 +66,4 @@
 
     <!-- SnackBar -->
     <color name="snackbar_action_pressed">#4C4C4C</color>
-
-    <!-- Default is #99000000 -->
-    <color name="overlay_fade_color_notes_panel">#66000000</color>
 </resources>


### PR DESCRIPTION
Before:

https://drive.google.com/file/d/0B0LJ7nmd6PoyM194emY1MU85NjA/view

After:

https://drive.google.com/file/d/0B0LJ7nmd6PoyV21nbUZwejZtUnM/view

Some things that I'd like your thoughts on:

1 - Background shading. I don't think we need it, the grey background on the notes panel provides enough contrast and the shading makes the chart difficult to read.
2 - The size of the notes panel. It's at 50% now as opposed to 70% earlier.
3 - The notes panel now stays the same size when the keyboard expands. This looks pretty bad at 50% because there's no room for old notes, but could work well at larger sizes.

My preference is:
1. Eliminate background shading, it's not necessary.
2. Stick with 70% notes panel height. At 50%, it's impossible to read old notes whilst writing new notes. I could be talked down to 65% maybe :)
3. I like that the notes panel stays the same size when the keyboard pops up, I think we should keep this.
