### PR TITLE
Search for name contains, instead of word prefix

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/filter/matchers/patient/NameFilter.java
+++ b/app/src/main/java/org/projectbuendia/client/filter/matchers/patient/NameFilter.java
@@ -36,27 +36,15 @@ public final class NameFilter implements MatchingFilter<Patient> {
         String givenName = (patient.givenName == null) ? "" : patient.givenName;
         String familyName = (patient.familyName == null) ? "" : patient.familyName;
         String fullName = givenName + " " + familyName;
-        String[] nameParts = fullName.toLowerCase().split(" ");
+        String fullNameLowercase = fullName.toLowerCase();
 
         // Get array of words in the search query
         String[] searchTerms = constraint.toString().toLowerCase().split(" ");
 
-        // Loop through each of the search terms checking if there is a prefix match
-        // for it in any word of the name.
+        // Loop through each of the search terms checking if there is a match for every one in the
+        // name.
         for (String searchTerm : searchTerms) {
-            boolean termMatched = false;
-            for (String namePart : nameParts) {
-                // If both the search term and a name are dashes, use a more permissive matcher
-                // that allows for an arbitrary type of dash. This makes it simpler to search for
-                // patients with an unknown name, which is represented by a dash.
-                if (namePart.startsWith(searchTerm) || areBothDashes(namePart, searchTerm)) {
-                    termMatched = true;
-                    break;  // no need to keep checking for this term
-                }
-            }
-            // This search term was not matched to any word of the name,
-            // so this patient is not a match
-            if (!termMatched) {
+            if (!fullNameLowercase.contains(searchTerm)) {
                 return false;
             }
         }


### PR DESCRIPTION
Issues: https://github.com/projectbuendia/client/issues/309
Scope: PatientSearchController, NameFilter
Requested reviewers: @saratheneale @zestyping 

#### User-visible changes

Search for names will now match if input search strings match middle or end of name instead of just prefix.

#### Verification performed

Searching for names. Verify that previous prefix search works, and that searching for substrings in middle/end also works.

#### Guidance for reviewers <!-- optional -->

Searching for names. Verify that previous prefix search works, and that searching for substrings in middle/end also works.

#### Guidance for testers <!-- optional -->

Searching for names. Verify that previous prefix search works, and that searching for substrings in middle/end also works.

#### Rationale and alternatives considered  <!-- optional -->

Was somewhat confusing going through the various Filter classes. Some seem to filter through SQL, and NameFilter does filtering in memory.
