### PR TITLE
Fix back navigation by making activities singleInstance.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,7 +95,8 @@
             android:name=".ui.lists.FilteredPatientListActivity"
             android:label="@string/title_patient_list"
             android:parentActivityName=".ui.lists.LocationListActivity"
-            android:screenOrientation="userPortrait" >
+            android:screenOrientation="userPortrait"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.nfc.action.TAG_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -106,7 +107,8 @@
             android:label="@string/title_patient_chart"
             android:parentActivityName=".ui.lists.FilteredPatientListActivity"
             android:screenOrientation="userPortrait"
-            android:uiOptions="splitActionBarWhenNarrow">
+            android:uiOptions="splitActionBarWhenNarrow"
+            android:launchMode="singleInstance">
             <meta-data
                 android:name="android.support.UI_OPTIONS"
                 android:value="splitActionBarWhenNarrow" />

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
@@ -447,7 +447,6 @@ public abstract class BaseActivity extends FragmentActivity {
 
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         App.getInstance().inject(this);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -167,7 +167,7 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
         // TODO: Implement this in one way or another!
     }
 
-    public void onEvent(PatientChartRequestedEvent event) {
+    public void onEventMainThread(PatientChartRequestedEvent event) {
         PatientChartActivity.start(this, event.uuid);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -81,7 +81,8 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
             return;
         }
 
-        // Show the Up button in the action bar.
+        // Turn the action bar icon into a "back" arrow that goes back in the activity stack.
+        getActionBar().setIcon(R.drawable.ic_back_36dp);
         getActionBar().setDisplayHomeAsUpEnabled(true);
 
         onCreateImpl(savedInstanceState);

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -81,6 +81,9 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
             return;
         }
 
+        // Show the Up button in the action bar.
+        getActionBar().setDisplayHomeAsUpEnabled(true);
+
         onCreateImpl(savedInstanceState);
         mIsCreated = true;
     }
@@ -128,6 +131,17 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
     }
 
     public void onExtendOptionsMenu(Menu menu) {
+    }
+
+    @Override public boolean onOptionsItemSelected(MenuItem item) {
+        int id = item.getItemId();
+        if (id == android.R.id.home) {
+            // Go back rather than reloading the activity, so that the patient list retains its
+            // filter state.
+            onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private void updateActiveUser() {

--- a/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
@@ -226,10 +226,8 @@ public class SettingsActivity extends PreferenceActivity {
     /** Set up the {@link android.app.ActionBar}, if the API is available. */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     private void setupActionBar() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            // Show the Up button in the action bar.
-            getActionBar().setDisplayHomeAsUpEnabled(true);
-        }
+        getActionBar().setIcon(R.drawable.ic_back_36dp);
+        getActionBar().setDisplayHomeAsUpEnabled(true);
     }
 
     @Override protected boolean isValidFragment(String fragmentName) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -271,6 +271,14 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
         initChartMenu();
     }
 
+    @Override protected void onNewIntent(Intent intent) {
+        String uuid = intent.getStringExtra("uuid");
+        if (uuid != null) {
+            mGridWebView.clearView();
+            mController.setPatient(uuid);
+        }
+    }
+
     class DateObsDialog extends DatePickerDialog {
         private String mTitle;
 
@@ -345,11 +353,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
     @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         mIsFetchingXform = false;
         mController.onXFormResult(requestCode, resultCode, data);
-    }
-
-    @Override protected void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putBundle(KEY_CONTROLLER_STATE, mController.getState());
     }
 
     private String getFormattedPcrString(double pcrValue) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -174,17 +174,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
         Utils.showIf(mPcr, ebolaLabTestFormEnabled);
     }
 
