### PR TITLE
Remove sqlcipher and its dependencies.

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/sync/SyncTestCase.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/sync/SyncTestCase.java
@@ -16,7 +16,7 @@ import android.net.wifi.WifiManager;
 import android.preference.PreferenceManager;
 import android.support.test.espresso.Espresso;
 
-import net.sqlcipher.database.SQLiteException;
+import android.database.sqlite.SQLiteException;
 
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.events.sync.SyncFailedEvent;

--- a/app/src/main/assets/icudt46l.zip
+++ b/app/src/main/assets/icudt46l.zip
@@ -1,1 +1,0 @@
-../../../../client-libs/app/src/main/assets/icudt46l.zip

--- a/app/src/main/java/org/projectbuendia/client/App.java
+++ b/app/src/main/java/org/projectbuendia/client/App.java
@@ -16,8 +16,6 @@ import android.preference.PreferenceManager;
 
 import com.facebook.stetho.Stetho;
 
-import net.sqlcipher.database.SQLiteDatabase;
-
 import org.odk.collect.android.application.Collect;
 import org.projectbuendia.client.diagnostics.HealthMonitor;
 import org.projectbuendia.client.net.OpenMrsConnectionDetails;
@@ -65,8 +63,6 @@ public class App extends Application {
         // Enable Stetho, which lets you inspect the app's database, UI, and network activity
         // just by opening chrome://inspect in Chrome on a computer connected to the tablet.
         Stetho.initializeWithDefaults(this);
-
-        SQLiteDatabase.loadLibs(this);
 
         mObjectGraph = ObjectGraph.create(Modules.list(this));
         mObjectGraph.inject(this);

--- a/app/src/main/java/org/projectbuendia/client/providers/DelegatingProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/DelegatingProvider.java
@@ -17,7 +17,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
-import net.sqlcipher.database.SQLiteOpenHelper;
+import android.database.sqlite.SQLiteOpenHelper;
 
 /** A {@link ContentProvider} that delegates responsibility to {@link ProviderDelegate}s. */
 abstract class DelegatingProvider<T extends SQLiteOpenHelper> extends ContentProvider {

--- a/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
@@ -16,8 +16,8 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteStatement;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
 
 import org.projectbuendia.client.sync.Database;
 import org.projectbuendia.client.sync.QueryBuilder;

--- a/app/src/main/java/org/projectbuendia/client/providers/InsertableItemProviderDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/InsertableItemProviderDelegate.java
@@ -15,7 +15,7 @@ import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.net.Uri;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import android.database.sqlite.SQLiteDatabase;
 
 import org.projectbuendia.client.sync.Database;
 

--- a/app/src/main/java/org/projectbuendia/client/providers/ProviderDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/ProviderDelegate.java
@@ -17,7 +17,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
-import net.sqlcipher.database.SQLiteOpenHelper;
+import android.database.sqlite.SQLiteOpenHelper;
 
 /** A delegate used to handle a single URI for {@link DelegatingProvider}. */
 public interface ProviderDelegate<T extends SQLiteOpenHelper> {

--- a/app/src/main/java/org/projectbuendia/client/providers/ProviderDelegateRegistry.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/ProviderDelegateRegistry.java
@@ -15,7 +15,7 @@ import android.content.UriMatcher;
 import android.net.Uri;
 import android.util.SparseArray;
 
-import net.sqlcipher.database.SQLiteOpenHelper;
+import android.database.sqlite.SQLiteOpenHelper;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/app/src/main/java/org/projectbuendia/client/providers/SQLiteDatabaseTransactionHelper.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/SQLiteDatabaseTransactionHelper.java
@@ -11,7 +11,7 @@
 
 package org.projectbuendia.client.providers;
 
-import net.sqlcipher.database.SQLiteStatement;
+import android.database.sqlite.SQLiteStatement;
 
 import org.projectbuendia.client.sync.Database;
 

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -12,12 +12,9 @@
 package org.projectbuendia.client.sync;
 
 import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
 
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteException;
-import net.sqlcipher.database.SQLiteOpenHelper;
-
-import org.projectbuendia.client.BuildConfig;
 import org.projectbuendia.client.providers.Contracts.Table;
 import org.projectbuendia.client.utils.Logger;
 
@@ -40,36 +37,6 @@ public class Database extends SQLiteOpenHelper {
     public static final String DATABASE_FILENAME = "buendia.db";
 
     File file;
-
-    /*
-     * This deserves a brief comment on security. Patient data encrypted by a hardcoded key
-     * might seem like security by obscurity. It is.
-     *
-     * Security of patient data for these apps is established by physical security for the tablets
-     * and server, not software security and encryption. The software is designed to be used in
-     * high risk zones while wearing PPE. Thus it deliberately does not have barriers to usability
-     * like passwords or lock screens. Without these it is hard to implement a secure encryption
-     * scheme, and so we haven't. All patient data is viewable in the app anyway.
-     *
-     * So why bother using SQL cipher? The major reason is as groundwork. Eventually we would like
-     * to add some better security. To do this we need to make sure all code we write is compatible
-     * with an encrypted database.
-     *
-     * However, there is some value now. The presumed attacker is someone who doesn't care very much
-     * about patient data, but has broken into an Ebola Management Centre to steal the tablet to
-     * re-sell. We would rather the patient data wasn't trivially readable using existing public
-     * tools, so there is slight defense in depth. Firstly, as the data is stored in per-app storage
-     * the device would need to be rooted, or adb used, to get access to the data. Encryption adds
-     * a second layer of security, in that once they have access to the database file, it isn't
-     * readable without the key. Of course as the key is in plaintext in the open source, anyone
-     * technically savvy enough to use adb can almost certainly find it, but at least it isn't as
-     * simple as using grep or strings.
-     *
-     * TODO/security: add something better. At the very minimum a server call and local storage
-     * with expiry so that it has to sync to the server every so often. Even better some sort of
-     * public key based scheme to only deliver the key on login with registered user on good device.
-     */
-    private static final String ENCRYPTION_PASSWORD = BuildConfig.ENCRYPTION_PASSWORD;
 
     /**
      * A map of SQL table schemas, with one entry per table.  The values should
@@ -197,26 +164,5 @@ public class Database extends SQLiteOpenHelper {
         // Never call zero-argument clear() from onUpgrade, as getWritableDatabase
         // can trigger onUpgrade, leading to endless recursion.
         clear(getWritableDatabase());
-    }
-
-    private void deleteDatabaseIfPasswordIncorrect() {
-        try {
-            getWritableDatabase(ENCRYPTION_PASSWORD);
-        } catch (SQLiteException e) {
-            if (e.getMessage().contains("encrypt")) {
-                // Incorrect or missing encryption password; delete the database and start over.
-                file.delete();
-            }
-        }
-    }
-
-    public SQLiteDatabase getWritableDatabase() {
-        deleteDatabaseIfPasswordIncorrect();
-        return getWritableDatabase(ENCRYPTION_PASSWORD);
-    }
-
-    public SQLiteDatabase getReadableDatabase() {
-        deleteDatabaseIfPasswordIncorrect();
-        return getReadableDatabase(ENCRYPTION_PASSWORD);
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/QueryBuilder.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/QueryBuilder.java
@@ -16,7 +16,7 @@ import android.database.Cursor;
 
 import com.google.common.collect.ObjectArrays;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import android.database.sqlite.SQLiteDatabase;
 
 import org.projectbuendia.client.providers.Contracts;
 

--- a/app/src/main/java/org/projectbuendia/client/user/UserStore.java
+++ b/app/src/main/java/org/projectbuendia/client/user/UserStore.java
@@ -24,7 +24,7 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.RequestFuture;
 import com.google.common.collect.ImmutableSet;
 
-import net.sqlcipher.database.SQLiteException;
+import android.database.sqlite.SQLiteException;
 
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.json.JsonNewUser;


### PR DESCRIPTION
Issues: Closes #299.
Scope: database, user store, all providers

#### User-visible changes

The only obvious user-visible change is that the shared library error dialog on startup no longer appears.

Internally, the SQLite database is no longer encrypted on the tablet.  As a nice side effect, the APK size drops from 13.6 MB to a mere 4.7 MB.