### PR TITLE
Show a selectable number of columns per day.

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -10,16 +10,32 @@ th, td {
   text-align: left;
   vertical-align: baseline;
 }
+
+/* Grid lines */
 /* TODO: Adding left/right padding >0 breaks frozen headers.  Figure out why. */
+#grid th.day {
+  border-top: 1px solid #666;
+}
+
+#grid th[scope="row"], #grid td {
+  border-bottom: 1px solid #ddd;
+}
+
 #grid th, #grid td {
   padding: 0.7em 0 0.8em; /* extra 0.1em on bottom for vertical centering */
-  /* Use linear-gradient to get a border thickness of 1 device pixel. */
-  background-image: linear-gradient(
-      90deg, transparent 33%, rgba(0, 0, 0, 0.2) 33%, rgba(0, 0, 0, 0.2));
-  background-size: 1px 100%;
-  background-repeat: no-repeat;
-  background-position: right;
+  border-right: 1px solid #ddd;
 }
+
+#grid .day, #grid .day-last, #grid th[scope="rowgroup"].day-last,
+#grid .gap, #grid th[scope="rowgroup"].gap,
+#grid th[scope="row"], #grid th.corner {
+  border-right: 1px solid #666;
+}
+
+#grid th[scope="rowgroup"], #grid th.command {
+  border-right: none;
+}
+
 #grid th[scope="row"] {
   padding-left: 16px;
 }
@@ -39,13 +55,13 @@ th, td {
   font-size: 1.4rem;
   padding: 0.2em 0 0.3em; /* extra 0.1em on bottom for vertical centering */
 }
-#grid .gap {
-  background: #eee;
+#grid th.gap, #grid th[scope="rowgroup"].gap {
+  background: repeating-linear-gradient(45deg, #fff, #fff 10px, #eee 10px, #eee 20px);
 }
 
 /* Row headers: should match @style/text.caps */
 #grid tbody th { white-space: nowrap; }
-#grid tbody th[scope="rowgroup"] {
+#grid th[scope="rowgroup"] {
   text-transform: uppercase;
   font-size: 1.4rem;
   font-weight: bold;
@@ -53,7 +69,7 @@ th, td {
   padding-top: 1.6em;
   padding-left: 16px;
 }
-#grid th:first-child { overflow: hidden; }
+#grid th[scope="row"] { overflow: hidden; }
 /* TODO: Specifying max-width in vw doesn't work here.  Figure out why. */
 #grid th[scope="row"] div { max-width: 24rem; overflow: hidden; }
 
@@ -87,15 +103,6 @@ th, td {
 }
 .tile .caption { /* should match @style/text.caption */
   font-size: 1.4rem;
-}
-
-#tiles, thead tr, #grid tr {
-  /* Use linear-gradient to get a border thickness of 1 device pixel. */
-  background-image: linear-gradient(
-      0deg, transparent 33%, rgba(0, 0, 0, 0.2) 33%, rgba(0, 0, 0, 0.2));
-  background-size: 100% 1px;
-  background-repeat: no-repeat;
-  background-position: bottom;
 }
 
 /* In-range / out-of-range colours */

--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -17,6 +17,10 @@ th, td {
   border-top: 1px solid #666;
 }
 
+#grid thead tr:last-child th, #grid thead th.gap {
+  border-bottom: 1px solid #666;
+}
+
 #grid th[scope="row"], #grid td {
   border-bottom: 1px solid #ddd;
 }
@@ -28,7 +32,7 @@ th, td {
 
 #grid .day, #grid .day-last, #grid th[scope="rowgroup"].day-last,
 #grid .gap, #grid th[scope="rowgroup"].gap,
-#grid th[scope="row"], #grid th.corner {
+#grid th[scope="rowgroup"]:first-child, #grid th[scope="row"], #grid th.corner {
   border-right: 1px solid #666;
 }
 

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -39,7 +39,7 @@
             {% if column.start != prevStop %}
               <th class="gap" scope="col" rowspan=2>&nbsp;</th>
             {% endif %}
-            <th colspan={{numColumnsPerDay}} onclick="od('','{{column.dayStart.millis}}','{{column.dayStop.millis}}');">
+            <th class="{{column.dayStart == nowDayStart ? 'now' : ''}}" colspan={{numColumnsPerDay}} onclick="od('','{{column.dayStart.millis}}','{{column.dayStop.millis}}');">
               {{column.heading}}
             </th>
           {% endif %}

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -33,15 +33,25 @@
     <thead>
       <tr>
         <th> </th>
