### PR TITLE
Fix "Void Observations" so that it actually works.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -91,10 +91,6 @@ public class AppModel {
     }
 
     public void VoidObservation(CrudEventBus bus, VoidObs voidObs) {
-        String conditions = Contracts.Observations.UUID + " = ?";
-        ContentValues values = new ContentValues();
-        values.put(Contracts.Observations.VOIDED,1);
-        mContentResolver.update(Contracts.Observations.CONTENT_URI, values, conditions, new String[]{voidObs.Uuid});
         mTaskFactory.voidObsTask(bus, voidObs).execute();
     }
 
@@ -216,10 +212,6 @@ public class AppModel {
         mContentResolver = contentResolver;
         mLoaderSet = loaderSet;
         mTaskFactory = taskFactory;
-    }
-
-    public void voidObservation(CrudEventBus bus, VoidObs obs) {
-        mTaskFactory.newVoidObsAsyncTask(obs, bus).execute();
     }
 
     /** A subscriber that handles error events posted to {@link CrudEventBus}es. */

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/TaskFactory.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/TaskFactory.java
@@ -58,7 +58,7 @@ public class TaskFactory {
 
     public VoidObsTask voidObsTask(CrudEventBus bus, VoidObs voidObs) {
         return new VoidObsTask(
-                this, mLoaderSet, mServer, mContentResolver, voidObs, bus);
+                mServer, mContentResolver, voidObs, bus);
     }
 
     /** Creates a new {@link UpdatePatientTask}. */
@@ -84,7 +84,7 @@ public class TaskFactory {
     public VoidObsTask newVoidObsAsyncTask(
             VoidObs obs, CrudEventBus bus) {
         return new VoidObsTask(
-                this, mLoaderSet, mServer, mContentResolver, obs, bus);
+                mServer, mContentResolver, obs, bus);
     }
 
     /** Creates a new {@link DeleteOrderTask}. */

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/VoidObsTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/VoidObsTask.java
@@ -2,42 +2,30 @@ package org.projectbuendia.client.models.tasks;
 
 import android.content.ContentResolver;
 import android.os.AsyncTask;
+
+import com.android.volley.toolbox.RequestFuture;
+
 import org.projectbuendia.client.events.CrudEventBus;
-import org.projectbuendia.client.json.JsonVoidObs;
+import org.projectbuendia.client.events.data.ItemDeletedEvent;
+import org.projectbuendia.client.events.data.VoidObsFailedEvent;
 import org.projectbuendia.client.models.VoidObs;
-import org.projectbuendia.client.models.LoaderSet;
 import org.projectbuendia.client.net.Server;
 import org.projectbuendia.client.providers.Contracts;
-import org.projectbuendia.client.utils.Logger;
-
-import android.net.Uri;
-import org.projectbuendia.client.events.data.VoidObsFailedEvent;
-import com.android.volley.toolbox.RequestFuture;
 
 import java.util.concurrent.ExecutionException;
 
