### PR TITLE
Add CircleCI configuration.

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,0 +1,6 @@
+# https://support.circleci.com/hc/en-us/articles/360006735753-Validating-CircleCI-configuration-files-YAML-linting-issues-etc-
+
+all: test
+
+test:
+	cd .. && circleci config validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,69 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/client
+    docker:
+      - image: circleci/android:api-23
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - checkout
+
+      - run:
+          name: Init client-lib submodule
+          command: git submodule update --init client-libs
+
+      - restore_cache:
+          keys:
+            - buendia-client-v1-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+            - buendia-client-v1-{{ checksum "build.gradle" }}-
+            - buendia-client-v1-{{ checksum "build.gradle" }}-
+      - run:
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: buendia-client-v1-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      
+      - run:
+          name: Build APK
+          command: |
+            export ANDROID_PATH=/opt/android/sdk
+            ./gradlew assembleDebug
+
+      - run:
+          name: Run Tests
+          # lint is slightly busted for us here
+          # command: ./gradlew lint test
+          command: ./gradlew test
+
+      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/ 
+          path: app/build/outputs
+          destination: outputs
+
+      #- store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+      #path: app/build/test-results
+
+workflows:
+  version: 2
+  dev-build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              # Don't do a normal build for master; instead let the
+              # release-build job do the builds off master iff that branch is
+              # tagged as part of the documented release process.
+              ignore:
+                - master
+  release-build:
+    # Ensure that tagged releases get their own CircleCI build:
+    # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
           name: Init client-lib submodule
           command: git submodule update --init client-libs
 
+      - run:
+          name: Get package version
+          command: echo "export PACKAGE_VERSION=$(.circleci/get_package_version)" >> $BASH_ENV
+
       - restore_cache:
           keys:
             - buendia-client-v1-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
@@ -21,6 +25,7 @@ jobs:
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies
+
       - save_cache:
           paths:
             - ~/.gradle
@@ -31,6 +36,8 @@ jobs:
           command: |
             export ANDROID_PATH=/opt/android/sdk
             ./gradlew assembleDebug
+            mkdir -p /tmp/artifacts
+            cp app/build/outputs/apk/debug/app-debug.apk /tmp/artifacts/buendia-client-${PACKAGE_VERSION}.apk
 
       - run:
           name: Run Tests
@@ -39,8 +46,8 @@ jobs:
           command: ./gradlew test
 
       - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/ 
-          path: app/build/outputs
-          destination: outputs
+          path: /tmp/artifacts
+          destination: artifacts
 
       #- store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
       #path: app/build/test-results

--- a/.circleci/get_package_version
+++ b/.circleci/get_package_version
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+# get_package_version.sh tries to come up with a sensible package version
+# scheme for the current build situation. The logic we're following is that
+# only release packages built in CI get a formal version number; all other
+# builds should be marked as such.
+#
+# Also, we should treat CI builds as more recent than release builds for the
+# same version tag; however, we should NOT treat manual builds as more recent
+# than either. The logic there is that we do want to allow deployment of
+# replicable pre-release builds, but we don't want accidental deployment of 
+# developer builds. The most recent version is retained for the sanity of the
+# developer.
+
+# If we're building in CircleCI and this is a tagged release, strip the leading
+# 'v' and use that as a version number.
+if echo "$CIRCLE_TAG" | grep -Eq '^v([0-9]+\.?)+$'; then
+    echo "${CIRCLE_TAG#v}"
+    exit
+fi
+
+# Find the most recent release tag on master.
+TAG=$(git describe --match='v*' --abbrev=0 origin/master)
+
+# If we're building in CircleCI, the version is "x.y.z+b<n>" where <n> is the
+# latest build number. 
+if [ -n "$CIRCLE_BUILD_NUM" ]; then
+    echo "${TAG#v}+b${CIRCLE_BUILD_NUM}"
+    exit
+fi
+
+# Otherwise, we're building locally, so the version should be "x.y.z~g<commit>"
+# where <commit> is the latest unambiguous commit identifier. This version is
+# actually treated by Debian as _less_ recent than "x.y.z".
+COMMIT=$(git describe --abbrev --dirty=+dirty)
+echo "${TAG#v}~${COMMIT#*g}"

--- a/README.md
+++ b/README.md
@@ -226,3 +226,29 @@ The graphical Android SDK Manager at `$ANDROID_HOME/tools/android` will let you 
 `ANDROID_HOME` is usually `/opt/android-sdk-linux` on a Linux machine and `~/Library/Android/sdk` on a Mac.
 
 To build the client from the command line, go to the root of your `client` repo and run `./gradlew clean assembleDebug`.  The resulting apk will be at `app/build/outputs/apk/app-debug.apk`.
+
+### Setting up command-line tools on Debian stretch
+
+```
+sudo apt-get install openjdk-8-jdk unzip git
+
+mkdir -p ~/.android && touch ~/.android/repositories.cfg
+
+mkdir android && cd android
+wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
+unzip sdk-tools-linux-4333796.zip 
+
+export PATH=$HOME/android/tools:$HOME/android/tools/bin:$PATH
+export ANDROID_HOME=$HOME/android
+
+yes | sdkmanager --licenses
+sdkmanager "platforms;android-21" "build-tools;19.1.0" "extras;android;m2repository" "platform-tools"
+
+cd ../client/
+git submodule update --init client-libs
+
+./gradlew assembleDebug 
+ls app/build/outputs/apk/debug/
+
+# ./gradlew -PversionNumber=0.10.0 clean assembleDebug 
+```


### PR DESCRIPTION
Add a CircleCI configuration `build` job that compiles the debug APK.

This job is used by two workflows:

* `dev-build`: called whenever a non-master branch is pushed
* `release-build`: called whenever a `v*.*.*` tag is pushed

The APK is stored as a build artifact with a name that is based on the [server version number conventions](https://github.com/projectbuendia/buendia/wiki/Software-Package-Management#project-version-numbering-conventions). This is meant to be a spike solution, not a permanent state of affairs.