### PR TITLE
Fix test compilation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -248,6 +248,8 @@ android {
         exclude 'META-INF/NOTICE.txt'
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/maven/com.google.guava/guava/pom.properties'
+        exclude 'META-INF/maven/com.google.guava/guava/pom.xml'
     }
 
     lintOptions {


### PR DESCRIPTION
These META-INF files got included in both `espresso` and `espresso-web` `classes.jar` files somehow, which breaks test suite compilation. See [Espresso-web import causes duplicateFileException](http://stackoverflow.com/questions/33800924/espresso-web-import-causes-duplicatefileexception) for more details.
