### PR TITLE
Add a "Stop order now" button.

### DIFF
--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -135,6 +135,15 @@
           {% for column in columns %}
             <td class="{{column.start == nowColumnStart ? 'now' : ''}}">
               {% set active = intervals_overlap(order.interval, column.interval) %}
+              <!--
+              HACK: we want to support zero-length durations, but our code doesn't really know how
+              to handle a bunch of edge cases like that yet. See corresponding
+              TODO in {@link PatientChartController#onEventMainThread(OrderSaveRequestedEvent)}.
+              -->
+              {% if active and order.stop == order.start %}
+                {% set active = false %}
+                {% set previousActive = true %}
+              {% endif %}
               {% if order.stop == null and previousActive %}
                 <div class="future">&nbsp;</div>
               {% elseif order.stop != null and previousActive and not active %}

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -183,6 +183,12 @@ public class ChartRenderer {
         void addOrders(List<Order> orders) {
             for (Order order : orders) {
                 if (order.stop != null) {
+                    // Special case: order is for a single day.
+                    // TODO: remove this, fix up the order timestamp-handling logic.
+                    if (order.start.toLocalDate().equals(order.stop.toLocalDate())) {
+                        getColumnContainingTime(order.start);
+                        continue;
+                    }
                     for (DateTime dt = order.start; !dt.isAfter(order.stop.plusDays(1)); dt = dt.plusDays(1)) {
                         getColumnContainingTime(dt); // creates the column if it doesn't exist
                     }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -827,6 +827,15 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
                 // the client's time zone matches the server's time zone, because
                 // the server's fidelity is time-zone-dependent (auggghh!!!)
                 stop = stopDate.toDateTimeAtStartOfDay().minusSeconds(1);
+                // If we end up with a zero-duration day, then stop < start with the current logic.
+                // We correct that case here.
+                // TODO: Just add durationDays to startTime and use that instead, which should
+                // result in a more stable model all around. I'm not sure how the Chart rendering
+                // code would cope with that (there's an open bug for it) so for the pilot we
+                // only correct this case instead of all cases.
+                if (stop.isBefore(start)) {
+                    stop = start;
+                }
             }
 
             mAppModel.saveOrder(mCrudEventBus, new Order(

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -29,6 +29,7 @@
 
       <TextView
           style="@style/field_label"
+          android:labelFor="@+id/order_medication"
           android:layout_column="0"
           android:layout_marginEnd="12sp"
           android:text="@string/order_medication"/>
@@ -50,6 +51,7 @@
 
       <TextView
           style="@style/field_label"
+          android:labelFor="@+id/order_dosage"
           android:layout_column="0"
           android:layout_marginEnd="12sp"
           android:text="@string/order_dosage"/>
@@ -73,6 +75,7 @@
           style="@style/field_label"
           android:layout_column="0"
           android:layout_marginEnd="12sp"
+          android:labelFor="@+id/order_frequency"
           android:text="@string/order_frequency"/>
 
       <EditText
@@ -131,8 +134,8 @@
       <TextView
           style="@style/field_label"
           android:layout_column="0"
-          android:layout_marginEnd="12sp"
           android:gravity="center_vertical"
+          android:labelFor="@+id/order_give_for_days"
           android:text="@string/order_give_for"/>
 
       <EditText
@@ -145,13 +148,24 @@
           android:inputType="numberDecimal"
           android:maxLength="3"/>
 
-      <TextView
-          android:id="@+id/order_give_for_days_label"
-          android:layout_width="600sp"
-          android:layout_column="2"
-          android:layout_gravity="top|start"
-          android:layout_marginStart="4sp"
-          android:text="@string/order_give_for_days"/>
+        <LinearLayout
+            android:layout_column="2" >
+
+          <TextView
+              style="@style/field_label"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:id="@+id/order_give_for_days_label"
+              android:text="@string/order_give_for_days"/>
+
+          <Button
+              android:id="@+id/order_stop_immediately"
+              android:text="@string/order_stop_now"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
     </TableRow>
 
     <TableRow
@@ -170,20 +184,12 @@
     </TableRow>
   </TableLayout>
 
-  <LinearLayout
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal"
-      >
-
   <Button
       android:id="@+id/order_delete"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_margin="16sp"
       android:padding="24sp"
-      android:text="@string/order_delete"
-  />
-  </LinearLayout>
+      android:text="@string/order_delete" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,8 @@
   <string name="order_give_for">Give for</string>
   <string name="order_give_for_days">days</string>
   <string name="order_give_for_day">day</string>
+  <string name="order_duration_stop_yesterday">(stop yesterday)</string>
+  <string name="order_duration_stop_immediately">(stop immediately)</string>
   <string name="order_duration_stop_after_today">(stop after today)</string>
   <string name="order_duration_stop_after_tomorrow">(stop after tomorrow)</string>
   <string name="order_duration_stop_after_date">(stop after %s)</string>


### PR DESCRIPTION
Note that I had to make some changes to support when an order gets a duration of zero, in a
circumstance when (e.g.) a user creates an order, administers the order, and then stops the order.
These changes are hacky at the moment because our data model doesn't support < 1 day duration
orders. Long term, we should clean this up, but we have an outstanding bug for that anyway.

Also: Cleanup order fragment XML.
- Remove unnecessary LinearLayout
- Add `android:labelFor` attributes for TextViews that point at EditTexts.
