### PR TITLE
Turn off package server check.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/diagnostics/DiagnosticsModule.java
+++ b/app/src/main/java/org/projectbuendia/client/diagnostics/DiagnosticsModule.java
@@ -40,10 +40,10 @@ public class DiagnosticsModule {
         Application application,
         OpenMrsConnectionDetails connectionDetails,
         AppSettings settings) {
+        // TODO: restore PackageServerHealthCheck, we'll probably want that again in the future.
         return ImmutableSet.of(
             new WifiHealthCheck(application, settings),
-            new BuendiaApiHealthCheck(application, connectionDetails),
-            new PackageServerHealthCheck(application, settings));
+            new BuendiaApiHealthCheck(application, connectionDetails));
     }
 
     @Provides

--- a/app/src/main/java/org/projectbuendia/client/diagnostics/PackageServerHealthCheck.java
+++ b/app/src/main/java/org/projectbuendia/client/diagnostics/PackageServerHealthCheck.java
@@ -29,6 +29,9 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 
 /** A {@link HealthCheck} that checks whether the package server is up and running. */
+// TODO: restore PackageServerHealthCheck, we'll probably want it again once the packages are
+// working on the server.
+@SuppressWarnings("unused")
 public class PackageServerHealthCheck extends HealthCheck {
 
     private static final Logger LOG = Logger.create();


### PR DESCRIPTION
It takes up space (especially noticeable on patient chart), and it's persistent, which inadvertently trains users to ignore the snackbar.
