### PR TITLE
Add a script that makes a "release-ish" build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ local.properties
 .classpath
 .settings
 .project
+
+# OpenMRS password file.
+.openmrs_password

--- a/build-release-settings.sh
+++ b/build-release-settings.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# TODO: add check that file exists.
+
+OPENMRS_PASSWORD=`cat .openmrs_password`
+
+VER=""
+
+if [[ $# == 1 ]]; then
+  echo "Building version number $1"
+  VER="-PversionNumber=$1"
+fi
+
+./gradlew app:assembleDebug -Pserver="server" -PopenmrsUser="buendia" -PopenmrsPassword="$OPENMRS_PASSWORD" -PrequireWifi="true" $VER
+
+# if file exists ./app/build/outputs/apk/app-debug.apk
+APK_PATH=`find . -name app-debug.apk`
+echo "APK available at" `find . -name app-debug.apk`
+echo "Install it with \`adb install -r $APK_PATH\`"


### PR DESCRIPTION
This build has the same parameters as a release build - require WiFi, production username / password
defaults set - but is a debug build, because our "release build" process is difficult when there's
nobody really sure of how it works anymore. Also, it's useful to be able to get a tablet with a bug
and debug it live in the field.

Note that you need to add a file named `.openmrs_password` that only contains the OpenMRS password.
This file is explicitly ignored by git to avoid storing the password in source control.
