### PR TITLE
Show historical Ebola lab test results

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
@@ -187,7 +187,7 @@ public final class PatientChartControllerTest {
         // GIVEN controller is initialized
         mController.init();
         // WHEN test results are pressed
-        mController.onAddTestResultsPressed();
+        mController.onPcrResultsPressed();
         // THEN the controller displays the loading dialog
         verify(mMockUi).showFormLoadingDialog(true);
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -278,7 +278,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
         });
         mPcr.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View view) {
-                mController.onAddTestResultsPressed();
+                mController.onPcrResultsPressed();
             }
         });
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -393,21 +393,12 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
         return request;
     }
 
-    public void onAddTestResultsPressed() {
-        Preset preset = new Preset();
-        preset.locationName = "Triage";
-
-        JsonUser user = App.getUserManager().getActiveUser();
-        Utils.logUserAction("form_opener_pressed", "form", "lab_test");
-        if (user != null) {
-            preset.clinicianName = user.fullName;
+    public void onPcrResultsPressed() {
+        String[] conceptUuids = new String[] {ConceptUuids.PCR_GP_UUID, ConceptUuids.PCR_NP_UUID};
+        List<ObsRow> obsRows = mChartHelper.getPatientObservationsByConcept(mPatientUuid, conceptUuids);
+        if (!obsRows.isEmpty()) {
+            mUi.showObsDetailDialog(obsRows, Arrays.asList(conceptUuids));
         }
-
-        mUi.showFormLoadingDialog(true);
-        FormRequest request = newFormRequest(EBOLA_LAB_TEST_FORM_UUID, mPatientUuid);
-        mUi.fetchAndShowXform(
-            request.requestIndex, request.formUuid,
-            mPatient.toOdkPatient(), preset);
     }
 
     public void onOpenFormPressed(String formUuid) {

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -33,7 +33,6 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.R;
-import org.projectbuendia.client.models.ObsRow;
 import org.projectbuendia.client.net.Server;
 
 import java.io.PrintWriter;
@@ -45,7 +44,6 @@ import java.net.URLEncoder;
 import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -626,10 +624,7 @@ public class Utils {
     /** Returns an unambiguous string representation of a string, suitable for logging. */
     public static String repr(String str, int maxLength) {
         try {
-            return str != null ? format("(length %d) \"%s\"%s",
-                str.length(), escape(str, maxLength),
-                str.length() > maxLength ? "..." : ""
-            ) : "(null String)";
+            return str != null ? escape(str, maxLength) : "(null String)";
         } catch (Throwable ignored) {
             return "(repr of " + str + " failed)";
         }
@@ -638,10 +633,8 @@ public class Utils {
     /** Returns an unambiguous string representation of a byte array, suitable for logging. */
     public static String repr(byte[] bytes, int maxLength) {
         try {
-            return bytes != null ? format("(length %d) \"%s\"%s",
-                bytes.length, escape(new String(bytes, "ISO-8859-1"), maxLength),
-                bytes.length > maxLength ? "\"..." : "\""
-            ) : "(null byte[])";
+            return bytes != null ?
+                escape(new String(bytes, "ISO-8859-1"), maxLength) : "(null byte[])";
         } catch (Throwable ignored) {
             return "(repr of " + bytes + " failed)";
         }
@@ -678,6 +671,7 @@ public class Utils {
                     }
             }
         }
+        buffer.append(str.length() > maxLength ? "\"..." : "\"");
         return buffer.toString();
     }
 


### PR DESCRIPTION
Issues: Closes #379.
Scope: patient chart, observation list dialog

#### User-visible changes

When you tap the "Ebola test" tile in the top-right corner of the patient chart, a detail dialog now pops up with the history of Ebola lab test results.

