### PR TITLE
UI support for setting custom start dates on Orders.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/DatePickerDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/DatePickerDialogFragment.java
@@ -1,0 +1,71 @@
+package org.projectbuendia.client.ui.dialogs;
+
+import android.app.DatePickerDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.widget.DatePicker;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * A {@link DialogFragment} that displays a {@link DatePickerDialog}. Basic usage:
+ * <ul>
+ *     <li>call {@link #create(Date)} with a starting date.
+ *     <li>call {@link #setListener(DateChosenListener)} to set a listener that will be triggered
+ *         when a value has been set.
+ * </ul>
+ */
+public class DatePickerDialogFragment extends DialogFragment {
+    public interface DateChosenListener {
+        void onDateChosen(Date date);
+    }
+
+    private static final String YEAR_KEY = "year";
+    private static final String MONTH_KEY = "month";
+    private static final String DAY_KEY = "day";
+
+    @Nullable
+    private DateChosenListener mListener;
+
+    public static DatePickerDialogFragment create(@Nullable Date startingDate) {
+        if (startingDate == null) {
+            startingDate = new Date();
+        }
+        Bundle args = new Bundle();
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(startingDate);
+        args.putInt(YEAR_KEY, calendar.get(Calendar.YEAR));
+        args.putInt(MONTH_KEY, calendar.get(Calendar.MONTH));
+        args.putInt(DAY_KEY, calendar.get(Calendar.DAY_OF_MONTH));
+        DatePickerDialogFragment fragment = new DatePickerDialogFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public void setListener(@Nullable DateChosenListener listener) {
+        mListener = listener;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        int year = getArguments().getInt(YEAR_KEY);
+        int month = getArguments().getInt(MONTH_KEY);
+        int day = getArguments().getInt(DAY_KEY);
+        return new DatePickerDialog(getContext(), new DatePickerDialog.OnDateSetListener() {
+            @Override
+            public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
+                Calendar calendar = Calendar.getInstance();
+                calendar.set(year, monthOfYear, dayOfMonth);
+                Date date = calendar.getTime();
+                if (mListener != null) {
+                    mListener.onDateChosen(date);
+                }
+            }
+        }, year, month, day);
+    }
+}

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -12,6 +12,7 @@
 -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -92,6 +93,36 @@
           android:layout_marginStart="4sp"
           android:text="@string/order_times_per_day"/>
     </TableRow>
+
+      <TableRow
+          android:layout_width="match_parent"
+          android:layout_height="match_parent">
+
+          <TextView
+              style="@style/field_label"
+              android:text="@string/order_start_date"
+              android:layout_marginEnd="12sp" />
+
+          <LinearLayout
+              android:layout_column="1"
+              android:layout_span="2">
+
+              <TextView
+                  style="@style/field_label"
+                  android:id="@+id/order_start_date"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  tools:text="01 Jan, 2016" />
+
+              <Button
+                  android:id="@+id/order_start_date_change_button"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:text="@string/order_start_date_change_label" />
+
+          </LinearLayout>
+
+      </TableRow>
 
     <TableRow
         android:layout_width="fill_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,4 +358,9 @@
   <string name="notes_list_metadata_format">%1$tA, %1$td %1$tB • %1$tR • %2$s</string>
   <string name="notes_list_metadata_format_no_user_info">%1$tA, %1$td %1$tB • %1$tR</string>
   <string name="notes_list_empty">No recorded observations.</string>
+  <string name="order_start_date">Start Date</string>
+  <!-- The button that says "Change" next to the start date -->
+  <string name="order_start_date_change_label">Change</string>
+  <!-- The day of week plus "medium" date format. e.g. Tues, 26 Jan 2015 -->
+  <string name="day_of_week_and_medium_date">%1$tA, %1$td %1$tb %1$tY</string>
 </resources>


### PR DESCRIPTION
- You can set the start date when you first create an order, but not when you edit it.
- Fix the "stop after X days" logic to be a straightforward duration since start date, instead of being the duration from today. This makes a lot more sense now that we're actually displaying the start date.
