### PR TITLE
Avoid using the java.util.Locale.Category class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bin/
 build/
 gen/
 crashlytics-build.properties
+output.json
 
 # Gradle files
 .gradle/
@@ -33,9 +34,6 @@ local.properties
 .idea/copyright/profiles_settings.xml
 .idea/inspectionProfiles/Buendia.xml
 .idea/inspectionProfiles/profiles_settings.xml
-
-
-
 !.idea/inspectionProfiles
 !.idea/copyright
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
@@ -94,7 +94,10 @@ public class ObsFormat extends Format {
         }
         mRootObsFormat = Utils.orDefault(rootObsFormat, this);
         try {
-            mFormat = new ExtendedMessageFormat(pattern, new FormatFactoryMap());
+            // It's unsafe to use the ExtendedMessageFormat(pattern, registry) constructor,
+            // as it crashes with a NoClassDefFoundError on java.util.Locale.Category on
+            // Android 5.1.  We must use ExtendedMessageFormat(pattern, locale, registry).
+            mFormat = new ExtendedMessageFormat(pattern, Locale.US, new FormatFactoryMap());
         } catch (IllegalArgumentException e) {
             // Instead of crashing, display the invalid pattern in the output to aid debugging.
             mFormat = new Format() {
@@ -153,9 +156,9 @@ public class ObsFormat extends Format {
         }
 
         /**
-         * ExtendedMessageFormat expects a Map containing FormatFactory instances;
-         * rather than defining a separate FormatFactory class to go with every Format,
-         * we simply return this class, which can instantiate any Format.
+         * ExtendedMessageFormat expects a Map containing FormatFactory instances.
+         * Rather than defining a separate FormatFactory class for every Format,
+         * we return the FormatFactoryMap itself, which can instantiate any Format.
          */
         @Override public @Nullable FormatFactory get(Object name) {
             return FORMAT_CLASSES.containsKey("" + name) ? this : null;


### PR DESCRIPTION
Issues: Closes #385.
Scope: ObsFormat

#### User-visible changes

The app doesn't crash.

#### Internal changes <!-- optional -->

As the traceback in #385 shows, the first attempt to instantiate `ExtendedMessageFormat` crashes due to a failure to find the `java.util.Locale.Category` class.  As far as I can tell, this class is available in JDK 7 or 8 and available on Android versions supporting JDK 7, which means Android 5.0+.  So I can't explain why `java.util.Locale.Category` seems to be missing.

But, by using a different `ExtendedMessageFormat` constructor, we can avoid the code path that uses the `java.util.Locale.Category` class.  That's what happens in this PR.

#### Verification performed

In an emulator running Android 5.1, I installed client release 0.13.1 and confirmed that navigating to any patient chart causes a crash.  I then installed an APK with this change and confirmed that the same crash no longer occurs.