-import javax.xml.transform.ErrorListener;
-
 public class VoidObsTask extends AsyncTask<Void, Void, VoidObsFailedEvent> {
 
-    private static final Logger LOG = Logger.create();
-
-    private final TaskFactory mTaskFactory;
-    private final LoaderSet mLoaderSet;
     private final Server mServer;
     private final ContentResolver mContentResolver;
     private final VoidObs mVoidObs;
     private final CrudEventBus mBus;
 
     public VoidObsTask(
-            TaskFactory taskFactory,
-            LoaderSet loaderSet,
             Server server,
             ContentResolver contentResolver,
             VoidObs voidObs,
             CrudEventBus bus) {
-        mTaskFactory = taskFactory;
-        mLoaderSet = loaderSet;
         mServer = server;
         mContentResolver = contentResolver;
         mVoidObs = voidObs;
@@ -46,10 +34,35 @@ public class VoidObsTask extends AsyncTask<Void, Void, VoidObsFailedEvent> {
 
     @Override protected VoidObsFailedEvent doInBackground(Void... params) {
 
-        RequestFuture future = RequestFuture.newFuture();
-        mServer.deleteObservation(mVoidObs.Uuid, future);
+        RequestFuture<Void> future = RequestFuture.newFuture();
+        mServer.deleteObservation(mVoidObs.Uuid, future, future);
+
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            return new VoidObsFailedEvent(VoidObsFailedEvent.Reason.INTERRUPTED, e);
+        } catch (ExecutionException e) {
+            return new VoidObsFailedEvent(VoidObsFailedEvent.Reason.UNKNOWN_SERVER_ERROR, e);
+        }
+
+        mContentResolver.delete(
+                Contracts.Observations.CONTENT_URI,
+                "uuid = ?",
+                new String[]{mVoidObs.Uuid}
+        );
 
         return null;
+    }
 
+    @Override
+    protected void onPostExecute(VoidObsFailedEvent event) {
+        // If an error occurred, post the error event.
+        if (event != null) {
+            mBus.post(event);
+            return;
+        }
+
+        // Otherwise, broadcast that the deletion succeeded.
+        mBus.post(new ItemDeletedEvent(mVoidObs.Uuid));
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
@@ -12,11 +12,13 @@
 package org.projectbuendia.client.net;
 
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
+import com.android.volley.toolbox.StringRequest;
 import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -263,19 +265,26 @@ public class OpenMrsServer implements Server {
         mConnectionDetails.getVolley().addToRequestQueue(request);
     }
 
-    @Override public void deleteObservation(String Uuid,
-                                         final Response.ErrorListener errorListener) {
-        OpenMrsJsonRequest request = mRequestFactory.newOpenMrsJsonRequest(
-            mConnectionDetails,
-            Request.Method.DELETE,
-            mConnectionDetails.getRestApiUrl() + "/obs/" + Uuid,
-            null,
-            new Response.Listener<JSONObject>() {
-                @Override public void onResponse(JSONObject response) {
-                    LOG.i("Voided observation");
-                }
-            },
-            wrapErrorListener(errorListener));
+    @Override
+    public void deleteObservation(
+            String Uuid,
+            final Response.Listener<Void> successListener,
+            final Response.ErrorListener errorListener) {
+        StringRequest request = new OpenMrsStringRequest(
+                Request.Method.DELETE,
+                "/obs/" + Uuid,
+                new Response.Listener<String>() {
+                    @Override
+                    public void onResponse(String response) {
+                        if (!TextUtils.isEmpty(response)) {
+                            // TODO: Didn't expect this, pass it through to the client.
+                            LOG.w("Delete observation response returned a non-blank response.");
+                        } else {
+                            successListener.onResponse(null);
+                        }
+                    }
+                },
+                wrapErrorListener(errorListener));
         request.setRetryPolicy(new DefaultRetryPolicy(Common.REQUEST_TIMEOUT_MS_SHORT, 1, 1f));
         mConnectionDetails.getVolley().addToRequestQueue(request);
     }

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsStringRequest.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsStringRequest.java
@@ -1,0 +1,42 @@
+package org.projectbuendia.client.net;
+
+import com.android.volley.AuthFailureError;
+import com.android.volley.Response;
+import com.android.volley.toolbox.StringRequest;
+
+import org.projectbuendia.client.App;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A request that targets the OpenMRS REST API (as opposed to the Buendia API) and returns a string.
+ */
+public class OpenMrsStringRequest extends StringRequest {
+
+    public OpenMrsStringRequest(
+            int method, String urlSuffix, Response.Listener<String> listener,
+            Response.ErrorListener errorListener) {
+        super(
+                method,
+                App.getConnectionDetails().getRestApiUrl() + urlSuffix,
+                listener,
+                errorListener);
+    }
+
+    public OpenMrsStringRequest(
+            String urlSuffix, Response.Listener<String> listener,
+            Response.ErrorListener errorListener) {
+        super(App.getConnectionDetails().getRestApiUrl() + urlSuffix, listener, errorListener);
+    }
+
+    @Override
+    public Map<String, String> getHeaders() throws AuthFailureError {
+        HashMap<String, String> params = new HashMap<>();
+        OpenMrsConnectionDetails.addAuthHeader(
+                App.getConnectionDetails().getUser(),
+                App.getConnectionDetails().getPassword(),
+                params);
+        return params;
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/net/Server.java
+++ b/app/src/main/java/org/projectbuendia/client/net/Server.java
@@ -93,6 +93,7 @@ public interface Server {
      */
     void deleteObservation(
             String Uuid,
+            Response.Listener<Void> successListener,
             Response.ErrorListener errorListener);
 
     /**

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -41,7 +41,9 @@ import org.projectbuendia.client.events.data.EncounterAddFailedEvent;
 import org.projectbuendia.client.events.data.ItemCreatedEvent;
 import org.projectbuendia.client.events.data.ItemDeletedEvent;
 import org.projectbuendia.client.events.data.ItemFetchedEvent;
+import org.projectbuendia.client.events.data.OrderDeleteFailedEvent;
 import org.projectbuendia.client.events.data.PatientUpdateFailedEvent;
+import org.projectbuendia.client.events.data.VoidObsFailedEvent;
 import org.projectbuendia.client.events.sync.SyncSucceededEvent;
 import org.projectbuendia.client.json.JsonUser;
 import org.projectbuendia.client.models.AppModel;
@@ -58,6 +60,7 @@ import org.projectbuendia.client.models.PatientDelta;
 import org.projectbuendia.client.models.VoidObs;
 import org.projectbuendia.client.sync.ChartDataHelper;
 import org.projectbuendia.client.sync.SyncManager;
+import org.projectbuendia.client.ui.BigToast;
 import org.projectbuendia.client.ui.dialogs.AssignLocationDialog;
 import org.projectbuendia.client.utils.EventBusRegistrationInterface;
 import org.projectbuendia.client.utils.LocaleSelector;
@@ -842,6 +845,16 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
                 mAppModel.VoidObservation(mCrudEventBus, new VoidObs(uuid));
             }
             updatePatientObsUi(lastChartIndex);
+        }
+
+        public void onEventMainThread(OrderDeleteFailedEvent event) {
+            // TODO: don't use App.getInstance for this.
+            BigToast.show(App.getInstance(), R.string.order_delete_failed);
+        }
+
+        public void onEventMainThread(VoidObsFailedEvent event) {
+            // TODO: don't use App.getInstance for this.
+            BigToast.show(App.getInstance(), R.string.observation_delete_failed);
         }
 
         public void onEventMainThread(OrderExecutionSaveRequestedEvent event) {

--- a/app/src/main/res/layout/void_observations_switch.xml
+++ b/app/src/main/res/layout/void_observations_switch.xml
@@ -2,12 +2,12 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
-
     <Switch
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="50dp"
         android:text="@string/delete_observations"
+        android:layout_marginStart="16dp"
+        android:textSize="24sp"
         android:id="@+id/swVoid"
-        android:layout_gravity="right"/>
-
+        android:layout_gravity="end"/>
 </LinearLayout>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -90,6 +90,7 @@
   <string name="order_give_for_days_cannot_be_zero">Doit être vide ou supérieure à 0</string>
   <string name="order_stop_now">Arrêter maintenant</string>
   <string name="order_delete">Supprimer cette traitement</string>
+  <string name="order_delete_failed">Traitement n\'etait pas supprimer.</string>
   <string name="title_confirmation">Confirmation</string>
   <string name="confirm_order_delete">Vramient supprimer?</string>
   <string name="delete">Supprimer</string>
@@ -369,6 +370,7 @@ S\'il vous plaît patienter pendant que les données du patient et l\'emplacemen
   <!-- View Observations dialog -->
   <string name="observation_on_day">le</string>
   <string name="delete_observations">Supprimer observations…</string>
+  <string name="observation_delete_failed">Observation n\'etait pas supprimer.</string>
 
   <!-- Notes panel -->
   <string name="error_failed_to_submit_note">Remarque n\'est pas submit.</string>
@@ -386,5 +388,4 @@ S\'il vous plaît patienter pendant que les données du patient et l\'emplacemen
   <!-- The day of week plus "medium" date format. e.g. Tues, 26 Jan 2015 -->
   <string name="day_of_week_and_medium_date">%1$tA, %1$td %1$tb %1$tY</string>
   <string name="age_unknown">age pas connu</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
   <string name="order_give_for_days_cannot_be_zero">Must be empty or greater than 0</string>
   <string name="order_stop_now">Stop now</string>
   <string name="order_delete">Delete this treatment</string>
+  <string name="order_delete_failed">Couldn\'t delete treatment.</string>
   <string name="title_confirmation">Confirmation</string>
   <string name="confirm_order_delete">Really delete?</string>
   <string name="delete">Delete</string>
@@ -361,7 +362,8 @@ Please wait while patient and location data are retrieved. If this is the first 
 
   <!-- View Observations dialog -->
   <string name="observation_on_day">on</string>
-  <string name="delete_observations">Delete some observations…</string>
+  <string name="delete_observations">Delete observations…</string>
+  <string name="observation_delete_failed">Couldn\'t delete observation.</string>
 
   <!-- Notes panel -->
   <string name="error_failed_to_submit_note">Failed to submit note.</string>
@@ -379,5 +381,4 @@ Please wait while patient and location data are retrieved. If this is the first 
   <!-- The day of week plus "medium" date format. e.g. Tues, 26 Jan 2015 -->
   <string name="day_of_week_and_medium_date">%1$tA, %1$td %1$tb %1$tY</string>
   <string name="age_unknown">age unknown</string>
-
 </resources>


### PR DESCRIPTION
Previously, it deleted the observation locally, and made a request to an endpoint that didn't exist,
but didn't do anything with the error anyway, so there was no real indication that it wasn't
working.

This change fixes all that, and also:
- Introduces a new OpenMrsStringRequest, which allows for empty responses like 204s (as opposed to
  OpenMrsJsonRequest)
- Pops a toast when an observation isn't successfully deleted
- Also pops a toast when a treatment (order) isn't successfully deleted, which we weren't doing
  either
- Adds padding around the "Void Observation" toggle switch so that it's easier to press without
  accidentally closing the dialog.
