### PR TITLE
Use commons.text.ExtendedMessageFormat instead of the buggy commons.lang3.text.ExtendedMessageFormat.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'com.facebook.stetho:stetho-okhttp:1.5.0' // Network debugging
     implementation 'com.mitchellbosecke:pebble:1.5.1' // HTML templating
     implementation 'org.slf4j:slf4j-simple:1.7.12' // HTML templating dependency
-    implementation 'org.apache.commons:commons-lang3:3.4'
+    implementation 'org.apache.commons:commons-text:1.6' // ExtendedMessageFormat
 
     // Testing
     androidTestImplementation 'com.android.support.test:runner:0.3'

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
@@ -2,8 +2,8 @@ package org.projectbuendia.client.ui.chart;
 
 import com.google.common.base.Objects;
 
-import org.apache.commons.lang3.text.ExtendedMessageFormat;
-import org.apache.commons.lang3.text.FormatFactory;
+import org.apache.commons.text.ExtendedMessageFormat;
+import org.apache.commons.text.FormatFactory;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.projectbuendia.client.models.ObsPoint;
@@ -110,7 +110,7 @@ public class ObsFormat extends Format {
             };
         }
     }
-    
+
     public ObsFormat(String pattern) {
         this(pattern, null);
     }


### PR DESCRIPTION
Issues: Closes #322 
Scope: ObsFormat

The problem in #322 occurs because of a bug in ExtendedMessageFormat.  The one we use, `org.apache.commons.lang3.text.ExtendedMessageFormat`, was deprecated a while ago, and the new hotness is `org.apache.commons.text.ExtendedMessageFormat`, in which this particular bug has been fixed.  So, switching to `commons.text` does the trick!