### PR TITLE
Fix issue 330

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -493,7 +493,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
                 if (pcrObsTime != null) {
                     LocalDate today = LocalDate.now();
                     LocalDate obsDay = pcrObsTime.toLocalDate();
-                    String dateText = new RelativeDateTimeFormatter().format(today, obsDay);
+                    String dateText = new RelativeDateTimeFormatter().format(obsDay, today);
                     mPcr.setName(getResources().getString(
                         R.string.latest_pcr_label_with_date, dateText));
                 }


### PR DESCRIPTION
Patient Record Ebola Test -> says (in the future) when test was previously recorded

https://github.com/projectbuendia/client/issues/330

To fix, use today as anchor, and display test time relative to today.