-    @Override public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
-        if (id == android.R.id.home) {
-            // Go back rather than reloading the activity, so that the patient list retains its
-            // filter state.
-            onBackPressed();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
     @Override protected void onCreateImpl(Bundle savedInstanceState) {
         super.onCreateImpl(savedInstanceState);
         setContentView(R.layout.fragment_patient_chart);
@@ -254,9 +243,6 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             controllerState,
             mSyncManager,
             minimalHandler);
-
-        // Show the Up button in the action bar.
-        getActionBar().setDisplayHomeAsUpEnabled(true);
 
         mAdmissionDaysView.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View view) {

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
@@ -16,6 +16,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.text.Editable;
@@ -35,8 +36,8 @@ import org.projectbuendia.client.events.data.ItemFetchFailedEvent;
 import org.projectbuendia.client.events.data.ItemFetchedEvent;
 import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.models.Patient;
-import org.projectbuendia.client.sync.SyncAccountService;
 import org.projectbuendia.client.providers.Contracts.Patients;
+import org.projectbuendia.client.sync.SyncAccountService;
 import org.projectbuendia.client.utils.RelativeDateTimeFormatter;
 import org.projectbuendia.client.utils.Utils;
 
@@ -67,11 +68,10 @@ public class GoToPatientDialogFragment extends DialogFragment {
         mInflater = LayoutInflater.from(getActivity());
         mBus = mCrudEventBusProvider.get();
         mBus.register(this);
-
     }
 
     @Override public @NonNull Dialog onCreateDialog(Bundle savedInstanceState) {
-        View fragment = mInflater.inflate(R.layout.go_to_patient_dialog_fragment, null);
+        final View fragment = mInflater.inflate(R.layout.go_to_patient_dialog_fragment, null);
         ButterKnife.inject(this, fragment);
         mPatientId.addTextChangedListener(new IdWatcher());
         mPatientSearchResult.setOnClickListener(new View.OnClickListener() {
@@ -96,8 +96,17 @@ public class GoToPatientDialogFragment extends DialogFragment {
             "patient_id", mPatientId.getText().toString(),
             "patient_uuid", mPatientUuid);
         if (mPatientUuid != null) {
-            EventBus.getDefault().post(new PatientChartRequestedEvent(mPatientUuid));
             getDialog().dismiss();
+
+            // NOTE(ping): I don't fully understand why, but posting this on a
+            // Handler is necessary to get the numeric keypad to close.  If we
+            // post the event to the EventBus immediately, the numeric keypad
+            // stays up even as the new activity launches underneath it!
+            new Handler().post(new Runnable() {
+                @Override public void run() {
+                    EventBus.getDefault().post(new PatientChartRequestedEvent(mPatientUuid));
+                }
+            });
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
@@ -17,14 +17,10 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import org.projectbuendia.client.App;
-import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.R;
 import org.projectbuendia.client.filter.db.SimpleSelectionFilter;
-import org.projectbuendia.client.ui.OdkActivityLauncher;
 import org.projectbuendia.client.ui.SectionedSpinnerAdapter;
 import org.projectbuendia.client.utils.Utils;
-
-import javax.inject.Inject;
 
 /** A list of patients with a choice of several filters in a dropdown menu. */
 public class FilteredPatientListActivity extends BaseSearchablePatientListActivity {
@@ -81,7 +77,6 @@ public class FilteredPatientListActivity extends BaseSearchablePatientListActivi
             };
 
             final ActionBar actionBar = getActionBar();
-            actionBar.setLogo(R.drawable.ic_launcher);
             actionBar.setDisplayShowTitleEnabled(false);
             actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
             actionBar.setListNavigationCallbacks(adapter, callback);

--- a/app/src/main/java/org/projectbuendia/client/ui/login/LoginActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/login/LoginActivity.java
@@ -42,7 +42,6 @@ import de.greenrobot.event.EventBus;
 public class LoginActivity extends BaseActivity {
     private LoginController mController;
     private AlertDialog mSyncFailedDialog;
-    private boolean mSkippedThisActivity;
 
     @Inject Troubleshooter mTroubleshooter;
     @Inject AppSettings mSettings;
@@ -50,6 +49,10 @@ public class LoginActivity extends BaseActivity {
     @Override public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         App.getInstance().inject(this);
+
+        getActionBar().setDisplayUseLogoEnabled(false);
+        getActionBar().setIcon(R.drawable.ic_launcher);  // don't show the back arrow
+        getActionBar().setDisplayHomeAsUpEnabled(false);  // don't behave like a back button
 
         // This is the starting activity for the app, so show the app name and version.
         setTitle(getString(R.string.app_name) + " " + getString(R.string.app_version));

--- a/app/src/main/res/drawable/ic_back_36dp.xml
+++ b/app/src/main/res/drawable/ic_back_36dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="36dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -242,6 +242,8 @@ public class FormEntryActivity
 		setContentView(R.layout.form_entry);
 
         setTitle(getString(R.string.title_loading_form));
+
+        getActionBar().setDisplayHomeAsUpEnabled(true);
 //
 //		setTitle(getString(R.string.app_name) + " > "
 //				+ getString(R.string.loading_form));
@@ -1011,9 +1013,14 @@ public class FormEntryActivity
 
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
-		FormController formController = Collect.getInstance()
-				.getFormController();
+//		FormController formController = Collect.getInstance()
+//				.getFormController();
 		switch (item.getItemId()) {
+			case android.R.id.home :
+				// Go back rather than reloading the activity, so that the patient list retains its
+				// filter state.
+				onBackPressed();
+				return true;
 ////		case MENU_LANGUAGES:
 ////			Collect.getInstance()
 ////					.getActivityLogger()

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -243,8 +243,11 @@ public class FormEntryActivity
 
         setTitle(getString(R.string.title_loading_form));
 
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-//
+		// Turn the action bar icon into a "back" arrow that goes back in the activity stack.
+		getActionBar().setIcon(R.drawable.ic_back_36dp);
+		getActionBar().setDisplayHomeAsUpEnabled(true);
+
+		//
 //		setTitle(getString(R.string.app_name) + " > "
 //				+ getString(R.string.loading_form));
 

--- a/third_party/odkcollect/src/main/res/drawable-hdpi/ic_back_36dp.xml
+++ b/third_party/odkcollect/src/main/res/drawable-hdpi/ic_back_36dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="36dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>


### PR DESCRIPTION
Issues: Closes #336.
Scope: action bar, all activities other than login

#### User-visible changes

The top-left corner now shows a white "back" arrow, which you can tap to go back.  Going back always steps up one level in the activity hierarchy.

In particular, when you use the "Go to patient chart" dialog to jump directly to a patient chart, it does not stack a new patient chart on top of the current chart; it replaces the current chart on the stack.  Thereafter, going back takes you back to the patient list, instead of the previous chart.

As a side effect of this change, because we no longer destroy and relaunch the patient chart activity when jumping to a new chart, switching charts is noticeably faster.

#### Internal changes <!-- optional -->

Most of this work was done by @krtonga; I just rebased it and fixed the activity launching part.
