### PR TITLE
Fix for issue 351

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsErrorListener.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsErrorListener.java
@@ -12,8 +12,7 @@
 package org.projectbuendia.client.net;
 
 import android.graphics.Color;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.NinePatchDrawable;
+import android.view.View;
 import android.widget.Toast;
 
 import com.android.volley.AuthFailureError;
@@ -116,8 +115,8 @@ public class OpenMrsErrorListener implements ErrorListener {
             message,
             Toast.LENGTH_LONG
         );
-        NinePatchDrawable drawable = (NinePatchDrawable) toast.getView().getBackground();
-        drawable.setColorFilter(Color.RED, PorterDuff.Mode.SRC_IN);
+        View view = toast.getView();
+        view.setBackgroundColor(Color.RED);
         toast.show();
     }
 


### PR DESCRIPTION
https://github.com/projectbuendia/client/issues/351

Directly set background color of toast instead of getting background view, and handling `java.lang.ClassCastException: android.graphics.drawable.GradientDrawable cannot be cast to android.graphics.drawable.NinePatchDrawable`

I am uncertain what the intended design for the toast was supposed to be, as I cannot see it on my emulator.

Issues: Closes https://github.com/projectbuendia/client/issues/351
Scope: Affects OpenMrsErrorListener.displayErrorMessage()
Requested reviewers: @zestyping

#### User-visible changes

<!-- Toast with red background appears, and app does not crash, when attempting to modify patient id to id of another patient. -->

#### Verification performed

Follow steps in https://github.com/projectbuendia/client/issues/351. Open patient, click edit patient icon, set patient id to match id of another patient. See that a red toast appears.

#### Guidance for reviewers

If anyone h has knowledge of what the toast looked like previously with the Porter Duff mode, let me know. Wondering if there should be some opacity level on the toast color.

#### Guidance for testers <!-- optional -->

If anyone h has knowledge of what the toast looked like previously, let me know. Wondering if there should be some opacity level on the toast color.

App does exhibit other problematic behaviors after going through testing steps, though these behaviors existed before change. Uncertain of what is occurring with syncing with server when attempting to set patient id to match another patient id, or if the server is being intermittent while I'm testing this.