### PR TITLE
Fix the SQLiteDatabaseTransactionHelper so it doesn't crash the app.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
@@ -17,15 +17,12 @@ import org.projectbuendia.client.providers.Contracts.Table;
 /** A {@link DelegatingProvider} for MSF record info such as patients and locations. */
 public class BuendiaProvider extends DelegatingProvider<Database> {
 
-    /**
-     * Provides an {@link DatabaseTransaction} for beginning and ending savepoints
-     * (nested transactions).
-     */
-    public DatabaseTransaction getDbTransactionHelper() {
-        return new DatabaseTransaction(getDatabaseHelper());
+    /** Starts a transaction with the given savepoint name. */
+    public DatabaseTransaction startTransaction(String name) {
+        return new DatabaseTransaction(mDatabaseHelper, name);
     }
 
-    @Override protected Database getDatabaseHelper() {
+    @Override protected Database createDatabaseHelper() {
         return new Database(getContext());
     }
 

--- a/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
@@ -18,11 +18,11 @@ import org.projectbuendia.client.providers.Contracts.Table;
 public class BuendiaProvider extends DelegatingProvider<Database> {
 
     /**
-     * Provides an {@link SQLiteDatabaseTransactionHelper} for beginning and ending savepoints
+     * Provides an {@link DatabaseTransaction} for beginning and ending savepoints
      * (nested transactions).
      */
-    public SQLiteDatabaseTransactionHelper getDbTransactionHelper() {
-        return new SQLiteDatabaseTransactionHelper(getDatabaseHelper());
+    public DatabaseTransaction getDbTransactionHelper() {
+        return new DatabaseTransaction(getDatabaseHelper());
     }
 
     @Override protected Database getDatabaseHelper() {

--- a/app/src/main/java/org/projectbuendia/client/providers/DatabaseTransaction.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/DatabaseTransaction.java
@@ -16,7 +16,7 @@ import android.database.sqlite.SQLiteStatement;
 import org.projectbuendia.client.sync.Database;
 
 /** Provides helper functions for dealing with savepoints in SQLite databases. */
-public final class SQLiteDatabaseTransactionHelper { // @nolint
+public final class DatabaseTransaction { // @nolint
     private final Database mDbHelper;
 
     /** Closes the database resources in use by this object. */
@@ -59,7 +59,7 @@ public final class SQLiteDatabaseTransactionHelper { // @nolint
         statement.close();
     }
 
-    SQLiteDatabaseTransactionHelper(Database dbHelper) {
+    DatabaseTransaction(Database dbHelper) {
         mDbHelper = dbHelper;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/providers/DelegatingProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/DelegatingProvider.java
@@ -28,7 +28,7 @@ abstract class DelegatingProvider<T extends SQLiteOpenHelper> extends ContentPro
 
     @Override public boolean onCreate() {
         mRegistry = getRegistry();
-        mDatabaseHelper = getDatabaseHelper();
+        mDatabaseHelper = createDatabaseHelper();
         mContentResolver = getContext().getContentResolver();
 
         return true;
@@ -36,7 +36,7 @@ abstract class DelegatingProvider<T extends SQLiteOpenHelper> extends ContentPro
 
     protected abstract ProviderDelegateRegistry<T> getRegistry();
 
-    protected abstract T getDatabaseHelper();
+    protected abstract T createDatabaseHelper();
 
     @Override public String getType(Uri uri) {
         return mRegistry.getDelegate(uri).getType();

--- a/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
@@ -66,8 +66,8 @@ class GroupProviderDelegate implements ProviderDelegate<Database> {
             return 0;
         }
         final SQLiteDatabase db = dbHelper.getWritableDatabase();
-        SQLiteDatabaseTransactionHelper dbTransactionHelper =
-            new SQLiteDatabaseTransactionHelper(dbHelper);
+        DatabaseTransaction dbTransactionHelper =
+            new DatabaseTransaction(dbHelper);
 
         ContentValues first = allValues[0];
         String[] columns = first.keySet().toArray(new String[first.size()]);

--- a/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
@@ -66,42 +66,39 @@ class GroupProviderDelegate implements ProviderDelegate<Database> {
             return 0;
         }
         final SQLiteDatabase db = dbHelper.getWritableDatabase();
-        DatabaseTransaction dbTransactionHelper =
-            new DatabaseTransaction(dbHelper);
-
         ContentValues first = allValues[0];
         String[] columns = first.keySet().toArray(new String[first.size()]);
-        SQLiteStatement statement = makeInsertStatement(db, mTable.name, columns);
-        dbTransactionHelper.startNamedTransaction(BULK_INSERT_SAVEPOINT);
-        try {
-            Object[] bindings = new Object[first.size()];
-            for (ContentValues values : allValues) {
-                statement.clearBindings();
-                if (values.size() != first.size()) {
-                    throw new AssertionError();
-                }
-                for (int i = 0; i < bindings.length; i++) {
-                    Object value = values.get(columns[i]);
-                    // This isn't super safe, but is in our context.
-                    int bindingIndex = i + 1;
-                    if (value instanceof String) {
-                        statement.bindString(bindingIndex, (String) value);
-                    } else if ((value instanceof Long) || value instanceof Integer) {
-                        statement.bindLong(bindingIndex, ((Number) value).longValue());
-                    } else if ((value instanceof Double) || value instanceof Float) {
-                        statement.bindDouble(bindingIndex, ((Number) value).doubleValue());
+        try (DatabaseTransaction tx = new DatabaseTransaction(db, BULK_INSERT_SAVEPOINT)) {
+            SQLiteStatement statement = makeInsertStatement(db, mTable.name, columns);
+            try {
+                Object[] bindings = new Object[first.size()];
+                for (ContentValues values : allValues) {
+                    statement.clearBindings();
+                    if (values.size() != first.size()) {
+                        throw new AssertionError();
                     }
-                    bindings[i] = value;
+                    for (int i = 0; i < bindings.length; i++) {
+                        Object value = values.get(columns[i]);
+                        // This isn't super safe, but is in our context.
+                        int bindingIndex = i + 1;
+                        if (value instanceof String) {
+                            statement.bindString(bindingIndex, (String) value);
+                        } else if ((value instanceof Long) || value instanceof Integer) {
+                            statement.bindLong(bindingIndex, ((Number) value).longValue());
+                        } else if ((value instanceof Double) || value instanceof Float) {
+                            statement.bindDouble(bindingIndex, ((Number) value).doubleValue());
+                        }
+                        bindings[i] = value;
+                    }
+                    statement.executeInsert();
                 }
-                statement.executeInsert();
+            } catch (Throwable t) {
+                // If absolutely anything goes wrong, rollback to the savepoint.
+                tx.rollback();
+            } finally {
+                statement.close();
             }
-        } catch (Throwable t) {
-            // If absolutely anything goes wrong, rollback to the savepoint.
-            dbTransactionHelper.rollbackNamedTransaction(BULK_INSERT_SAVEPOINT);
-        } finally {
-            statement.close();
         }
-        dbTransactionHelper.releaseNamedTransaction(BULK_INSERT_SAVEPOINT);
         contentResolver.notifyChange(uri, null, false);
         return allValues.length;
     }

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAdapter.java
@@ -34,7 +34,7 @@ import org.projectbuendia.client.providers.BuendiaProvider;
 import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.providers.Contracts.Misc;
 import org.projectbuendia.client.providers.Contracts.SyncTokens;
-import org.projectbuendia.client.providers.SQLiteDatabaseTransactionHelper;
+import org.projectbuendia.client.providers.DatabaseTransaction;
 import org.projectbuendia.client.sync.controllers.ChartsSyncPhaseRunnable;
 import org.projectbuendia.client.sync.controllers.ConceptsSyncPhaseRunnable;
 import org.projectbuendia.client.sync.controllers.FormsSyncPhaseRunnable;
@@ -164,7 +164,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 
         BuendiaProvider buendiaProvider =
             (BuendiaProvider) (provider.getLocalContentProvider());
-        SQLiteDatabaseTransactionHelper dbTransactionHelper =
+        DatabaseTransaction dbTransactionHelper =
             buendiaProvider.getDbTransactionHelper();
         LOG.i("Setting savepoint %s", SYNC_SAVEPOINT_NAME);
         dbTransactionHelper.startNamedTransaction(SYNC_SAVEPOINT_NAME);
@@ -272,7 +272,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
         provider.insert(Misc.CONTENT_URI, cv);
     }
 
-    private void rollbackSavepoint(SQLiteDatabaseTransactionHelper dbTransactionHelper) {
+    private void rollbackSavepoint(DatabaseTransaction dbTransactionHelper) {
         LOG.i("Rolling back savepoint %s", SYNC_SAVEPOINT_NAME);
         dbTransactionHelper.rollbackNamedTransaction(SYNC_SAVEPOINT_NAME);
     }

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAdapter.java
@@ -161,70 +161,55 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 
         LOG.i("Requested phases are: %s", phases);
         broadcastSyncProgress(0, R.string.sync_in_progress);
-
-        BuendiaProvider buendiaProvider =
-            (BuendiaProvider) (provider.getLocalContentProvider());
-        DatabaseTransaction dbTransactionHelper =
-            buendiaProvider.getDbTransactionHelper();
-        LOG.i("Setting savepoint %s", SYNC_SAVEPOINT_NAME);
-        dbTransactionHelper.startNamedTransaction(SYNC_SAVEPOINT_NAME);
-
         TimingLogger timings = new TimingLogger(LOG.tag, "onPerformSync");
 
-        try {
-            if (fullSync) {
-                Instant syncStartTime = Instant.now();
-                LOG.i("Recording full sync start time: " + syncStartTime);
-                storeFullSyncStartTime(provider, syncStartTime);
-            }
-
-            float progressIncrement = 100.0f/phases.size();
-            int completedPhases = 0;
-            for (SyncPhase phase : SyncPhase.values()) {
-                if (!phases.contains(phase)) {
-                    continue;
+        BuendiaProvider buendiaProvider = (BuendiaProvider) provider.getLocalContentProvider();
+        try (DatabaseTransaction tx = buendiaProvider.startTransaction(SYNC_SAVEPOINT_NAME)) {
+            try {
+                if (fullSync) {
+                    storeFullSyncStartTime(provider, Instant.now());
                 }
-                checkCancellation("before " + phase);
-                LOG.i("--- Begin %s ---", phase);
-                broadcastSyncProgress((int) (completedPhases * progressIncrement), phase.message);
 
-                phase.runnable.sync(mContentResolver, syncResult, provider);
+                float progressIncrement = 100.0f/phases.size();
+                int completedPhases = 0;
+                for (SyncPhase phase : SyncPhase.values()) {
+                    if (phases.contains(phase)) {
+                        LOG.i("--- Begin %s ---", phase);
+                        checkCancellation("before " + phase);
+                        broadcastSyncProgress((int) (completedPhases * progressIncrement), phase.message);
+                        phase.runnable.sync(mContentResolver, syncResult, provider);
+                        timings.addSplit(phase.name() + " phase completed");
+                        completedPhases++;
+                    }
+                }
+                broadcastSyncProgress(100, R.string.completing_sync);
 
-                timings.addSplit(phase.name() + " phase completed");
-                completedPhases++;
+                if (fullSync) {
+                    storeFullSyncEndTime(provider, Instant.now());
+                }
+            } catch (CancellationException e) {
+                LOG.i(e, "Sync canceled");
+                tx.rollback();
+                // Reset canceled state so that it doesn't interfere with next sync.
+                broadcastSyncStatus(SyncManager.CANCELED);
+                return;
+            } catch (OperationApplicationException e) {
+                LOG.e(e, "Error updating database during sync");
+                tx.rollback();
+                syncResult.databaseError = true;
+                broadcastSyncStatus(SyncManager.FAILED);
+                return;
+            } catch (Throwable e) {
+                LOG.e(e, "Error during sync");
+                tx.rollback();
+                syncResult.stats.numIoExceptions++;
+                broadcastSyncStatus(SyncManager.FAILED);
+                return;
             }
-            broadcastSyncProgress(100, R.string.completing_sync);
-
-            if (fullSync) {
-                Instant syncEndTime = Instant.now();
-                LOG.i("Recording full sync end time: " + syncEndTime);
-                storeFullSyncEndTime(provider, syncEndTime);
-            }
-        } catch (CancellationException e) {
-            rollbackSavepoint(dbTransactionHelper);
-            // Reset canceled state so that it doesn't interfere with next sync.
-            LOG.i(e, "Sync canceled");
-            broadcastSyncStatus(SyncManager.CANCELED);
-            return;
-        } catch (OperationApplicationException e) {
-            rollbackSavepoint(dbTransactionHelper);
-            LOG.e(e, "Error updating database during sync");
-            syncResult.databaseError = true;
-            broadcastSyncStatus(SyncManager.FAILED);
-            return;
-        } catch (Throwable e) {
-            rollbackSavepoint(dbTransactionHelper);
-            LOG.e(e, "Error during sync");
-            syncResult.stats.numIoExceptions++;
-            broadcastSyncStatus(SyncManager.FAILED);
-            return;
-        } finally {
-            LOG.i("Releasing savepoint %s", SYNC_SAVEPOINT_NAME);
-            dbTransactionHelper.releaseNamedTransaction(SYNC_SAVEPOINT_NAME);
-            dbTransactionHelper.close();
         }
         timings.dumpToLog();
         broadcastSyncStatus(SyncManager.COMPLETED);
+        LOG.i("onPerformSync completed");
     }
 
     /**
@@ -258,23 +243,18 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
         );
     }
 
-    private void storeFullSyncStartTime(ContentProviderClient provider, Instant syncStartTime)
-        throws RemoteException {
+    private void storeFullSyncStartTime(ContentProviderClient provider, Instant time) throws RemoteException {
+        LOG.i("Recording full sync start time: " + time);
         ContentValues cv = new ContentValues();
-        cv.put(Misc.FULL_SYNC_START_MILLIS, syncStartTime.getMillis());
+        cv.put(Misc.FULL_SYNC_START_MILLIS, time.getMillis());
         provider.insert(Misc.CONTENT_URI, cv);
     }
 
-    private void storeFullSyncEndTime(ContentProviderClient provider, Instant syncEndTime)
-        throws RemoteException {
+    private void storeFullSyncEndTime(ContentProviderClient provider, Instant time) throws RemoteException {
+        LOG.i("Recording full sync end time: " + time);
         ContentValues cv = new ContentValues();
-        cv.put(Misc.FULL_SYNC_END_MILLIS, syncEndTime.getMillis());
+        cv.put(Misc.FULL_SYNC_END_MILLIS, time.getMillis());
         provider.insert(Misc.CONTENT_URI, cv);
-    }
-
-    private void rollbackSavepoint(DatabaseTransaction dbTransactionHelper) {
-        LOG.i("Rolling back savepoint %s", SYNC_SAVEPOINT_NAME);
-        dbTransactionHelper.rollbackNamedTransaction(SYNC_SAVEPOINT_NAME);
     }
 
     /** Returns the server timestamp corresponding to the last observation sync. */

--- a/app/src/main/java/org/projectbuendia/client/user/UserStore.java
+++ b/app/src/main/java/org/projectbuendia/client/user/UserStore.java
@@ -32,7 +32,7 @@ import org.projectbuendia.client.json.JsonUser;
 import org.projectbuendia.client.providers.BuendiaProvider;
 import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.providers.Contracts.Users;
-import org.projectbuendia.client.providers.SQLiteDatabaseTransactionHelper;
+import org.projectbuendia.client.providers.DatabaseTransaction;
 import org.projectbuendia.client.utils.Logger;
 
 import java.util.ArrayList;
@@ -145,7 +145,7 @@ public class UserStore {
             .acquireContentProviderClient(Users.CONTENT_URI);
         BuendiaProvider buendiaProvider =
             (BuendiaProvider) (client.getLocalContentProvider());
-        SQLiteDatabaseTransactionHelper dbTransactionHelper =
+        DatabaseTransaction dbTransactionHelper =
             buendiaProvider.getDbTransactionHelper();
         try {
             LOG.d("Setting savepoint %s", USER_SYNC_SAVEPOINT_NAME);


### PR DESCRIPTION
Issues: Closes #308.  Closes #310.  Closes #319.
Scope: sync adapter, user store, providers and delegates

#### Overview

The previous SQLiteDatabaseTransactionHelper had three problems:
(a) It uses a newly created Database object every time, perhaps because the `getDatabaseHelper` method was misnamed.  That method is now named `createDatabaseHelper` to make it clear that it constructs a new thing; it doesn't just hand you an existing thing.  And it did this despite the fact that the DelegatingProvider already has its own `mDatabaseHelper` field that is otherwise initialized.
(b) It closes whatever Database object you give it.  It should only close what it opens.
(c) it relies on the caller to make calls in a specific sequence.  It's been replaced by an AutoCloseable object so you can use a try-with-resources block to ensure that it is cleaned up properly.

The new class is named simply `DatabaseTransaction`, because instantiating it starts a transaction, and closing it completes the transaction.

#### Verification performed

I tried to repeat the steps in #319 and confirmed that they no longer cause a crash.  @saratheneale did more extensive testing and has confirmed that #310 and #319 no longer occur when this change is applied.