-        {% set prevColumn = null %}
+        {% set prevStop = columns[0].start %}
         {% for column in columns %}
-          {% if prevColumn is not null and column.start != prevColumn.stop %}
-            <th class="gap" scope="col">&nbsp;</th>
+          {% if loop.index % numColumnsPerDay == 0 %}
+            {% if column.start != prevStop %}
+              <th class="gap" scope="col" rowspan=2>&nbsp;</th>
+            {% endif %}
+            <th colspan={{numColumnsPerDay}} onclick="od('','{{column.dayStart.millis}}','{{column.dayStop.millis}}');">
+              {{column.heading}}
+            </th>
           {% endif %}
+          {% set prevStop = column.stop %}
+        {% endfor %}
+      </tr>
+      <tr>
+        <th> </th>
+        {% for column in columns %}
           <th class="{{column.start == nowColumnStart ? 'now' : ''}}" scope="col" onclick="od('','{{column.start.millis}}','{{column.stop.millis}}');">
-            {{column.headingHtml | raw}}
+            {{column.subheading}}
           </th>
-          {% set prevColumn = column %}
         {% endfor %}
       </tr>
     </thead>

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -41,9 +41,11 @@
           {% if column.start == column.dayStart %}
             <th class="day {{column.date == nowDate ? 'now' : ''}}" colspan={{numColumnsPerDay}} onclick="od('','{{column.dayStart.millis}}','{{column.dayStop.millis}}');">
               {% if numColumnsPerDay == 1 %}
-                {{column.dayLabel}}<br>{{column.shortDate}}
-              {% else %}
+                {{column.dayLabel}}
+              {% elseif column.dayLabel is not empty %}
                 {{column.dayLabel}}, {{column.shortDate}}
+              {% else %}
+                {{column.shortDate}}
               {% endif %}
             </th>
           {% endif %}
@@ -54,7 +56,11 @@
         <th class="corner"> </th>
         {% for column in columns %}
           <th class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumnStart ? 'now' : ''}}" scope="col" onclick="od('','{{column.start.millis}}','{{column.stop.millis}}');">
-            {{column.startHour}}&ndash;{{column.stopHour}}
+            {% if numColumnsPerDay == 1 %}
+              {{column.shortDate}}
+            {% else %}
+              {{column.startHour}}&ndash;{{column.stopHour}}
+            {% endif %}
           </th>
         {% endfor %}
       </tr>

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -131,7 +131,7 @@
           {% if prevColumn is not null and column.start != prevColumn.stop %}
             <th scope="rowgroup" class="gap" rowspan={{orders.size + 1}}>&nbsp;</th>
           {% endif %}
-          <th scope="rowgroup"></th>
+        <th scope="rowgroup" class="{{column.stop == column.dayStop ? 'day-last' : ''}}"></th>
           {% set prevColumn = column %}
         {% endfor %}
       </tr>
@@ -144,7 +144,7 @@
           {% set previousActive = false %}
           {% set future = false %}
           {% for column in columns %}
-            <td class="{{column.start == nowColumnStart ? 'now' : ''}}">
+            <td class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumnStart ? 'now' : ''}}">
               {% set active = intervals_overlap(order.interval, column.interval) %}
               {% if order.stop == null and previousActive %}
                 <div class="future">&nbsp;</div>

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -32,25 +32,29 @@
   <table id="grid" cellspacing="0" cellpadding="0">
     <thead>
       <tr>
-        <th> </th>
+        <th class="corner"> </th>
         {% set prevStop = columns[0].start %}
         {% for column in columns %}
