### PR TITLE
Only enable Stetho on debug builds.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,13 +57,19 @@ dependencies {
     compile 'com.squareup.dagger:dagger:1.2.2' // Dependency injection
     compile 'de.greenrobot:eventbus:2.4.0' // The event bus
     compile 'joda-time:joda-time:2.5' // Better dates and times
-    compile 'com.facebook.stetho:stetho:1.2.0' // Handy debugging bridge
-    compile 'com.facebook.stetho:stetho-okhttp:1.2.0' // Network debugging
     compile 'com.mitchellbosecke:pebble:1.5.1' // HTML templating
     compile 'org.slf4j:slf4j-simple:1.7.12' // HTML templating dependency
     compile 'org.apache.commons:commons-lang3:3.4'
     // Magic sliding panel that we use for the notes view.
     compile 'com.sothree.slidinguppanel:library:3.2.1'
+    // We use this as a network base so we can use intercept network calls with Stetho on debug
+    // builds.
+    compile 'com.squareup.okhttp:okhttp:2.7.5'
+    compile 'com.google.code.findbugs:jsr305:2.0.1' // Nullable annotations
+
+    // Debug features only
+    debugCompile 'com.facebook.stetho:stetho:1.2.0' // Handy debugging bridge
+    debugCompile 'com.facebook.stetho:stetho-okhttp:1.2.0' // Network debugging
 
     // Testing
     androidTestCompile 'com.android.support.test:runner:0.3'

--- a/app/src/debug/java/org/projectbuendia/client/Modules.java
+++ b/app/src/debug/java/org/projectbuendia/client/Modules.java
@@ -11,9 +11,10 @@
 
 package org.projectbuendia.client;
 
+import org.projectbuendia.client.debug.DebugModule;
+
 /**
- * The modules used for injection in a debug build. Currently identical to a normal build, but
- * can be used to add debug-specific modules.
+ * The modules used for injection in a debug build.
  */
 final class Modules {
 
@@ -22,7 +23,8 @@ final class Modules {
 
     static Object[] list(App app) {
         return new Object[] {
-            new AppModule(app)
+            new AppModule(app),
+            new DebugModule()
         };
     }
 }

--- a/app/src/debug/java/org/projectbuendia/client/debug/DebugModule.java
+++ b/app/src/debug/java/org/projectbuendia/client/debug/DebugModule.java
@@ -1,0 +1,45 @@
+package org.projectbuendia.client.debug;
+
+import android.content.Context;
+
+import com.facebook.stetho.Stetho;
+import com.facebook.stetho.okhttp.StethoInterceptor;
+import com.squareup.okhttp.OkHttpClient;
+
+import org.projectbuendia.client.AppModule;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * A module that provides debug bindings.
+ */
+@Module(
+    includes = {
+        AppModule.class
+    },
+    library = true,
+    overrides = true
+)
+public class DebugModule {
+
+    private static final StethoInitializer STETHO_INITIALIZER = new StethoInitializer() {
+        @Override
+        public void initialize(Context context) {
+            Stetho.initializeWithDefaults(context);
+        }
+
+        @Override
+        public void registerInterceptors(OkHttpClient okHttpClient) {
+            okHttpClient.networkInterceptors().add(new StethoInterceptor());
+        }
+    };
+
+    @Provides
+    @Singleton
+    public StethoInitializer getStethoInitializer() {
+        return STETHO_INITIALIZER;
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/App.java
+++ b/app/src/main/java/org/projectbuendia/client/App.java
@@ -16,9 +16,8 @@ import android.content.Context;
 import android.preference.PreferenceManager;
 import android.support.multidex.MultiDex;
 
-import com.facebook.stetho.Stetho;
-
 import org.odk.collect.android.application.Collect;
+import org.projectbuendia.client.debug.StethoInitializer;
 import org.projectbuendia.client.diagnostics.HealthMonitor;
 import org.projectbuendia.client.net.OpenMrsConnectionDetails;
 import org.projectbuendia.client.net.Server;
@@ -41,6 +40,7 @@ public class App extends Application {
     @Inject OpenMrsConnectionDetails mOpenMrsConnectionDetails;
     @Inject Server mServer;
     @Inject HealthMonitor mHealthMonitor;
+    @Inject StethoInitializer mStethoInitializer;
 
     public static synchronized App getInstance() {
         return sInstance;
@@ -62,13 +62,13 @@ public class App extends Application {
         Collect.onCreate(this);
         super.onCreate();
 
-        // Enable Stetho, which lets you inspect the app's database, UI, and network activity
-        // just by opening chrome://inspect in Chrome on a computer connected to the tablet.
-        Stetho.initializeWithDefaults(this);
-
         mObjectGraph = ObjectGraph.create(Modules.list(this));
         mObjectGraph.inject(this);
         mObjectGraph.injectStatics();
+
+        // Enable Stetho, which lets you inspect the app's database, UI, and network activity
+        // just by opening chrome://inspect in Chrome on a computer connected to the tablet.
+        mStethoInitializer.initialize(this);
 
         // Ensure all unset preferences get initialized with default values.
         PreferenceManager.setDefaultValues(this, R.xml.pref_general, false);

--- a/app/src/main/java/org/projectbuendia/client/AppModule.java
+++ b/app/src/main/java/org/projectbuendia/client/AppModule.java
@@ -15,6 +15,7 @@ import android.app.Application;
 import android.content.ContentResolver;
 import android.preference.PreferenceManager;
 
+import org.projectbuendia.client.debug.StethoInitializer;
 import org.projectbuendia.client.diagnostics.DiagnosticsModule;
 import org.projectbuendia.client.events.EventsModule;
 import org.projectbuendia.client.models.AppModelModule;
@@ -113,5 +114,11 @@ public final class AppModule {
     @Provides
     @Singleton ChartDataHelper provideLocalizedChartHelper(ContentResolver contentResolver) {
         return new ChartDataHelper(contentResolver);
+    }
+
+    @Provides
+    @Singleton
+    StethoInitializer provideStethoInitializer() {
+        return new StethoInitializer.NoOp();
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/debug/StethoInitializer.java
+++ b/app/src/main/java/org/projectbuendia/client/debug/StethoInitializer.java
@@ -1,0 +1,22 @@
+package org.projectbuendia.client.debug;
+
+import android.content.Context;
+
+import com.squareup.okhttp.OkHttpClient;
+
+/**
+ * Potentially initializes Stetho, the debug bridge.
+ */
+public interface StethoInitializer {
+  void initialize(Context context);
+  void registerInterceptors(OkHttpClient okHttpClient);
+
+  class NoOp implements StethoInitializer {
+
+    @Override
+    public void initialize(Context context) {}
+
+    @Override
+    public void registerInterceptors(OkHttpClient okHttpClient) {}
+  }
+}

--- a/app/src/main/java/org/projectbuendia/client/net/NetModule.java
+++ b/app/src/main/java/org/projectbuendia/client/net/NetModule.java
@@ -16,11 +16,8 @@ import android.app.Application;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 import org.projectbuendia.client.AppSettings;
-import org.projectbuendia.client.json.DateTimeSerializer;
-import org.projectbuendia.client.json.LocalDateSerializer;
+import org.projectbuendia.client.debug.StethoInitializer;
 import org.projectbuendia.client.json.Serializers;
 
 import javax.inject.Singleton;
@@ -34,13 +31,14 @@ import dagger.Provides;
 public class NetModule {
 
     @Provides
-    @Singleton VolleySingleton provideVolleySingleton(Application app) {
-        return VolleySingleton.getInstance(app);
+    @Singleton
+    VolleyRequestQueue provideVolleySingleton(StethoInitializer stetho, Application app) {
+        return new VolleyRequestQueue(stetho, app);
     }
 
     @Provides
     @Singleton OpenMrsConnectionDetails provideOpenMrsConnectionDetails(
-        VolleySingleton volley, AppSettings settings) {
+        VolleyRequestQueue volley, AppSettings settings) {
         return new OpenMrsConnectionDetails(volley, settings);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsConnectionDetails.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsConnectionDetails.java
@@ -20,21 +20,21 @@ import java.util.Map;
 /** Provides the URL and credentials for connecting to OpenMRS. */
 public class OpenMrsConnectionDetails {
 
-    private final VolleySingleton mVolley;
+    private final VolleyRequestQueue mVolley;
     private final AppSettings mSettings;
 
     /**
      * Constructs an {@link OpenMrsConnectionDetails} object.
-     * @param volley   the {@link VolleySingleton} for making requests
+     * @param volley   the {@link VolleyRequestQueue} for making requests
      * @param settings the application settings
      */
-    public OpenMrsConnectionDetails(VolleySingleton volley, AppSettings settings) {
+    public OpenMrsConnectionDetails(VolleyRequestQueue volley, AppSettings settings) {
         mVolley = volley;
         mSettings = settings;
     }
 
     /** Gets the Volley instance to use for network connections. */
-    public VolleySingleton getVolley() {
+    public VolleyRequestQueue getVolley() {
         return mVolley;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/net/VolleyRequestQueue.java
+++ b/app/src/main/java/org/projectbuendia/client/net/VolleyRequestQueue.java
@@ -17,31 +17,18 @@ import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.Volley;
 import com.circle.android.api.OkHttpStack;
-import com.facebook.stetho.okhttp.StethoInterceptor;
 import com.squareup.okhttp.OkHttpClient;
 
-/** Wraps Volley up in a singleton object. */
-public class VolleySingleton {
-    private static VolleySingleton sInstance;
+import org.projectbuendia.client.debug.StethoInitializer;
+
+/** Wraps Volley up into a single request queue. */
+public class VolleyRequestQueue {
 
     private final RequestQueue mRequestQueue;
 
     /**
-     * Get the VolleySingleton instance for doing multiple operations on a single context.
-     * In general prefer convenience methods unless doing multiple operations.
-     * @param context the Android Application context
-     * @return the Singleton for accessing Volley.
-     */
-    public static synchronized VolleySingleton getInstance(Context context) {
-        if (sInstance == null) {
-            sInstance = new VolleySingleton(context);
-        }
-        return sInstance;
-    }
-
-    /**
-     * A convenience method for adding a request to the Volley request queue getting all singleton
-     * handling and contexts correct.
+     * A convenience method for adding a request to the Volley request queue getting all contexts
+     * correct.
      */
     public <T> void addToRequestQueue(Request<T> req) {
         getRequestQueue().add(req);
@@ -51,10 +38,11 @@ public class VolleySingleton {
         return mRequestQueue;
     }
 
-    private VolleySingleton(Context context) {
-        // Let Stetho inspect all our network requests.
+    public VolleyRequestQueue(StethoInitializer stetho, Context context) {
         final OkHttpClient client = new OkHttpClient();
-        client.networkInterceptors().add(new StethoInterceptor());
+
+        // Let Stetho inspect all our network requests.
+        stetho.registerInterceptors(client);
 
         // getApplicationContext() is key, it keeps you from leaking the
         // Activity or BroadcastReceiver if someone passes one in.

--- a/app/src/main/java/org/projectbuendia/client/updater/PackageServer.java
+++ b/app/src/main/java/org/projectbuendia/client/updater/PackageServer.java
@@ -18,12 +18,16 @@ import com.google.gson.reflect.TypeToken;
 import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.net.Common;
 import org.projectbuendia.client.net.GsonRequest;
-import org.projectbuendia.client.net.VolleySingleton;
+import org.projectbuendia.client.net.VolleyRequestQueue;
 import org.projectbuendia.client.json.JsonUpdateInfo;
 
 import java.util.List;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 /** Encapsulates requests to the package server. */
+@Singleton
 public class PackageServer {
 
     /**
@@ -33,10 +37,11 @@ public class PackageServer {
      */
     private static final String MODULE_NAME = "buendia-client";
 
-    private final VolleySingleton mVolley;
+    private final VolleyRequestQueue mVolley;
     private final AppSettings mSettings;
 
-    public PackageServer(VolleySingleton volley, AppSettings settings) {
+    @Inject
+    public PackageServer(VolleyRequestQueue volley, AppSettings settings) {
         mVolley = volley;
         mSettings = settings;
     }

--- a/app/src/main/java/org/projectbuendia/client/updater/UpdateModule.java
+++ b/app/src/main/java/org/projectbuendia/client/updater/UpdateModule.java
@@ -14,7 +14,6 @@ package org.projectbuendia.client.updater;
 import android.app.Application;
 
 import org.projectbuendia.client.AppSettings;
-import org.projectbuendia.client.net.VolleySingleton;
 import org.projectbuendia.client.ui.lists.BaseSearchablePatientListActivity;
 
 import javax.inject.Singleton;
@@ -30,12 +29,6 @@ import dagger.Provides;
     complete = false,
     library = true)
 public class UpdateModule {
-
-    @Provides
-    @Singleton
-    PackageServer providePackageServer(Application application, AppSettings settings) {
-        return new PackageServer(VolleySingleton.getInstance(application), settings);
-    }
 
     @Provides
     @Singleton UpdateManager provideUpdateManager(


### PR DESCRIPTION
- The gist is to introduce a Debug module that overrides the No-op StethoInitializer in the main module, which required a bit of reworking of our object graph.
- VolleySingleton is no longer a self-managed singleton, but its singleton nature is now managed by Dagger. This allows us to Inject the correct StethoInitializer.
