### PR TITLE
Only refresh the patient chart if something changed after a sync.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/models/Order.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Order.java
@@ -23,6 +23,7 @@ import org.projectbuendia.client.json.JsonOrder;
 import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.utils.Utils;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -133,6 +134,19 @@ public final class Order extends Base<String> implements Comparable<Order> {
         int result = start.compareTo(other.start);
         result = result != 0 ? result : instructions.compareTo(other.instructions);
         return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Order)) {
+            return false;
+        }
+        Order o = (Order) obj;
+        return Objects.equals(uuid, o.uuid) &&
+                Objects.equals(patientUuid, o.patientUuid) &&
+                Objects.equals(instructions, o.instructions) &&
+                Objects.equals(start, o.start) &&
+                Objects.equals(stop, o.stop);
     }
 
     public JSONObject toJson() throws JSONException {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -8,12 +8,9 @@ import android.webkit.WebView;
 import com.google.common.collect.Lists;
 import com.mitchellbosecke.pebble.PebbleEngine;
 
-import org.joda.time.Chronology;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.ReadableInstant;
-import org.joda.time.chrono.ISOChronology;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -51,7 +49,6 @@ public class ChartRenderer {
     Resources mResources;  // resources used for localizing the rendering
     private List<Obs> mLastRenderedObs;  // last set of observations rendered
     private List<Order> mLastRenderedOrders;  // last set of orders rendered
-    private Chronology chronology = ISOChronology.getInstance(DateTimeZone.getDefault());
     private String lastChart = "";
 
     public interface GridJsInterface {
@@ -85,8 +82,10 @@ public class ChartRenderer {
             mView.loadUrl("file:///android_asset/no_chart.html");
             return;
         }
-        if ((observations.equals(mLastRenderedObs) && orders.equals(mLastRenderedOrders))
-            && (lastChart.equals(chart.name))){
+
+        if (observations.equals(mLastRenderedObs)
+                && orders.equals(mLastRenderedOrders)
+                && Objects.equals(lastChart, chart.name)) {
             return;  // nothing has changed; no need to render again
         }
         lastChart = chart.name;
@@ -105,15 +104,13 @@ public class ChartRenderer {
                                             admissionDate, firstSymptomsDate).getHtml();
         mView.loadDataWithBaseURL("file:///android_asset/", html,
             "text/html; charset=utf-8", "utf-8", null);
-        mView.setWebContentsDebuggingEnabled(true);
+        WebView.setWebContentsDebuggingEnabled(true);
 
         mLastRenderedObs = observations;
         mLastRenderedOrders = orders;
     }
 
     class GridHtmlGenerator {
-        List<String> mTileConceptUuids;
-        List<String> mGridConceptUuids;
         List<Order> mOrders;
         DateTime mNow;
         Column mNowColumn;


### PR DESCRIPTION
Previously, we refreshed the patient chart whenever a sync completed, even if there was no
additional data. Now, we only refresh the chart if the data has changed.

Note that we could still improve upon this a lot - for example, by checking for whether observations
for the given patient had changed - but our data model doesn't support this at the moment.