-          {% if loop.index % numColumnsPerDay == 0 %}
-            {% if column.start != prevStop %}
-              <th class="gap" scope="col" rowspan=2>&nbsp;</th>
-            {% endif %}
-            <th class="{{column.dayStart == nowDayStart ? 'now' : ''}}" colspan={{numColumnsPerDay}} onclick="od('','{{column.dayStart.millis}}','{{column.dayStop.millis}}');">
-              {{column.heading}}
+          {% if column.start != prevStop %}
+            <th class="gap" scope="col" rowspan=2>&nbsp;</th>
+          {% endif %}
+          {% if column.start == column.dayStart %}
+            <th class="day {{column.date == nowDate ? 'now' : ''}}" colspan={{numColumnsPerDay}} onclick="od('','{{column.dayStart.millis}}','{{column.dayStop.millis}}');">
+              {% if numColumnsPerDay == 1 %}
+                {{column.dayLabel}}<br>{{column.shortDate}}
+              {% else %}
+                {{column.dayLabel}}, {{column.shortDate}}
+              {% endif %}
             </th>
           {% endif %}
           {% set prevStop = column.stop %}
         {% endfor %}
       </tr>
       <tr>
-        <th> </th>
+        <th class="corner"> </th>
         {% for column in columns %}
-          <th class="{{column.start == nowColumnStart ? 'now' : ''}}" scope="col" onclick="od('','{{column.start.millis}}','{{column.stop.millis}}');">
-            {{column.subheading}}
+          <th class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumnStart ? 'now' : ''}}" scope="col" onclick="od('','{{column.start.millis}}','{{column.stop.millis}}');">
+            {{column.startHour}}&ndash;{{column.stopHour}}
           </th>
         {% endfor %}
       </tr>
@@ -66,7 +70,7 @@
           {% if prevColumn is not null and column.start != prevColumn.stop %}
             <th scope="rowgroup" class="gap" rowspan={{rows.size + 1}}>&nbsp;</th>
           {% endif %}
-          <th scope="rowgroup"></th>
+          <th scope="rowgroup" class="{{column.stop == column.dayStop ? 'day-last' : ''}}"></th>
           {% set prevColumn = column %}
         {% endfor %}
       </tr>
@@ -88,7 +92,7 @@
             {% set class = summaryValue | format_values(row.item.cssClass) %}
             {% set style = summaryValue | format_values(row.item.cssStyle) %}
             <td id="cell-{{id}}-{{column.start.millis}}"
-              class="{{column.start == nowColumnStart ? 'now' : ''}} {{class}}"
+              class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumnStart ? 'now' : ''}} {{class}}"
               style="{{style}}"
               onclick="{% if points is not empty%}
                        {% if (row.item.type).string != 'text_icon' %}

--- a/app/src/main/java/org/projectbuendia/client/AppSettings.java
+++ b/app/src/main/java/org/projectbuendia/client/AppSettings.java
@@ -60,6 +60,16 @@ public class AppSettings {
             mResources.getString(R.string.package_server_root_url_default));
     }
 
