### PR TITLE
Allow empty sections in ODK forms.

### DIFF
--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1438,35 +1438,22 @@ public class FormEntryActivity
 		case FormEntryController.EVENT_REPEAT:
 			ODKView odkv = null;
 			// should only be a group here if the event_group is a field-list
-			try {
-				FormEntryPrompt[] prompts = formController.getQuestionPrompts();
-				FormEntryCaption[] groups = formController
-						.getGroupsForCurrentIndex();
-				odkv = new ODKView(this, prompts, groups, advancingPage, preset);
-                if (preset != null
-                        && preset.targetGroup != null
-                        && preset.targetGroup.equals(groups[groups.length - 1].getLongText())) {
-                    mTargetView = odkv;
-                }
-				Log.i(TAG,
-						"created view for group "
-								+ (groups.length > 0 ? groups[groups.length - 1]
-										.getLongText() : "[top]")
-								+ " "
-								+ (prompts.length > 0 ? prompts[0]
-										.getQuestionText() : "[no question]"));
-			} catch (RuntimeException e) {
-				Log.e(TAG, e.getMessage(), e);
-				// this is badness to avoid a crash.
-                try {
-                    event = formController.stepToNextScreenEvent();
-                    createErrorDialog(e.getMessage(), DO_NOT_EXIT);
-                } catch (JavaRosaException e1) {
-                    Log.e(TAG, e1.getMessage(), e1);
-                    createErrorDialog(e.getMessage() + "\n\n" + e1.getCause().getMessage(), DO_NOT_EXIT);
-                }
-                return createView(event, advancingPage, preset);
-            }
+			FormEntryPrompt[] prompts = formController.getQuestionPrompts();
+			FormEntryCaption[] groups = formController
+					.getGroupsForCurrentIndex();
+			odkv = new ODKView(this, prompts, groups, advancingPage, preset);
+			if (preset != null
+					&& preset.targetGroup != null
+					&& preset.targetGroup.equals(groups[groups.length - 1].getLongText())) {
+				mTargetView = odkv;
+			}
+			Log.i(TAG,
+					"created view for group "
+							+ (groups.length > 0 ? groups[groups.length - 1]
+									.getLongText() : "[top]")
+							+ " "
+							+ (prompts.length > 0 ? prompts[0]
+									.getQuestionText() : "[no question]"));
 
 			// Makes a "clear answer" menu pop up on long-click
 			for (QuestionWidget qw : odkv.getWidgets()) {

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -599,8 +599,13 @@ public class FormController {
         }
 
         // jump to the end of the group
-        mFormEntryController.jumpToIndex(indicies.get(indicies.size() - 1));
-        return stepToNextEvent(STEP_OVER_GROUP);
+        if (indicies.size() > 0) {
+            mFormEntryController.jumpToIndex(indicies.get(indicies.size() - 1));
+            return stepToNextEvent(STEP_OVER_GROUP);
+        } else {
+            FormIndex idx = mFormEntryController.getModel().incrementIndex(getFormIndex());
+            return mFormEntryController.jumpToIndex(idx);
+        }
     }
 
     /**
@@ -912,7 +917,7 @@ public class FormController {
 
         // For questions, there is only one.
         // For groups, there could be many, but we set that below
-        FormEntryPrompt[] questions = new FormEntryPrompt[1];
+        FormEntryPrompt[] questions = new FormEntryPrompt[0];
 
     	IFormElement element = mFormEntryController.getModel().getForm().getChild(currentIndex);
         if (element instanceof GroupDef) {
@@ -965,7 +970,7 @@ public class FormController {
             }
         } else {
             // We have a quesion, so just get the one prompt
-            questions[0] = getQuestionPrompt();
+            questions = new FormEntryPrompt[] {getQuestionPrompt()};
         }
 
         return questions;


### PR DESCRIPTION
Fixes #199.
- In FormEntryActivity, remove the try{} block that catches RuntimeExceptions and tries to skip
  forward. It just hides errors.
- In FormController, remove assumption that groups are non-empty, and update the "next entry" logic
  to handle empty groups.
