### PR TITLE
Ensure table rows have uniform height regardless of their contents.

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -26,8 +26,11 @@ th, td {
 }
 
 #grid th, #grid td {
-  padding: 0.7em 0 0.8em; /* extra 0.1em on bottom for vertical centering */
+  padding: 0.6em 0 0.5em; /* extra 0.1em on top for vertical centering */
   border-right: 1px solid #ddd;
+  /* Some symbols have a different height than other characters, so we need */
+  /* to set the line-height to ensure that rows have uniform height. */
+  line-height: 1.3;
 }
 
 #grid .day, #grid .day-last, #grid th[scope="rowgroup"].day-last,
@@ -57,7 +60,7 @@ th, td {
   text-align: center;
   white-space: nowrap;
   font-size: 1.4rem;
-  padding: 0.2em 0 0.3em; /* extra 0.1em on bottom for vertical centering */
+  padding: 0.2em 0;
 }
 #grid th.gap, #grid th[scope="rowgroup"].gap {
   background: repeating-linear-gradient(45deg, #fff, #fff 10px, #eee 10px, #eee 20px);


### PR DESCRIPTION
Issues: none
Scope: chart CSS

#### User-visible changes

Certain symbol characters have different heights than other characters—for example, the open circle and filled circle that we have used to indicate the absence or presence of a symptom have a taller height than normal letters.  Previously, table rows that contained these characters were rendered as taller, making some rows taller than others.

This CSS change forces all the rows to have the same height.