+    /** Gets the index of the preferred chart zoom level. */
+    public int getChartZoomIndex() {
+        return mSharedPreferences.getInt("chart_zoom_index", 0);
+    }
+
+    /** Sets the preferred chart zoom level. */
+    public void setChartZoomIndex(int zoom) {
+        mSharedPreferences.edit().putInt("chart_zoom_index", zoom).commit();
+    }
+
     /**
      * Gets the minimum period between checks for APK updates, in seconds.
      * Repeated calls to UpdateManager.checkForUpdate() within this period
@@ -97,5 +107,4 @@ public class AppSettings {
         return mSharedPreferences.getBoolean("require_wifi",
             mResources.getBoolean(R.bool.require_wifi_default));
     }
-
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -9,15 +9,13 @@ import android.webkit.WebView;
 import com.google.common.collect.Lists;
 import com.mitchellbosecke.pebble.PebbleEngine;
 
-import org.joda.time.Chronology;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.ReadableInstant;
-import org.joda.time.chrono.ISOChronology;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.R;
 import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.models.Chart;
@@ -43,17 +41,27 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import static org.projectbuendia.client.utils.Utils.HOUR;
+
 /** Renders a patient's chart to HTML displayed in a WebView. */
 public class ChartRenderer {
     static PebbleEngine sEngine;
     private static final Logger LOG = Logger.create();
+    public static ZoomLevel[] ZOOM_LEVELS = new ZoomLevel[] {
+        new ZoomLevel(R.string.zoom_day, 0),
+        new ZoomLevel(R.string.zoom_half, 0, 12*HOUR),
+        new ZoomLevel(R.string.zoom_third, 0, 8*HOUR, 16*HOUR),
+        new ZoomLevel(R.string.zoom_quarter, 0, 6*HOUR, 12*HOUR, 18*HOUR)
+    };
 
     WebView mView;  // view into which the HTML table will be rendered
     Resources mResources;  // resources used for localizing the rendering
+    AppSettings mSettings;
+
     private List<Obs> mLastRenderedObs;  // last set of observations rendered
     private List<Order> mLastRenderedOrders;  // last set of orders rendered
-    private Chronology chronology = ISOChronology.getInstance(DateTimeZone.getDefault());
-    private String lastChart = "";
+    private int mLastRenderedZoomIndex;  // last zoom level index rendered
+    private String mLastChartName = "";
 
     public interface GridJsInterface {
         @android.webkit.JavascriptInterface
@@ -71,9 +79,10 @@ public class ChartRenderer {
         void onPageUnload(int scrollX, int scrollY);
     }
 
-    public ChartRenderer(WebView view, Resources resources) {
+    public ChartRenderer(WebView view, Resources resources, AppSettings settings) {
         mView = view;
         mResources = resources;
+        mSettings = settings;
     }
 
     /** Renders a patient's history of observations to an HTML table in the WebView. */
@@ -86,11 +95,12 @@ public class ChartRenderer {
             mView.loadUrl("file:///android_asset/no_chart.html");
             return;
         }
-        if ((observations.equals(mLastRenderedObs) && orders.equals(mLastRenderedOrders))
-            && (lastChart.equals(chart.name))){
+        if (mLastChartName.equals(chart.name) &&
+            mLastRenderedZoomIndex == mSettings.getChartZoomIndex() &&
+            observations.equals(mLastRenderedObs) &&
+            orders.equals(mLastRenderedOrders)) {
             return;  // nothing has changed; no need to render again
         }
-        lastChart = chart.name;
 
         // setDefaultFontSize is supposed to take a size in sp, but in practice
         // the fonts don't change size when the user font size preference changes.
@@ -102,14 +112,23 @@ public class ChartRenderer {
         mView.getSettings().setJavaScriptEnabled(true);
         mView.addJavascriptInterface(controllerInterface, "controller");
         mView.setWebChromeClient(new WebChromeClient());
-        String html = new GridHtmlGenerator(chart, latestObservations, observations, orders,
-                                            admissionDate, firstSymptomsDate).getHtml();
-        mView.loadDataWithBaseURL("file:///android_asset/", html,
-            "text/html; charset=utf-8", "utf-8", null);
+        String html = new GridHtmlGenerator(
+            chart, latestObservations, observations, orders,
+            admissionDate, firstSymptomsDate).getHtml();
+        mView.loadDataWithBaseURL(
+            "file:///android_asset/", html, "text/html; charset=utf-8", "utf-8", null);
         mView.setWebContentsDebuggingEnabled(true);
 
+        mLastChartName = chart.name;
+        mLastRenderedZoomIndex = mSettings.getChartZoomIndex();
         mLastRenderedObs = observations;
         mLastRenderedOrders = orders;
+    }
+
+    /** Gets the starting times (in ms) of the segments into which the day is divided. */
+    public int[] getSegmentStartTimes() {
+        int index = mSettings.getChartZoomIndex();
+        return Utils.safeIndex(ZOOM_LEVELS, index).segmentStartTimes;
     }
 
     class GridHtmlGenerator {
@@ -194,25 +213,11 @@ public class ChartRenderer {
             }
         }
 
-        /** Gets the starting times (in ms) of the segments into which the day is divided. */
-        public int[] getSegmentStartingTimes() {
-            // Assumptions: the first element of this array must be zero; the
-            // values must be strictly increasing; the last element must be less
-            // than the length of the shortest day (23 hours accounting for DST).
-            return new int[] {
-                0,
-                6 * Utils.HOUR,
-                10 * Utils.HOUR,
-                14 * Utils.HOUR,
-                20 * Utils.HOUR
-            };
-        }
-
         /** Gets the n + 1 boundaries of the n segments of a specific day. */
         public DateTime[] getSegmentFenceposts(LocalDate date) {
             DateTime start = date.toDateTimeAtStartOfDay();
             DateTime stop = date.plusDays(1).toDateTimeAtStartOfDay();
-            int[] starts = getSegmentStartingTimes();
+            int[] starts = getSegmentStartTimes();
             DateTime[] fenceposts = new DateTime[starts.length + 1];
             for (int i = 0; i < starts.length; i++) {
                 fenceposts[i] = start.plusMillis(starts[i]);
@@ -305,7 +310,7 @@ public class ChartRenderer {
             context.put("tileRows", mTileRows);
             context.put("rows", mRows);
             context.put("columns", Lists.newArrayList(mColumnsByStartMillis.values()));
-            context.put("numColumnsPerDay", getSegmentStartingTimes().length);
+            context.put("numColumnsPerDay", getSegmentStartTimes().length);
             context.put("nowColumnStart", mNowColumn.start);
             context.put("nowDate", mNow.toLocalDate());
             context.put("orders", mOrders);
@@ -349,6 +354,26 @@ public class ChartRenderer {
                 StringWriter writer = new StringWriter();
                 e.printStackTrace(new PrintWriter(writer));
                 return "<div style=\"font-size: 150%\">" + writer.toString().replace("&", "&amp;").replace("<", "&lt;").replace("\n", "<br>");
+            }
+        }
+    }
+
+    public static class ZoomLevel {
+        public final int labelId;
+        public final int[] segmentStartTimes;
+
+        public ZoomLevel(int labelId, int... segmentStartTimes) {
+            this.labelId = labelId;
+            this.segmentStartTimes = segmentStartTimes;
+
+            if (segmentStartTimes[0] != 0) throw new IllegalArgumentException("First segment must start at time zero");
+            int prev = -1;
+            for (int next : segmentStartTimes) {
+                if (next <= prev) throw new IllegalArgumentException("Segment starting times must strictly increase");
+                prev = next;
+            }
+            if (prev >= 23*HOUR) {
+                throw new IllegalArgumentException("Last segment must start before end of a DST-shortened day");
             }
         }
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -250,28 +250,14 @@ public class ChartRenderer {
             for (int i = 0; i + 1 < fenceposts.length; i++) {
                 DateTime start = fenceposts[i];
                 DateTime stop = fenceposts[i + 1];
-                String heading = formatDateHeading(date);
-                String subheading = formatSegmentHeading(date, start, stop);
-                Column column = new Column(start, stop, heading, subheading);
+                Column column = new Column(start, stop, formatDayNumber(date));
                 mColumnsByStartMillis.put(column.start.getMillis(), column);
             }
         }
 
-        String formatDateHeading(LocalDate date) {
+        String formatDayNumber(LocalDate date) {
             int admitDay = Utils.dayNumberSince(mAdmissionDate, date);
-            String admitDayLabel = (admitDay >= 1) ?
-                mResources.getString(R.string.day_n, admitDay) + ", " : "";
-            return admitDayLabel + date.toString("d MMM");
-        }
-
-        String formatSegmentHeading(LocalDate date, DateTime start, DateTime stop) {
-            long dayStartMillis = date.toDateTimeAtStartOfDay().getMillis();
-            long startMillis = start.getMillis();
-            long stopMillis = stop.getMillis();
-            long startHour = (startMillis - dayStartMillis) / Utils.HOUR;
-            long stopHour = (stopMillis - dayStartMillis) / Utils.HOUR;
-            // Typography: en-dashes should be used to indicate a span between values.
-            return startHour + "–" + stopHour;
+            return (admitDay >= 1) ? mResources.getString(R.string.day_n, admitDay) : "";
         }
 
         void addObs(Column column, Obs obs) {
@@ -321,7 +307,7 @@ public class ChartRenderer {
             context.put("columns", Lists.newArrayList(mColumnsByStartMillis.values()));
             context.put("numColumnsPerDay", getSegmentStartingTimes().length);
             context.put("nowColumnStart", mNowColumn.start);
-            context.put("nowDayStart", mNow.toLocalDate().toDateTimeAtStartOfDay());
+            context.put("nowDate", mNow.toLocalDate());
             context.put("orders", mOrders);
             context.put("dataCellsByConceptId", getJsonDataDump());
             return renderTemplate("assets/chart.html", context);

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -321,6 +321,7 @@ public class ChartRenderer {
             context.put("columns", Lists.newArrayList(mColumnsByStartMillis.values()));
             context.put("numColumnsPerDay", getSegmentStartingTimes().length);
             context.put("nowColumnStart", mNowColumn.start);
+            context.put("nowDayStart", mNow.toLocalDate().toDateTimeAtStartOfDay());
             context.put("orders", mOrders);
             context.put("dataCellsByConceptId", getJsonDataDump());
             return renderTemplate("assets/chart.html", context);

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/Column.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/Column.java
@@ -14,14 +14,16 @@ import java.util.SortedSet;
 public class Column {
     public Instant start;
     public Instant stop;
-    public String headingHtml;
+    public String heading;
+    public String subheading;
     public Map<String, SortedSet<ObsPoint>> pointSetByConceptUuid = new HashMap<>();
     public Map<String, Integer> executionCountsByOrderUuid = new HashMap<>();
 
-    public Column(ReadableInstant start, ReadableInstant stop, String headingHtml) {
+    public Column(ReadableInstant start, ReadableInstant stop, String heading, String subheading) {
         this.start = new Instant(start);
         this.stop = new Instant(stop);
-        this.headingHtml = headingHtml;
+        this.heading = heading;
+        this.subheading = subheading;
     }
 
     public Interval getInterval() {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/Column.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/Column.java
@@ -1,5 +1,6 @@
 package org.projectbuendia.client.ui.chart;
 
+import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.joda.time.Interval;
 import org.joda.time.ReadableInstant;
@@ -28,5 +29,9 @@ public class Column {
 
     public Interval getInterval() {
         return Utils.toInterval(start, stop);
+    }
+
+    public DateTime getDayStart() {
+        return new DateTime(start).toLocalDate().toDateTimeAtStartOfDay();
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/Column.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/Column.java
@@ -1,8 +1,8 @@
 package org.projectbuendia.client.ui.chart;
 
-import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.joda.time.Interval;
+import org.joda.time.LocalDate;
 import org.joda.time.ReadableInstant;
 import org.projectbuendia.client.models.ObsPoint;
 import org.projectbuendia.client.utils.Utils;
@@ -13,25 +13,45 @@ import java.util.SortedSet;
 
 /** A column (containing the data for its observations) in the patient history grid. */
 public class Column {
-    public Instant start;
-    public Instant stop;
-    public String heading;
-    public String subheading;
-    public Map<String, SortedSet<ObsPoint>> pointSetByConceptUuid = new HashMap<>();
-    public Map<String, Integer> executionCountsByOrderUuid = new HashMap<>();
+    public final LocalDate date;
+    public final Instant start;
+    public final Instant stop;
+    public final String dayLabel;
+    public final Map<String, SortedSet<ObsPoint>> pointSetByConceptUuid = new HashMap<>();
+    public final Map<String, Integer> executionCountsByOrderUuid = new HashMap<>();
 
-    public Column(ReadableInstant start, ReadableInstant stop, String heading, String subheading) {
+    public Column(ReadableInstant start, ReadableInstant stop, String dayLabel) {
+        this.date = new LocalDate(start);
         this.start = new Instant(start);
         this.stop = new Instant(stop);
-        this.heading = heading;
-        this.subheading = subheading;
+        this.dayLabel = dayLabel;
     }
 
     public Interval getInterval() {
         return Utils.toInterval(start, stop);
     }
 
-    public DateTime getDayStart() {
-        return new DateTime(start).toLocalDate().toDateTimeAtStartOfDay();
+    public Instant getDayStart() {
+        return date.toDateTimeAtStartOfDay().toInstant();
+    }
+
+    public Instant getDayStop() {
+        return date.toDateTimeAtStartOfDay().plusDays(1).toInstant();
+    }
+
+    public String getShortDate() {
+        return date.toString("d MMM");
+    }
+
+    public int getDayNumberSince(LocalDate admissionDate) {
+        return Utils.dayNumberSince(admissionDate, date);
+    }
+
+    public long getStartHour() {
+        return (start.getMillis() - getDayStart().getMillis()) / Utils.HOUR;
+    }
+
+    public long getStopHour() {
+        return (stop.getMillis() - getDayStart().getMillis()) / Utils.HOUR;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -59,6 +59,9 @@ public class Utils {
     public static final DateTime MAX_DATETIME = new DateTime(MAX_TIME, DateTimeZone.UTC);
     public static final LocalDate MIN_DATE = new LocalDate(0, 1, 1).year().withMinimumValue();
     public static final LocalDate MAX_DATE = new LocalDate(0, 12, 31).year().withMaximumValue();
+    public static final int SECOND = 1000;  // in ms
+    public static final int MINUTE = 60 * SECOND;  // in ms
+    public static final int HOUR = 60 * MINUTE;  // in ms
 
     /**
      * Compares two objects that may be null, Integer, Long, BigInteger, or String.
@@ -463,8 +466,8 @@ public class Utils {
         return sw.toString();
     }
 
-    public static String removeUnsafeChars(String input)
-    {
+    // TODO(ping) The name and purpose of this method are unclear.
+    public static String removeUnsafeChars(String input) {
         return input.replaceAll("[\\W]", "_");
     }
 

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -350,6 +350,14 @@ public class Utils {
         return date == null ? null : date.toString();
     }
 
+    /** Safely index into an array, clamping the index if it's out of bounds. */
+    public static <T> T safeIndex(T[] array, int index) {
+        if (array.length == 0) return null;
+        if (index < 0) index = 0;
+        if (index > array.length - 1) index = array.length - 1;
+        return array[index];
+    }
+
     /** Returns the greater of two DateTimes, treating null as the least value. */
     public static @Nullable DateTime max(DateTime a, DateTime b) {
         return a == null ? b : b == null ? a : a.isAfter(b) ? a : b;

--- a/app/src/main/res/menu/chart.xml
+++ b/app/src/main/res/menu/chart.xml
@@ -19,6 +19,10 @@
       android:title="@string/action_go_to"
       android:showAsAction="ifRoom|collapseActionView" />
 
+  <item android:id="@+id/action_zoom"
+        android:title="@string/action_zoom"
+        android:showAsAction="ifRoom|collapseActionView" />
+
   <item android:id="@+id/action_update_chart"
       android:showAsAction="ifRoom"
       android:title="@string/action_update_chart"/>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,6 +43,7 @@
   <string name="family_name">Nom de famille</string>
   <string name="action_search">Rechercher</string>
   <string name="action_go_to">Recherche ID</string>
+  <string name="action_zoom">Zoom</string>
   <string name="title_location_list">Emplacements</string>
   <string name="today">Aujourd\'hui</string>
   <string name="today_date">Aujourd\'hui, %s</string>
@@ -109,6 +110,11 @@
   <string name="unknown">Inconnu</string>
   <string name="title_updating_patient">Mise à jour du patient</string>
   <string name="please_wait">Attendez SVP</string>
+
+  <string name="zoom_day">1 colonne par jour</string>
+  <string name="zoom_half">2 colonnes par jour</string>
+  <string name="zoom_third">3 colonnes par jour</string>
+  <string name="zoom_quarter">4 colonnes par jour</string>
 
   <string name="go_to_patient_title">Accédez au dossier du patient</string>
   <string name="go_to_patient_id_label">Patient ID</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
   <string name="action_search">Search</string>
   <string name="action_edit">Edit</string>
   <string name="action_go_to">Search by ID</string>
+  <string name="action_zoom">Zoom</string>
   <string name="title_location_list">Locations</string>
   <string name="today">Today</string>
   <string name="today_date">Today, %s</string>
@@ -116,6 +117,12 @@
   <string name="unknown">Unknown</string>
   <string name="title_updating_patient">Updating patient</string>
   <string name="please_wait">Please wait&#8230;</string>
+
+  <string name="title_zoom">Set zoom level</string>
+  <string name="zoom_day">1 column per day</string>
+  <string name="zoom_half">2 columns per day</string>
+  <string name="zoom_third">3 columns per day</string>
+  <string name="zoom_quarter">4 columns per day</string>
 
   <string name="go_to_patient_title">Go to patient chart</string>
   <string name="go_to_patient_id_label">Patient ID</string>


### PR DESCRIPTION
Issues: none
Scope: chart activity, chart renderer, chart HTML and CSS

#### User-visible changes

A new "Zoom" button pops up a dialog that allows you to select 1, 2, 3, or 4 columns per day.  When more than 1 column is shown per day, the time span of each column is shown in a second row of column headers.

To improve visual understanding, gaps that represent omitted (empty) columns are drawn with grey diagonal stripes.