### PR TITLE
Display patient sex and age in subtitle on PatientChartActivity

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -560,7 +560,12 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             labels.add(patient.birthdate == null ? "age unknown"
                 : Utils.birthdateToAge(patient.birthdate, getResources())); // TODO/i18n
             String sexAge = Joiner.on(", ").join(labels);
-            PatientChartActivity.this.setTitle(id + ". " + fullName + SEPARATOR_DOT + sexAge);
+
+            ActionBar actionBar = getActionBar();
+            if (actionBar != null) {
+                actionBar.setTitle(id + ". " + fullName);
+                actionBar.setSubtitle(sexAge);
+            }
         }
 
         @Override public void showWaitDialog(int titleId) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -93,7 +93,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
     private static final double PCR_NEGATIVE_THRESHOLD = 39.95;
 
     private static final String KEY_CONTROLLER_STATE = "controllerState";
-    private static final String SEPARATOR_DOT = "\u00a0\u00a0\u00b7\u00a0\u00a0";
 
     private PatientChartController mController;
     private boolean mIsFetchingXform = false;

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -36,6 +36,7 @@
   <style name="ActionBar" parent="android:Widget.Holo.Light.ActionBar.Solid.Inverse">
     <item name="android:height">56sp</item>
     <item name="android:titleTextStyle">@style/text.large.white</item>
+    <item name="android:subtitleTextStyle">@style/text.medium.white</item>
     <item name="android:background">@drawable/action_bar_bg</item>
     <item name="android:progressBarPadding">32sp</item>
     <item name="android:itemPadding">8sp</item>
@@ -234,7 +235,13 @@
   <style name="text.large">
     <item name="android:textSize">22sp</item> <!-- matches dialog title size -->
   </style>
+  <style name="text.medium">
+    <item name="android:textSize">18sp</item> <!-- matches dialog title size -->
+  </style>
   <style name="text.large.white">
+    <item name="android:textColor">@android:color/white</item>
+  </style>
+  <style name="text.medium.white">
     <item name="android:textColor">@android:color/white</item>
   </style>
 


### PR DESCRIPTION
Solution to https://github.com/projectbuendia/client/issues/325

This does leave display of patient and sex and age in smaller font than previously, even if id and name is short. I am uncertain if that is acceptable, given visibility requirements.

A potential alternative would be using a custom view for action bar.

Prior view:

![Screen Shot 2019-06-24 at 4 11 25 PM](https://user-images.githubusercontent.com/709584/60059761-aa725a00-96a2-11e9-82de-92b00206934d.png)


New view, long name:

![Screen Shot 2019-06-24 at 4 10 13 PM](https://user-images.githubusercontent.com/709584/60059772-b78f4900-96a2-11e9-958c-220a16a9dff9.png)


New view, short name:

![Screen Shot 2019-06-24 at 4 09 43 PM](https://user-images.githubusercontent.com/709584/60059786-c2e27480-96a2-11e9-832a-464f24195d56.png)
