### PR TITLE
Krtonga/remove update chart from dropdown

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 import android.graphics.Point;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -178,7 +177,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
                 ebolaLabTestFormEnabled = true;
             }
         }
-        Log.d("**PATIENT CHART*** ", "Menu size: "+menu.size());
         Utils.showIf(mPcr, ebolaLabTestFormEnabled);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.graphics.Point;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -161,18 +162,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             }
         );
 
-        MenuItem updateChart = menu.findItem(R.id.action_update_chart);
-        updateChart.setIcon(createIcon(Iconify.IconValue.fa_pencil_square_o, 0xccffffff));
-        updateChart.setOnMenuItemClickListener(
-            new MenuItem.OnMenuItemClickListener() {
-
-                @Override public boolean onMenuItemClick(MenuItem item) {
-                    mController.onAddObservationPressed();
-                    return true;
-                }
-            });
-
-        boolean clinicalObservationFormEnabled = false;
         boolean ebolaLabTestFormEnabled = false;
         for (final Form form : mChartDataHelper.getForms()) {
             MenuItem item = menu.add(form.name);
@@ -184,14 +173,11 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
                     }
                 }
             );
-            if (form.uuid.equals(PatientChartController.OBSERVATION_FORM_UUID)) {
-                clinicalObservationFormEnabled = true;
-            }
             if (form.uuid.equals(PatientChartController.EBOLA_LAB_TEST_FORM_UUID)) {
                 ebolaLabTestFormEnabled = true;
             }
         }
-        updateChart.setVisible(clinicalObservationFormEnabled);
+        Log.d("**PATIENT CHART*** ", "Menu size: "+menu.size());
         Utils.showIf(mPcr, ebolaLabTestFormEnabled);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -165,6 +165,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
         boolean ebolaLabTestFormEnabled = false;
         for (final Form form : mChartDataHelper.getForms()) {
             MenuItem item = menu.add(form.name);
+            item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM | MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
             item.setOnMenuItemClickListener(
                 new MenuItem.OnMenuItemClickListener() {
                     @Override public boolean onMenuItemClick(MenuItem menuItem) {

--- a/app/src/main/res/menu/base.xml
+++ b/app/src/main/res/menu/base.xml
@@ -15,7 +15,7 @@
 
     <item
         android:id="@+id/user"
-        android:showAsAction="ifRoom"
+        android:showAsAction="always"
         android:title=""
         android:actionLayout="@layout/action_bar_user_menu_button" />
 

--- a/app/src/main/res/menu/chart.xml
+++ b/app/src/main/res/menu/chart.xml
@@ -22,8 +22,4 @@
   <item android:id="@+id/action_zoom"
         android:title="@string/action_zoom"
         android:showAsAction="ifRoom|collapseActionView" />
-
-  <item android:id="@+id/action_update_chart"
-      android:showAsAction="ifRoom"
-      android:title="@string/action_update_chart"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,6 @@
   <string name="action_new_round">New round</string>
   <string name="action_assign_location">Assign location</string>
   <string name="action_edit_patient">Edit patient</string>
-  <string name="action_update_chart">Update chart</string>
   <string name="action_view_round_archive">Round archive</string>
   <string name="snackbar_update_available">Application update available</string>
   <string name="snackbar_update_downloaded">Application update downloaded</string>


### PR DESCRIPTION
I am removing the update chart option from the dropdown menu.

Note: the blank line in the dropdown menu was appearing because the `BaseLoggedInActivity` adds a user profile icon to the menubar. The user item has no title, and the click listener was not working because the icon was not designed to be in a dropdown. As a simple fix, I set `showAsAction` to `always`. Please let me know if a better solution would be to not show this menu item on this page. 