### PR TITLE
Fix local storage of encounter times.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -32,7 +32,6 @@ import android.webkit.WebViewClient;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.common.base.Joiner;
 import com.joanzapata.android.iconify.IconDrawable;


### PR DESCRIPTION
ODK rounds times to the nearest minute for submission. We work around this by sending the real
submission time (including seconds) in JSON with the completed Xform. The temporary observations
stored on the client until the next sync, however, are given the timestamp extracted from the Xform,
which means that under the following circumstances:
- An Xform is filled out at 12:03:05
- The values are added as temporary observations, with the timestamp 12:03:00
- A sync completes at 12:03:08, which causes those temporary observations to be replaced with the
  real observations, timestamped correctly at 12:03:05
- Another Xform is filled out at 12:03:25
- The values are added as temporary observations, with the timestamp 12:03:00
- These values do not show up on the patient chart, because the previously synced older values have
  a later timestamp.

This change fixes that problem by using the actual time of submission to store temporary
observations, instead of the time extracted from the Xform.

This is a partial fix for #125.
