### PR TITLE
Fix a crash relating to displaying forms with persistent fields.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/models/ConceptUuids.java
+++ b/app/src/main/java/org/projectbuendia/client/models/ConceptUuids.java
@@ -28,7 +28,7 @@ public class ConceptUuids {
     public static final String PREGNANCY_UUID = "5272AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     // Persistent fields
-    public static HashSet<String> PERSISTENT_FIELDS = new HashSet<String>();
+    public static final HashSet<String> PERSISTENT_FIELDS = new HashSet<>();
 
     static {
         // TODO: Determine from the profile which fields should be persistent (on a per form basis), instead of here

--- a/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
@@ -65,7 +65,7 @@ public class ChartDataHelper {
     private static final Logger LOG = Logger.create();
 
     /** When non-null, sConceptNames and sConceptTypes contain valid data for this locale. */
-    private static Object sLoadingLock = new Object();
+    private static final Object sLoadingLock = new Object();
     private static String sLoadedLocale;
 
     private static Map<String, String> sConceptNames;
@@ -81,7 +81,7 @@ public class ChartDataHelper {
     }
 
     /** Returns the loaded concept name for the specified concept UUID */
-    public String getConceptNameByUuid(String uuid) {
+    public @Nullable String getConceptNameByUuid(String uuid) {
         if(sConceptNames == null) return "";
 
         return sConceptNames.get(uuid);

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -340,16 +340,7 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
             preset.clinicianName = user.fullName;
         }
 
-        Map<String, Obs> observations =
-            mChartHelper.getLatestObservations(mPatientUuid);
-
-        // TODO: Refactor this as it's repeated in two methods
-        for(String uuid : ConceptUuids.PERSISTENT_FIELDS) {
-            if (observations.containsKey(uuid)
-                    && ConceptUuids.YES_UUID.equals(observations.get(uuid).value)) {
-                preset.persistentFieldsSelected.add(mChartHelper.getConceptNameByUuid(uuid).toLowerCase());
-            }
-        }
+        // TODO: implement persistent fields here, if we keep this code.
 
         preset.targetGroup = targetGroup;
 
@@ -439,7 +430,14 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
         for(String uuid : ConceptUuids.PERSISTENT_FIELDS) {
             if (observations.containsKey(uuid)
                     && ConceptUuids.YES_UUID.equals(observations.get(uuid).value)) {
-                preset.persistentFieldsSelected.add(mChartHelper.getConceptNameByUuid(uuid).toLowerCase());
+                // TODO: Ideally, we'd know how to determine whether a field was in a form, which
+                // would make this more efficent. But we can't at the moment.
+                String conceptName = mChartHelper.getConceptNameByUuid(uuid);
+                // The concept name could be null if there's an observation whose concept isn't in
+                // use in the profile.
+                if (conceptName != null) {
+                    preset.persistentFieldsSelected.add(conceptName.toLowerCase());
+                }
             }
         }
 


### PR DESCRIPTION
If a patient has observations that use question UUIDs that aren't in our forms or charts, we don't download the concept. When we try and load the concept name to tell ODK collect to persist the field, it doesn't work because the concept UUID is null.

We fix that with a null check.
