### PR TITLE
Add route field to order dialog; store instructions using field separators; fix interpretation of orders with no stop time.

### DIFF
--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -139,7 +139,7 @@
       {% for order in orders %}
         <tr class="order">
           <th scope="row" onclick="controller.onOrderHeadingPressed('{{order.uuid}}')">
-            <div class="medication">{{order.instructions.medication}}</div>
+            <div class="medication">{{order.instructions.medication}}&nbsp;{{order.instructions.route}}</div>
             <div>{{order.instructions.dosage}}&nbsp;</div>
           </th>
           {% set counts = executionCounts[order.uuid] %}

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -373,7 +373,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
     }
 
     private void showZoomDialog() {
-        CharSequence[] labels = new CharSequence[ChartRenderer.ZOOM_LEVELS.length];
+        String[] labels = new String[ChartRenderer.ZOOM_LEVELS.length];
         for (int i = 0; i < labels.length; i++) {
             labels[i] = getString(ChartRenderer.ZOOM_LEVELS[i].labelId);
         }
@@ -383,7 +383,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             .setSingleChoiceItems(labels, selected, new DialogInterface.OnClickListener() {
                 @Override public void onClick(DialogInterface dialog, int which) {
                     mController.setZoomIndex(which);
-                    dialog.cancel();
+                    dialog.dismiss();
                 }
             })
             .setNegativeButton(R.string.cancel, null)

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -787,6 +787,7 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
                 }
             }
 
+            LOG.i("Saving order: %s", event.instructions);
             mAppModel.saveOrder(mCrudEventBus, new Order(
                 event.orderUuid, event.patientUuid, event.instructions, start, stop));
         }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
@@ -362,6 +362,8 @@ public class PebbleExtension extends AbstractExtension {
         }
     }
 
+    // TODO(ping): Switch to looking up dose counts by division index instead
+    // of using this expensive function.
     static class CountScheduledDosesFunction implements Function {
         @Override public List<String> getArgumentNames() {
             return ImmutableList.of("order", "interval");

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -272,6 +272,16 @@ public class Utils {
         return String.format(Locale.US, template, args);
     }
 
+    /** Splits a string, returning an array padded out to known length with empty strings. */
+    public static String[] splitFields(String text, String separator, int count) {
+        String[] fields = text.split(separator, -1);
+        String[] result = new String[count];
+        for (int i = 0; i < count; i++) {
+            result[i] = i < fields.length ? fields[i] : "";
+        }
+        return result;
+    }
+
     /** URL-encodes a nullable string, catching the useless exception that never happens. */
     public static String urlEncode(@Nullable String s) {
         if (s == null) {
@@ -350,6 +360,15 @@ public class Utils {
     /** The same operation as map.getOrDefault(key), which is only available in API 24+. */
     public static <K, V> V getOrDefault(Map<K, V> map, K key, V defaultValue) {
         return map.containsKey(key) ? map.get(key) : defaultValue;
+    }
+
+    /** Converts a String to an integer, returning a default value instead of throwing an exception. */
+    public static int toIntegerOrDefault(String text, int defaultValue) {
+        try {
+            return Integer.valueOf(text);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
     }
 
     /** Converts a list of Longs to an array of primitive longs. */

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -30,7 +30,8 @@
           style="@style/field_label"
           android:layout_column="0"
           android:layout_marginEnd="12sp"
-          android:text="@string/order_medication"/>
+          android:text="@string/order_medication"
+          android:labelFor="@id/order_medication"/>
 
       <EditText
           android:id="@+id/order_medication"
@@ -42,6 +43,16 @@
           android:ems="15"
           android:inputType="textCapSentences|textNoSuggestions"
           android:maxLength="40"/>
+
+      <EditText
+          android:id="@+id/order_route"
+          style="?android:attr/spinnerStyle"
+          android:editable="false"
+          android:textSize="19sp"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_column="2"
+          android:hint="Route" />
     </TableRow>
 
     <TableRow
@@ -52,7 +63,8 @@
           style="@style/field_label"
           android:layout_column="0"
           android:layout_marginEnd="12sp"
-          android:text="@string/order_dosage"/>
+          android:text="@string/order_dosage"
+          android:labelFor="@id/order_dosage"/>
 
       <EditText
           android:id="@+id/order_dosage"
@@ -74,7 +86,8 @@
           style="@style/field_label"
           android:layout_column="0"
           android:layout_marginEnd="12sp"
-          android:text="@string/order_frequency"/>
+          android:text="@string/order_frequency"
+          android:labelFor="@id/order_frequency"/>
 
       <EditText
           android:id="@+id/order_frequency"
@@ -104,7 +117,8 @@
           android:layout_column="0"
           android:layout_marginEnd="12sp"
           android:gravity="center_vertical"
-          android:text="@string/order_give_for"/>
+          android:text="@string/order_give_for"
+          android:labelFor="@id/order_give_for_days"/>
 
       <EditText
           android:id="@+id/order_give_for_days"
@@ -150,7 +164,7 @@
       android:id="@+id/order_delete"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginLeft="16sp"
+      android:layout_marginStart="16sp"
       android:layout_marginBottom="16sp"
       android:padding="16sp"
       android:text="@string/order_delete"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
   <string name="order_duration_stop_after_tomorrow">(stop after tomorrow)</string>
   <string name="order_duration_stop_after_date">(stop after %s)</string>
   <string name="order_duration_unspecified">(no specific duration)</string>
+  <string name="order_duration_indefinitely">(indefinitely)</string>
+  <string name="order_duration_administer_once">(administer once)</string>
   <string name="enter_medication">Enter a medication</string>
   <string name="order_give_for_days_cannot_be_zero">Must be empty or greater than 0</string>
   <string name="order_cannot_exceed_n_times_per_day">Cannot exceed %d times per day</string>
@@ -92,6 +94,8 @@
   <string name="title_confirmation">Confirmation</string>
   <string name="confirm_order_delete">Really delete?</string>
   <string name="delete">Delete</string>
+
+  <string name="route_of_administration">Route of administration</string>
 
   <string name="order_execution_title">Treatment history</string>
   <string name="order_execution_historical_singular_html">Given &lt;b&gt;%1$d&lt;/b&gt; time on %2$s</string>


### PR DESCRIPTION
Issues: Progress toward #297.
Scope: treatments section of patient chart, order dialog

#### User-visible changes

The order dialog now offers a selection for the route of administration (PO, IV, IM, or SC).

Orders that have no frequency are considered to be administered exactly once (on the day of the order).

Orders with a frequency but no stop time are considered to be administered indefinitely.

#### Internal changes

The instruction fields (medication, route, dosage, frequency) are now packed into the OpenMRS "instructions" field using ASCII record separator characters (30 and 31) instead of fiddly regular expressions.

#### Screenshots

![route-of-administration](https://user-images.githubusercontent.com/236086/60414509-37c71a00-9b8d-11e9-813b-0758810d35db.png)
