### PR TITLE
Fix sync on UserManager.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/debug/DebugAssertions.java
+++ b/app/src/main/java/org/projectbuendia/client/debug/DebugAssertions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The Project Buendia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distrib-
+ * uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.projectbuendia.client.debug;
+
+import android.os.Looper;
+
+import org.projectbuendia.client.BuildConfig;
+
+/**
+ * Contains a handful of assertions that only throw exceptions when in debug builds.
+ */
+public class DebugAssertions {
+    private DebugAssertions() {}
+
+    public static void assertMainThread() {
+        if (!BuildConfig.DEBUG) {
+            return;
+        }
+        // NOTE: API 23 has {@link Looper#isCurrentThread()}, but we can't use that if we want
+        // backwards compatability to API 19.
+        if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
+            Thread mainThread = Looper.getMainLooper().getThread();
+            throw new IllegalStateException(String.format(
+                    "Expected main thread (%s), actually running on thread %s",
+                    mainThread, Thread.currentThread()));
+        }
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/net/OdkXformSyncTask.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OdkXformSyncTask.java
@@ -71,7 +71,6 @@ public class OdkXformSyncTask extends AsyncTask<OpenMrsXformIndexEntry, Void, Vo
             // Check if the uuid already exists in the database.
             Cursor cursor = null;
             boolean isNew;
-            final boolean usersHaveChanged = App.getUserManager().isDirty();
             try {
                 cursor = getCursorForFormFile(proposedPath, new String[] {
                     FormsProviderAPI.FormsColumns.DATE
@@ -88,11 +87,10 @@ public class OdkXformSyncTask extends AsyncTask<OpenMrsXformIndexEntry, Void, Vo
                     long existingTimestamp = cursor.getLong(0);
                     isNew = (existingTimestamp < formInfo.dateChanged);
 
-                    if (isNew || usersHaveChanged) {
+                    if (isNew) {
                         LOG.i("Form " + formInfo.uuid + " requires an update."
                             + " (Local creation date: " + existingTimestamp
-                            + ", (Latest version: " + formInfo.dateChanged + ")"
-                            + ", (Invalidated by UserManager: " + usersHaveChanged + ")");
+                            + ", (Latest version: " + formInfo.dateChanged + ")");
                     }
                 } else {
                     LOG.i("Form " + formInfo.uuid + " not found in database.");
@@ -104,7 +102,7 @@ public class OdkXformSyncTask extends AsyncTask<OpenMrsXformIndexEntry, Void, Vo
                 }
             }
 
-            if (!isNew && !usersHaveChanged) {
+            if (!isNew) {
                 LOG.i("Using form " + formInfo.uuid + " from local cache.");
                 if (mFormWrittenListener != null) {
                     mFormWrittenListener.formWritten(proposedPath, formInfo.uuid);
@@ -230,8 +228,6 @@ public class OdkXformSyncTask extends AsyncTask<OpenMrsXformIndexEntry, Void, Vo
                 mFormWrittenListener.formWritten(path, mUuid);
             }
             mEventBus.post(new FetchXformSucceededEvent());
-
-            App.getUserManager().setDirty(false);
         }
 
         private static boolean writeStringToFile(String response, File proposedPath) {

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -68,7 +68,7 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
             super.onCreate(savedInstanceState);
 
             // If there is no active user, then return the user to the user login activity.
-            BigToast.show(this, "Please login to continue"); // TODO/i18n
+            BigToast.show(this, R.string.toast_please_login);
 
             Intent intent = new Intent(this, LoginActivity.class);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);

--- a/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
@@ -11,8 +11,6 @@
 
 package org.projectbuendia.client.ui;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -53,7 +51,7 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
     protected ProgressBar mIndeterminateProgressBar;
     protected int mShortAnimationDuration;
     private State mState = State.LOADING;
-    private List<ChangeStateSubscriber> mSubscribers = new ArrayList<ChangeStateSubscriber>();
+    private List<ChangeStateSubscriber> mSubscribers = new ArrayList<>();
 
     public enum State {
         LOADING,
@@ -64,7 +62,7 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
     /** Subscriber for listening for state changes. */
     public interface ChangeStateSubscriber {
         /** Called whenever the state is changed. */
-        public void onChangeState(State newState);
+        void onChangeState(State newState);
     }
 
     public ProgressFragment() {
@@ -125,7 +123,7 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
         mIndeterminateProgressBar.setLayoutParams(relativeLayout);
 
         mProgressBarLayout =
-            inflater.inflate(R.layout.progress_fragment_measured_progress_view, null);
+            inflater.inflate(R.layout.progress_fragment_measured_progress_view, container, false);
         mProgressBarLayout.setLayoutParams(relativeLayout);
         mProgressBar =
             (ProgressBar) mProgressBarLayout.findViewById(R.id.progress_fragment_progress_bar);
@@ -175,11 +173,6 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
         mContent = LayoutInflater.from(getActivity()).inflate(layout, null, false);
     }
 
-    protected void incrementProgressBy(int progress) {
-        switchToHorizontalProgressBar();
-        mProgressBar.incrementProgressBy(progress);
-    }
-
     protected void switchToHorizontalProgressBar() {
         if (mState == State.LOADING) {
             mIndeterminateProgressBar.setVisibility(View.GONE);
@@ -201,35 +194,6 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
         if (mState == State.LOADING) {
             mIndeterminateProgressBar.setVisibility(View.VISIBLE);
             mProgressBarLayout.setVisibility(View.GONE);
-        }
-    }
-
-    private void crossfade(View inView, final View outView) {
-
-        // Set the content view to 0% opacity but visible, so that it is visible
-        // (but fully transparent) during the animation.
-        inView.setAlpha(0f);
-        inView.setVisibility(View.VISIBLE);
-
-        // Animate the content view to 100% opacity, and clear any animation
-        // listener set on the view.
-        inView.animate()
-            .alpha(1f)
-            .setDuration(mShortAnimationDuration)
-            .setListener(null);
-
-        // Animate the loading view to 0% opacity. After the animation ends,
-        // set its visibility to GONE as an optimization step (it won't
-        // participate in layout passes, etc.)
-        if (outView != null) {
-            outView.animate()
-                .alpha(0f)
-                .setDuration(mShortAnimationDuration)
-                .setListener(new AnimatorListenerAdapter() {
-                    @Override public void onAnimationEnd(Animator animation) {
-                        outView.setVisibility(View.GONE);
-                    }
-                });
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/user/UserStore.java
+++ b/app/src/main/java/org/projectbuendia/client/user/UserStore.java
@@ -23,6 +23,7 @@ import android.os.RemoteException;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.RequestFuture;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
 import org.projectbuendia.client.App;
@@ -84,6 +85,7 @@ public class UserStore {
         LOG.i("Updating user db with newly added user");
         ContentProviderClient client = App.getInstance().getContentResolver()
             .acquireContentProviderClient(Users.CONTENT_URI);
+        Preconditions.checkNotNull(client);
         try {
             ContentValues values = new ContentValues();
             values.put(Users.UUID, user.id);
@@ -142,8 +144,10 @@ public class UserStore {
         LOG.i("Updating local database with %d users", users.size());
         ContentProviderClient client = App.getInstance().getContentResolver()
             .acquireContentProviderClient(Users.CONTENT_URI);
+        Preconditions.checkNotNull(client);
         BuendiaProvider buendiaProvider =
             (BuendiaProvider) (client.getLocalContentProvider());
+        Preconditions.checkNotNull(buendiaProvider);
         SQLiteDatabaseTransactionHelper dbTransactionHelper =
             buendiaProvider.getDbTransactionHelper();
         try {
@@ -182,6 +186,7 @@ public class UserStore {
                 .acquireContentProviderClient(Users.CONTENT_URI);
 
             // Request users from database.
+            Preconditions.checkNotNull(client);
             cursor = client.query(Users.CONTENT_URI, new String[]{Users.FULL_NAME, Users.UUID},
                 null, null, Users.FULL_NAME);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,4 +386,6 @@ Please wait while patient and location data are retrieved. If this is the first 
   <!-- The day of week plus "medium" date format. e.g. Tues, 26 Jan 2015 -->
   <string name="day_of_week_and_medium_date">%1$tA, %1$td %1$tb %1$tY</string>
   <string name="age_unknown">age unknown</string>
+  <string name="toast_please_login"
+          tools:ignore="MissingTranslation">Please login to continue</string>
 </resources>


### PR DESCRIPTION
UserManager was documented as "only use from the Main Thread" but it was used on background threads too - for example, by sync.

This change makes UserManager thread safe and introduces @GuardedBy annotations for the whole thing.

It also introduces a `DebugAssertions` class, which has an `assertMainThread` method, which I used to discover this.

There was also loads of code that connected `UserManager` do `OdkSyncTask` - forms and users have been distinct concepts for as long as I've been on the project, so this change removes this coupling.
