### PR TITLE
Limit duration and frequency; adjust layout in the order dialog

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
@@ -41,6 +41,9 @@ import de.greenrobot.event.EventBus;
 
 /** A {@link DialogFragment} for adding a new user. */
 public class OrderDialogFragment extends DialogFragment {
+    public static final int MAX_FREQUENCY = 24;  // maximum 24 times per day
+    public static final int MAX_DURATION_DAYS = 30;  // maximum 30 days
+
     @InjectView(R.id.order_medication) EditText mMedication;
     @InjectView(R.id.order_dosage) EditText mDosage;
     @InjectView(R.id.order_frequency) EditText mFrequency;
@@ -131,8 +134,16 @@ public class OrderDialogFragment extends DialogFragment {
             setError(mMedication, R.string.enter_medication);
             valid = false;
         }
+        if (frequency > MAX_FREQUENCY) {
+            setError(mFrequency, R.string.order_cannot_exceed_n_times_per_day, MAX_FREQUENCY);
+            valid = false;
+        }
         if (durationDays != null && durationDays == 0) {
             setError(mGiveForDays, R.string.order_give_for_days_cannot_be_zero);
+            valid = false;
+        }
+        if (durationDays != null && durationDays > MAX_DURATION_DAYS) {
+            setError(mGiveForDays, R.string.order_cannot_exceed_n_days, MAX_DURATION_DAYS);
             valid = false;
         }
         Utils.logUserAction("order_submitted",
@@ -180,8 +191,8 @@ public class OrderDialogFragment extends DialogFragment {
             .create().show();
     }
 
-    private void setError(EditText field, int resourceId) {
-        field.setError(getResources().getString(resourceId));
+    private void setError(EditText field, int resourceId, Object... args) {
+        field.setError(getResources().getString(resourceId, args));
         field.invalidate();
         field.requestFocus();
     }

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -38,6 +38,7 @@
           android:layout_height="wrap_content"
           android:layout_column="1"
           android:layout_span="2"
+          android:layout_weight="1"
           android:ems="15"
           android:inputType="textCapSentences|textNoSuggestions"
           android:maxLength="40"/>
@@ -59,6 +60,7 @@
           android:layout_height="wrap_content"
           android:layout_column="1"
           android:layout_span="2"
+          android:layout_weight="1"
           android:ems="15"
           android:inputType="textNoSuggestions"
           android:maxLength="40"/>

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -20,7 +20,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
-      android:padding="16dp">
+      android:padding="16sp">
 
     <TableRow
         android:layout_width="fill_parent"
@@ -144,17 +144,16 @@
   <LinearLayout
       android:layout_width="fill_parent"
       android:layout_height="wrap_content"
-      android:orientation="horizontal"
-      >
+      android:orientation="horizontal">
 
   <Button
       android:id="@+id/order_delete"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_margin="16sp"
-      android:padding="24sp"
-      android:text="@string/order_delete"
-  />
+      android:layout_marginLeft="16sp"
+      android:layout_marginBottom="16sp"
+      android:padding="16sp"
+      android:text="@string/order_delete"/>
   </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -82,7 +82,7 @@
           android:digits="0123456789"
           android:ems="3"
           android:inputType="numberDecimal"
-          android:maxLength="3"/>
+          android:maxLength="2"/>
 
       <TextView
           android:id="@+id/order_times_per_day_label"
@@ -112,7 +112,7 @@
           android:digits="0123456789"
           android:ems="3"
           android:inputType="numberDecimal"
-          android:maxLength="3"/>
+          android:maxLength="2"/>
 
       <TextView
           android:id="@+id/order_give_for_days_label"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
   <string name="order_duration_unspecified">(no specific duration)</string>
   <string name="enter_medication">Enter a medication</string>
   <string name="order_give_for_days_cannot_be_zero">Must be empty or greater than 0</string>
+  <string name="order_cannot_exceed_n_times_per_day">Cannot exceed %d times per day</string>
+  <string name="order_cannot_exceed_n_days">Cannot exceed %d days</string>
   <string name="order_stop_now">Stop now</string>
   <string name="order_delete">Delete this treatment</string>
   <string name="title_confirmation">Confirmation</string>


### PR DESCRIPTION
Issues: Closes #366.
Scope: order dialog

#### User-visible changes

When prescribing a treatment, users are no longer allowed to enter frequencies greater than 24 times per day, or durations longer than 30 days.

There are also small cosmetic changes to the dialog.