### PR TITLE
Improve back navigation by upgrading to Toolbar. Closes #336

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,7 +95,8 @@
             android:name=".ui.lists.FilteredPatientListActivity"
             android:label="@string/title_patient_list"
             android:parentActivityName=".ui.lists.LocationListActivity"
-            android:screenOrientation="userPortrait" >
+            android:screenOrientation="userPortrait"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.nfc.action.TAG_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -106,7 +107,8 @@
             android:label="@string/title_patient_chart"
             android:parentActivityName=".ui.lists.FilteredPatientListActivity"
             android:screenOrientation="userPortrait"
-            android:uiOptions="splitActionBarWhenNarrow">
+            android:uiOptions="splitActionBarWhenNarrow"
+            android:launchMode="singleInstance">
             <meta-data
                 android:name="android.support.UI_OPTIONS"
                 android:value="splitActionBarWhenNarrow" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,6 +118,7 @@
         </activity>
         <activity
             android:name="org.projectbuendia.client.ui.SettingsActivity"
+            android:theme="@style/Theme.AppCompat.Light"
             android:label="@string/title_activity_settings"
             android:parentActivityName=".ui.lists.FilteredPatientListActivity"
             android:screenOrientation="userPortrait" >

--- a/app/src/main/java/org/projectbuendia/client/ui/AppCompatPreferenceActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/AppCompatPreferenceActivity.java
@@ -1,0 +1,122 @@
+// Copyright 2015 The Project Buendia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distrib-
+// uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+// specific language governing permissions and limitations under the License.
+
+package org.projectbuendia.client.ui;
+
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatDelegate;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A {@link PreferenceActivity} which implements and proxies the necessary calls
+ * to be used with AppCompat.
+ *
+ * Taken from: http://www.coderzheaven.com/2017/10/10/how-to-create-preferences-settings-in-your-app-using-android-built-in-settings-preference-apis/
+ */
+public abstract class AppCompatPreferenceActivity extends PreferenceActivity {
+
+    private AppCompatDelegate mDelegate;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        getDelegate().installViewFactory();
+        getDelegate().onCreate(savedInstanceState);
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        getDelegate().onPostCreate(savedInstanceState);
+    }
+
+    public ActionBar getSupportActionBar() {
+        return getDelegate().getSupportActionBar();
+    }
+
+    public void setSupportActionBar(@Nullable Toolbar toolbar) {
+        getDelegate().setSupportActionBar(toolbar);
+    }
+
+    @Override
+    public MenuInflater getMenuInflater() {
+        return getDelegate().getMenuInflater();
+    }
+
+    @Override
+    public void setContentView(@LayoutRes int layoutResID) {
+        getDelegate().setContentView(layoutResID);
+    }
+
+    @Override
+    public void setContentView(View view) {
+        getDelegate().setContentView(view);
+    }
+
+    @Override
+    public void setContentView(View view, ViewGroup.LayoutParams params) {
+        getDelegate().setContentView(view, params);
+    }
+
+    @Override
+    public void addContentView(View view, ViewGroup.LayoutParams params) {
+        getDelegate().addContentView(view, params);
+    }
+
+    @Override
+    protected void onPostResume() {
+        super.onPostResume();
+        getDelegate().onPostResume();
+    }
+
+    @Override
+    protected void onTitleChanged(CharSequence title, int color) {
+        super.onTitleChanged(title, color);
+        getDelegate().setTitle(title);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        getDelegate().onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        getDelegate().onStop();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        getDelegate().onDestroy();
+    }
+
+    public void invalidateOptionsMenu() {
+        getDelegate().invalidateOptionsMenu();
+    }
+
+    private AppCompatDelegate getDelegate() {
+        if (mDelegate == null) {
+            mDelegate = AppCompatDelegate.create(this, null);
+        }
+        return mDelegate;
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
@@ -22,6 +22,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.support.annotation.StringRes;
 import android.support.v4.app.FragmentActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
@@ -52,7 +53,7 @@ import de.greenrobot.event.EventBus;
  * view" that can be populated by implementing classes and a "status view" that can be used for
  * troubleshooting and status messages.
  */
-public abstract class BaseActivity extends FragmentActivity {
+public abstract class BaseActivity extends AppCompatActivity {
     private static final Logger LOG = Logger.create();
     private static final double PHI = (Math.sqrt(5) + 1)/2; // golden ratio
     private static final double STEP_FACTOR = Math.sqrt(PHI); // each step up/down scales this much

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -15,6 +15,7 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
+import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -81,10 +82,12 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
             return;
         }
 
-        // Show the Up button in the action bar.
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-
         onCreateImpl(savedInstanceState);
+
+        // Show the Up button in the action bar.
+        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
         mIsCreated = true;
     }
 
@@ -117,7 +120,7 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
 
         mPopupWindow = new MenuPopupWindow();
 
-        final View userView = mMenu.getItem(mMenu.size() - 1).getActionView();
+        final View userView = mMenu.findItem(R.id.action_user).getActionView();
         userView.setOnClickListener(new View.OnClickListener() {
 
             @Override public void onClick(View view) {
@@ -154,7 +157,7 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
         mLastActiveUser = user;
 
         TextView initials = (TextView) mMenu
-            .getItem(mMenu.size() - 1)
+            .findItem(R.id.action_user)
             .getActionView()
             .findViewById(R.id.user_initials);
 

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -81,6 +81,9 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
             return;
         }
 
+        // Show the Up button in the action bar.
+        getActionBar().setDisplayHomeAsUpEnabled(true);
+
         onCreateImpl(savedInstanceState);
         mIsCreated = true;
     }
@@ -128,6 +131,17 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
     }
 
     public void onExtendOptionsMenu(Menu menu) {
+    }
+
+    @Override public boolean onOptionsItemSelected(MenuItem item) {
+        int id = item.getItemId();
+        if (id == android.R.id.home) {
+            // Go back rather than reloading the activity, so that the patient list retains its
+            // filter state.
+            onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private void updateActiveUser() {

--- a/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
@@ -49,7 +49,7 @@ import javax.inject.Inject;
  * href="http://developer.android.com/guide/topics/ui/settings.html">Settings
  * API Guide</a> for more information on developing a Settings UI.
  */
-public class SettingsActivity extends PreferenceActivity {
+public class SettingsActivity extends AppCompatPreferenceActivity {
     /**
      * Controls whether to always show the simplified UI, where settings are
      * arranged in a single list without a left navigation panel.
@@ -220,7 +220,7 @@ public class SettingsActivity extends PreferenceActivity {
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         App.getInstance().inject(this);
-        setupActionBar();
+//        setupActionBar();
     }
 
     /** Set up the {@link android.app.ActionBar}, if the API is available. */
@@ -228,7 +228,7 @@ public class SettingsActivity extends PreferenceActivity {
     private void setupActionBar() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             // Show the Up button in the action bar.
-            getActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -175,17 +175,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
         Utils.showIf(mPcr, ebolaLabTestFormEnabled);
     }
 
-    @Override public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
-        if (id == android.R.id.home) {
-            // Go back rather than reloading the activity, so that the patient list retains its
-            // filter state.
-            onBackPressed();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
     @Override protected void onCreateImpl(Bundle savedInstanceState) {
         super.onCreateImpl(savedInstanceState);
         setContentView(R.layout.fragment_patient_chart);
@@ -255,9 +244,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             controllerState,
             mSyncManager,
             minimalHandler);
-
-        // Show the Up button in the action bar.
-        getActionBar().setDisplayHomeAsUpEnabled(true);
 
         mAdmissionDaysView.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View view) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -11,7 +11,6 @@
 
 package org.projectbuendia.client.ui.chart;
 
-import android.app.ActionBar;
 import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.ProgressDialog;
@@ -21,6 +20,8 @@ import android.content.Intent;
 import android.graphics.Point;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.ActionBar;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -60,7 +61,6 @@ import org.projectbuendia.client.ui.OdkActivityLauncher;
 import org.projectbuendia.client.ui.chart.PatientChartController.MinimalHandler;
 import org.projectbuendia.client.ui.chart.PatientChartController.OdkResultSender;
 import org.projectbuendia.client.ui.dialogs.EditPatientDialogFragment;
-import org.projectbuendia.client.ui.dialogs.GoToPatientDialogFragment;
 import org.projectbuendia.client.ui.dialogs.OrderDialogFragment;
 import org.projectbuendia.client.ui.dialogs.OrderExecutionDialogFragment;
 import org.projectbuendia.client.ui.dialogs.ViewObservationsDialogFragment;
@@ -177,7 +177,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
 
     @Override protected void onCreateImpl(Bundle savedInstanceState) {
         super.onCreateImpl(savedInstanceState);
-        setContentView(R.layout.fragment_patient_chart);
+        setContentView(R.layout.activity_patient_chart);
 
         @Nullable Bundle controllerState = null;
         if (savedInstanceState != null) {
@@ -305,20 +305,20 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
     private void initChartMenu() {
         List<Chart> charts = mController.getCharts();
         if (charts.size() > 1) {
-            final ActionBar actionBar = getActionBar();
+            final ActionBar actionBar = getSupportActionBar();
             actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
             ActionBar.TabListener tabListener = new ActionBar.TabListener() {
                 @Override
-                public void onTabSelected(ActionBar.Tab tab, android.app.FragmentTransaction ft) {
+                public void onTabSelected(ActionBar.Tab tab, FragmentTransaction ft) {
                     mController.setChartIndex(tab.getPosition());
                 }
 
                 @Override
-                public void onTabUnselected(ActionBar.Tab tab, android.app.FragmentTransaction ft) {
+                public void onTabUnselected(ActionBar.Tab tab, FragmentTransaction ft) {
                 }
 
                 @Override
-                public void onTabReselected(ActionBar.Tab tab, android.app.FragmentTransaction ft) {
+                public void onTabReselected(ActionBar.Tab tab, FragmentTransaction ft) {
                 }
             };
 
@@ -536,7 +536,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
                 : Utils.birthdateToAge(patient.birthdate, getResources())); // TODO/i18n
             String sexAge = Joiner.on(", ").join(labels);
 
-            ActionBar actionBar = getActionBar();
+            ActionBar actionBar = getSupportActionBar();
             if (actionBar != null) {
                 actionBar.setTitle(id + ". " + fullName);
                 actionBar.setSubtitle(sexAge);

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
@@ -11,10 +11,10 @@
 
 package org.projectbuendia.client.ui.lists;
 
-import android.app.ActionBar;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.AppSettings;
@@ -57,7 +57,7 @@ public class FilteredPatientListActivity extends BaseSearchablePatientListActivi
 
     @Override protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putInt(SELECTED_FILTER_KEY, getActionBar().getSelectedNavigationIndex());
+        outState.putInt(SELECTED_FILTER_KEY, getSupportActionBar().getSelectedNavigationIndex());
     }
 
     private final class FilterUi implements PatientFilterController.Ui {
@@ -80,7 +80,7 @@ public class FilteredPatientListActivity extends BaseSearchablePatientListActivi
                 }
             };
 
-            final ActionBar actionBar = getActionBar();
+            final ActionBar actionBar = getSupportActionBar();
             actionBar.setLogo(R.drawable.ic_launcher);
             actionBar.setDisplayShowTitleEnabled(false);
             actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListActivity.java
@@ -16,6 +16,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.view.MenuItemCompat;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -65,13 +66,15 @@ public final class LocationListActivity extends BaseSearchablePatientListActivit
         super.onExtendOptionsMenu(menu);
 
         MenuItem searchItem = menu.findItem(R.id.action_search);
-        searchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
-            @Override public boolean onMenuItemActionExpand(MenuItem item) {
+        MenuItemCompat.setOnActionExpandListener(searchItem, new MenuItemCompat.OnActionExpandListener() {
+            @Override
+            public boolean onMenuItemActionExpand(MenuItem item) {
                 mController.onSearchPressed();
                 return true;
             }
 
-            @Override public boolean onMenuItemActionCollapse(MenuItem item) {
+            @Override
+            public boolean onMenuItemActionCollapse(MenuItem item) {
                 mController.onSearchCancelled();
                 return true;
             }

--- a/app/src/main/java/org/projectbuendia/client/ui/login/LoginActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/login/LoginActivity.java
@@ -14,6 +14,7 @@ package org.projectbuendia.client.ui.login;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -51,10 +52,12 @@ public class LoginActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         App.getInstance().inject(this);
 
+        setContentView(R.layout.activity_user_login);
+        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
         // This is the starting activity for the app, so show the app name and version.
         setTitle(getString(R.string.app_name) + " " + getString(R.string.app_version));
 
-        setContentView(R.layout.activity_user_login);
         LoginFragment fragment = (LoginFragment)
             getSupportFragmentManager().findFragmentById(R.id.fragment_user_login);
         mController = new LoginController(

--- a/app/src/main/res/layout/activity_location_selection.xml
+++ b/app/src/main/res/layout/activity_location_selection.xml
@@ -9,8 +9,15 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:id="@+id/location_selection_container"
-    android:layout_width="match_parent" android:layout_height="match_parent"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/location_selection_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context="org.projectbuendia.client.ui.lists.LocationListActivity"
-    tools:ignore="MergeRootFrame" />
+    tools:ignore="MergeRootFrame" >
+
+    <include layout="@layout/toolbar" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_patient_chart.xml
+++ b/app/src/main/res/layout/activity_patient_chart.xml
@@ -19,8 +19,13 @@
     android:orientation="vertical"
     tools:context="org.projectbuendia.client.ui.chart.PatientChartFragment">
 
+  <include
+      android:id="@+id/toolbar"
+      layout="@layout/toolbar" />
+
   <LinearLayout
       android:id="@+id/patient_chart_status_section"
+      android:layout_below="@+id/toolbar"
       android:layout_width="fill_parent"
       android:layout_height="wrap_content"
       android:layout_margin="16dp"

--- a/app/src/main/res/layout/activity_patient_list.xml
+++ b/app/src/main/res/layout/activity_patient_list.xml
@@ -9,13 +9,22 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/patient_list"
-    android:name="org.projectbuendia.client.ui.lists.PatientListFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    tools:context="org.projectbuendia.client.ui.PatientListActivity"
-    tools:layout="@android:layout/list_content" />
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar" />
+
+    <fragment
+        android:id="@+id/patient_list"
+        android:name="org.projectbuendia.client.ui.lists.PatientListFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        tools:context="org.projectbuendia.client.ui.PatientListActivity"
+        tools:layout="@android:layout/list_content" />
+</LinearLayout>
+

--- a/app/src/main/res/layout/activity_round.xml
+++ b/app/src/main/res/layout/activity_round.xml
@@ -9,13 +9,21 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/single_location_patient_list"
-    android:name="org.projectbuendia.client.ui.lists.SingleLocationFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    tools:context="org.projectbuendia.client.ui.lists.SingleLocationActivity"
-    tools:layout="@android:layout/list_content" />
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar" />
+
+    <fragment
+        android:id="@+id/single_location_patient_list"
+        android:name="org.projectbuendia.client.ui.lists.SingleLocationFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        tools:context="org.projectbuendia.client.ui.lists.SingleLocationActivity"
+        tools:layout="@android:layout/list_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_user_login.xml
+++ b/app/src/main/res/layout/activity_user_login.xml
@@ -9,13 +9,21 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/fragment_user_login"
-    android:name="org.projectbuendia.client.ui.login.LoginFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    tools:context="org.projectbuendia.client.ui.UserLoginActivity"
-    tools:layout="@android:layout/list_content" />
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar" />
+
+    <fragment
+        android:id="@+id/fragment_user_login"
+        android:name="org.projectbuendia.client.ui.login.LoginFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        tools:context="org.projectbuendia.client.ui.UserLoginActivity"
+        tools:layout="@android:layout/list_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:elevation="4dp"
+    android:theme="@style/ToolbarTheme"
+    app:popupTheme="@style/ToolbarPopupTheme" />

--- a/app/src/main/res/menu/base.xml
+++ b/app/src/main/res/menu/base.xml
@@ -10,17 +10,17 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<menu
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/action_go_to"
         android:title="@string/action_go_to"
-        android:showAsAction="ifRoom|collapseActionView" />
+        app:showAsAction="ifRoom|collapseActionView" />
 
     <item
-        android:id="@+id/user"
-        android:showAsAction="always"
+        android:id="@+id/action_user"
+        app:showAsAction="always"
         android:title=""
-        android:actionLayout="@layout/action_bar_user_menu_button" />
+        app:actionLayout="@layout/action_bar_user_menu_button" />
 
 </menu>

--- a/app/src/main/res/menu/chart.xml
+++ b/app/src/main/res/menu/chart.xml
@@ -10,14 +10,15 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/action_zoom"
         android:title="@string/action_zoom"
-        android:showAsAction="ifRoom|collapseActionView" />
+        app:showAsAction="ifRoom|collapseActionView" />
 
     <item android:id="@+id/action_edit"
       android:title="@string/action_edit"
-      android:showAsAction="always" >
+      app:showAsAction="always" >
 
       <menu>
           <item android:id="@+id/edit_patient"

--- a/app/src/main/res/menu/login.xml
+++ b/app/src/main/res/menu/login.xml
@@ -10,16 +10,17 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <!-- TODO: Figure out why applying padding to @style/ActionButton doesn't work. -->
   <item
       android:id="@+id/action_new_user"
-      android:showAsAction="ifRoom"
+      app:showAsAction="ifRoom"
       android:title="@string/title_new_user"/>
   <item
       android:id="@+id/settings"
-      android:showAsAction="ifRoom"
+      app:showAsAction="ifRoom"
       android:title= "@string/title_activity_settings"/>
 
 </menu>

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -10,15 +10,16 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/action_search"
           android:title="@string/action_search"
-          android:showAsAction="ifRoom|collapseActionView"
-          android:actionViewClass="android.widget.SearchView"/>
+          app:showAsAction="ifRoom|collapseActionView"
+          app:actionViewClass="android.widget.SearchView"/>
 
     <item android:id="@+id/action_new_patient"
-          android:showAsAction="ifRoom|collapseActionView"
+          app:showAsAction="ifRoom|collapseActionView"
           android:title="@string/action_new_patient"/>
 <!--
     <item android:id="@+id/action_cancel"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,7 +15,10 @@
     tools:ignore="UnusedResources">
 
     <!-- Theme -->
+    <color name="color_primary">#494</color>
+    <color name="color_accent">#00FF00</color>
     <color name="menubar_icon">#ffffff</color>
+    <color name="submenu_background">#e1e1e1</color>
 
     <!-- Vitals -->
     <color name="vital_fg_light">#ffffff</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,51 +14,49 @@
   <!-- THEMES -->
 
   <!-- Base application theme -->
-  <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
-
+  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
     <!-- Action Bar -->
-    <item name="android:actionBarStyle">@style/ActionBar</item>
-    <item name="android:actionMenuTextAppearance">@style/MenuActionBar</item>
     <item name="android:actionButtonStyle">@style/ActionButton</item>
     <!-- Action Bar: Chart Tabs -->
     <item name="android:actionBarTabBarStyle">@style/ChartTabBarStyle</item>
     <item name="android:actionBarTabTextStyle">@style/ChartTabBarTextStyle</item>
     <!-- Widgets -->
-    <item name="android:textViewStyle">@style/widgets.TextView</item>
     <item name="android:editTextStyle">@style/widgets.EditText</item>
     <item name="android:buttonStyle">@style/widgets.Button</item>
     <item name="android:radioButtonStyle">@style/widgets.RadioButton</item>
-  </style>
-
-
-  <!-- ACTION BAR -->
-
-  <style name="ActionBar" parent="android:Widget.Holo.Light.ActionBar.Solid.Inverse">
-    <item name="android:height">56sp</item>
-    <item name="android:titleTextStyle">@style/text.large.white</item>
-    <item name="android:subtitleTextStyle">@style/text.medium.white</item>
-    <item name="android:background">@drawable/action_bar_bg</item>
-    <item name="android:progressBarPadding">32sp</item>
     <item name="android:itemPadding">8sp</item>
   </style>
 
-  <style name="MenuActionBar" parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Menu">
-    <item name="android:textAppearance">@style/text.large.white</item>
+  <!-- ACTION BAR -->
+  <style name="ToolbarTheme" parent="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+    <item name="android:textColorPrimary">@color/white</item>
+    <item name="actionMenuTextColor">@color/white</item>
+    <item name="colorAccent">@color/color_accent</item>
+    <item name="colorControlNormal">@color/white</item>
+    <item name="colorControlActivated">@color/color_accent</item>
+    <item name="android:background">@color/color_primary</item>
+    <item name="android:itemPadding">8sp</item>
+    <item name="android:titleTextStyle">@style/text.large.white</item>
+    <item name="android:subtitleTextStyle">@style/text.medium.white</item>
+  </style>
+    
+  <style name="ToolbarPopupTheme" parent="@style/ThemeOverlay.AppCompat.Light">
+    <item name="android:background">@color/submenu_background</item>
   </style>
 
-  <style name="ChartTabBarTextStyle" parent="android:Widget.Holo.Light.ActionBar.TabText">
+  <style name="ChartTabBarTextStyle" parent="Base.Widget.AppCompat.ActionBar.TabText">
     <item name="android:textSize">18dp</item>
     <item name="android:textColor">@color/white</item>
   </style>
 
-  <style name="ChartTabBarStyle" parent="android:Widget.Holo.Light.ActionBar.TabBar">
+  <style name="ChartTabBarStyle" parent="Base.Widget.AppCompat.ActionBar.TabBar">
     <item name="android:background">@drawable/action_bar_bg</item>
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_gravity">fill_horizontal</item>
   </style>
 
   <!-- TODO: Figure out why applying padding to @style/ActionButton doesn't work. -->
-  <style name="ActionButton" parent="@android:style/Widget.Holo.Light.ActionButton">
+  <style name="ActionButton" parent="Base.Widget.AppCompat.ActionButton">
     <item name="android:textSize">19sp</item>
     <item name="android:minWidth">56sp</item>
     <item name="android:paddingStart">16sp</item>
@@ -68,13 +66,8 @@
 
   <!-- WIDGETS -->
 
-  <!-- TextView -->
-  <style name="widgets.TextView" parent="android:Widget.Holo.Light.TextView">
-    <item name="android:textAppearance">@style/text</item>
-  </style>
-
   <!-- EditText -->
-  <style name="widgets.EditText" parent="android:Widget.Holo.Light.EditText">
+  <style name="widgets.EditText" parent="Base.V7.Widget.AppCompat.EditText">
     <item name="android:focusable">true</item>
     <item name="android:focusableInTouchMode">true</item>
     <item name="android:clickable">true</item>
@@ -82,13 +75,13 @@
   </style>
 
   <!-- Button -->
-  <style name="widgets.Button" parent="android:Widget.Holo.Light.Button">
+  <style name="widgets.Button" parent="Base.Widget.AppCompat.Button">
     <item name="android:textAppearance">@style/text</item>
   </style>
 
   <!-- Radio Button -->
   <style name="widgets.RadioButton"
-      parent="android:Widget.Holo.Light.CompoundButton.RadioButton">
+      parent="Base.Widget.AppCompat.CompoundButton.RadioButton">
     <item name="android:paddingTop">6sp</item>
     <item name="android:paddingBottom">6sp</item>
     <item name="android:paddingStart">18sp</item>

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -242,6 +242,8 @@ public class FormEntryActivity
 		setContentView(R.layout.form_entry);
 
         setTitle(getString(R.string.title_loading_form));
+
+        getActionBar().setDisplayHomeAsUpEnabled(true);
 //
 //		setTitle(getString(R.string.app_name) + " > "
 //				+ getString(R.string.loading_form));
@@ -1011,9 +1013,14 @@ public class FormEntryActivity
 
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
-		FormController formController = Collect.getInstance()
-				.getFormController();
+//		FormController formController = Collect.getInstance()
+//				.getFormController();
 		switch (item.getItemId()) {
+			case android.R.id.home :
+				// Go back rather than reloading the activity, so that the patient list retains its
+				// filter state.
+				onBackPressed();
+				return true;
 ////		case MENU_LANGUAGES:
 ////			Collect.getInstance()
 ////					.getActivityLogger()


### PR DESCRIPTION
Issues: Closes #336 
Scope: All top menu navigation
Requested reviewers: <!-- Tag reviewers here. -->

#### User-visible changes

The `appbar` has been replaced with the newer `toolbar`, which looks and behaves as expected. 

The chart and patient list activities have been made to only exist once in the stack, resulting in a back button experience that is much simpler.

_Two known minor bugs:_ 
1. The toolbar properly increases in size with the `+` and `-` volume buttons, but the signed in user icon resizes too fast, and the title font size is not increasing. 
2. The settings activity uses a different theme from the rest of the app.

#### Internal changes 

Changing to toolbar required me to use `AppCompatActivity`, and use a `NoActionBar` theme. This resulted in some deprecations where we use toolbar tabs, which will need to be examined at a later point.

Also to note: Because settings screen was implemented using `PreferenceActivity` which inherits from `Activity`, I added an extra class that uses a delegate to get `AppCompat` functionality. Instead of using a custom layout, I simply use a default `AppCompat` theme with action bar.

#### Guidance for testers 

Please double check all app bar navigation.

#### Rationale and alternatives considered  

I realize that this upgrade added time and complexity to this PR. I attempted some hacky solutions to make the back button look and feel as expected, and was not getting the results I wanted. The [Google Developers documentation strongly recommended using `toolbar` instead](https://developer.android.com/training/appbar/setting-up.html).

Also to note: I attempted a few things on the `SettingsActivity` including a custom layout and using a custom theme. I kept running into bugs, and I decided it was not worth the time investment at this junction.

#### Screenshots 
![336-toolbar](https://user-images.githubusercontent.com/7307817/60299058-a92e7080-98e0-11e9-9c05-da40fec1d5ca.png)
![336-zoom-bug](https://user-images.githubusercontent.com/7307817/60299059-a92e7080-98e0-11e9-82d1-a1d3f9874ae4.png)
![336-toolbar-settings](https://user-images.githubusercontent.com/7307817/60299057-a92e7080-98e0-11e9-9b4e-1bf6921ba56d.png)



