### PR TITLE
Don't add too many empty columns when there are multiple columns per day.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -327,9 +327,10 @@ public class ChartRenderer {
             for (Long startMillis : mColumnsByStartMillis.keySet()) {
                 starts.add(new DateTime(startMillis));
             }
+            int maxEmptyColumns = 3 / getSegmentStartingTimes().length;
             DateTime prev = starts.get(0);
             for (DateTime next : starts) {
-                if (!next.isAfter(prev.plusDays(3))) {
+                if (!next.isAfter(prev.plusDays(maxEmptyColumns))) {
                     for (DateTime dt = prev.plusDays(1); dt.isBefore(next); dt = dt.plusDays(1)) {
                         getColumnContainingTime(dt); // creates a column if it doesn't exist yet
                     }


### PR DESCRIPTION
Issues: none
Scope: chart renderer

#### User-visible changes

The chart usually replaces gaps with empty columns when there are fewer than 3 omitted days of empty data.  It should now only do this when there are fewer than 3 omitted columns, not 3 omitted days.