### PR TITLE
Restore clickability for all tiles with 1 concept.

### DIFF
--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -21,8 +21,8 @@
         <td
           id="tile-{{id}}"
           class="tile concept-{{id}} {{class}}"
-          {% if tile.item.conceptUuids.length == 1 %}
-            onclick="od('{{tile.item.conceptUuids | first }}','','');"
+          {% if tile.item.conceptUuids.size == 1 %}
+            onclick="od('{{tile.item.conceptUuids[0] }}','','');"
           {% endif %}
           style="{{style}}"
           width="{{100.0 / tileRow.size}}%" >

--- a/app/src/main/java/org/projectbuendia/client/models/ChartItem.java
+++ b/app/src/main/java/org/projectbuendia/client/models/ChartItem.java
@@ -16,6 +16,7 @@ import org.projectbuendia.client.utils.Utils;
 
 import java.text.Format;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -26,7 +27,7 @@ public class ChartItem {
     public final @Nonnull String label;
     public final @Nonnull String type;
     public final boolean required;
-    public final @Nonnull String[] conceptUuids;
+    public final @Nonnull List<String> conceptUuids;
     public final @Nonnull List<Object> conceptIds;
     public final @Nullable Format format;
     public final @Nullable Format captionFormat;
@@ -35,7 +36,7 @@ public class ChartItem {
     public final @Nonnull String script;
 
     public ChartItem(@Nullable String label, @Nullable String type, boolean required,
-                     @Nullable String[] conceptUuids, @Nullable String format,
+                     @Nullable List<String> conceptUuids, @Nullable String format,
                      @Nullable String captionFormat, @Nullable String cssClass,
                      @Nullable String cssStyle, @Nullable String script) {
         this(label, type, required, conceptUuids,
@@ -44,13 +45,15 @@ public class ChartItem {
     }
 
     public ChartItem(@Nullable String label, @Nullable String type, boolean required,
-                     @Nullable String[] conceptUuids, @Nullable Format format,
+                     @Nullable List<String> conceptUuids, @Nullable Format format,
                      @Nullable Format captionFormat, @Nullable Format cssClass,
                      @Nullable Format cssStyle, @Nullable String script) {
         this.label = label == null ? "" : label;
         this.type = type == null ? "" : type;
         this.required = required;
-        this.conceptUuids = conceptUuids == null ? new String[0] : conceptUuids;
+        this.conceptUuids = conceptUuids == null
+                ? Collections.<String>emptyList()
+                : conceptUuids;
         this.format = format;
         this.captionFormat = captionFormat;
         this.cssClass = cssClass;

--- a/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
@@ -35,6 +35,7 @@ import org.projectbuendia.client.utils.Logger;
 import org.projectbuendia.client.utils.Utils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -340,7 +341,8 @@ public class ChartDataHelper {
                         ChartItem item = new ChartItem(label,
                             Utils.getString(c, ChartItems.TYPE),
                             Utils.getLong(c, ChartItems.REQUIRED, 0L) > 0L,
-                            Utils.getString(c, ChartItems.CONCEPT_UUIDS, "").split(","),
+                            Arrays.asList
+                                    (Utils.getString(c, ChartItems.CONCEPT_UUIDS, "").split(",")),
                             Utils.getString(c, ChartItems.FORMAT),
                             Utils.getString(c, ChartItems.CAPTION_FORMAT),
                             Utils.getString(c, ChartItems.CSS_CLASS),

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -28,7 +28,6 @@ import org.projectbuendia.client.utils.Utils;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,16 +134,16 @@ public class ChartRenderer {
             for (ChartSection tileGroup : chart.tileGroups) {
                 List<Tile> tileRow = new ArrayList<>();
                 for (ChartItem item : tileGroup.items) {
-                    ObsPoint[] points = new ObsPoint[item.conceptUuids.length];
+                    ObsPoint[] points = new ObsPoint[item.conceptUuids.size()];
                     for (int i = 0; i < points.length; i++) {
-                        Obs obs = latestObservations.get(item.conceptUuids[i]);
+                        Obs obs = latestObservations.get(item.conceptUuids.get(i));
                         if (obs != null) {
                             points[i] = obs.getObsPoint();
                         }
                     }
                     tileRow.add(new Tile(item, points));
                     if (!item.script.trim().isEmpty()) {
-                        mConceptsToDump.addAll(Arrays.asList(item.conceptUuids));
+                        mConceptsToDump.addAll(item.conceptUuids);
                     }
                 }
                 mTileRows.add(tileRow);
@@ -153,9 +152,9 @@ public class ChartRenderer {
                 for (ChartItem item : section.items) {
                     Row row = new Row(item);
                     mRows.add(row);
-                    mRowsByUuid.put(item.conceptUuids[0], row);
+                    mRowsByUuid.put(item.conceptUuids.get(0), row);
                     if (!item.script.trim().isEmpty()) {
-                        mConceptsToDump.addAll(Arrays.asList(item.conceptUuids));
+                        mConceptsToDump.addAll(item.conceptUuids);
                     }
                 }
             }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
@@ -294,7 +294,7 @@ public class PebbleExtension extends AbstractExtension {
             // TODO/robustness: Check types before casting.
             Row row = (Row) args.get("row");
             Column column = (Column) args.get("column");
-            return column.pointSetByConceptUuid.get(row.item.conceptUuids[0]);
+            return column.pointSetByConceptUuid.get(row.item.conceptUuids.get(0));
         }
     }
 
@@ -308,7 +308,8 @@ public class PebbleExtension extends AbstractExtension {
             // TODO/robustness: Check types before casting.
             Row row = (Row) args.get("row");
             Column column = (Column) args.get("column");
-            SortedSet<ObsPoint> obsSet = column.pointSetByConceptUuid.get(row.item.conceptUuids[0]);
+            SortedSet<ObsPoint> obsSet =
+                    column.pointSetByConceptUuid.get(row.item.conceptUuids.get(0));
             return obsSet.isEmpty() ? null : obsSet.last();
         }
     }


### PR DESCRIPTION
Previously, all tiles had their clicking disabled by faulty logic. Pebble doesn't know how to handle
the `.length` property of arrays, and interpreted it as null, which prevented the relevant code
from firing. This change converts `ChartItem#conceptUuids` to a List instead of an array, such that
Pebble is capable of working with the field.
