### PR TITLE
Add scroll buttons to the patient chart.

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -14,6 +14,31 @@ th, td { font-weight: normal; text-align: left; vertical-align: baseline; }
 #grid-left { flex-basis: 0; flex-grow: 0; }
 #grid-body { flex-basis: 0; flex-grow: 1; overflow: scroll; position: relative; }
 
+#buttons button {
+  font-size: 3.2rem;
+  -webkit-text-stroke: 0.2rem black;
+  opacity: 0.4;
+  width: 6rem;
+  height: 6rem;
+  padding-top: 0.3rem; /* adjust the centering of the arrow */
+  background: transparent;
+  border: none;
+  outline: none;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+}
+#buttons button[disabled] { opacity: 0.15; color: black; }
+#buttons button::before { content: '\00279c'; }
+button#home::before { content: '\0025c9'; }
+button#up { transform: rotate(270deg); }
+button#left { transform: rotate(180deg); }
+button#down { transform: rotate(90deg); }
+button#left { right: 12rem; }
+button#home { right: 6rem; }
+button#up { bottom: 12rem; }
+button#down { bottom: 6rem; }
+
 /* Apply borders to all cells so their sizes are uniform. */
 .top th { border-top: 1px solid transparent; }
 th, td { border: 1px solid transparent; border-width: 0 1px 1px 0; }

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -227,6 +227,13 @@
 <div id="scroller">
   <div id="grid-left"></div>
   <div id="grid-body"></div>
+  <div id="buttons">
+    <button id="up" ontouchstart="moveTarget(0, -jumpY)"></button>
+    <button id="down" ontouchstart="moveTarget(0, jumpY)"></button>
+    <button id="left" ontouchstart="moveTarget(-jumpX, 0)"></button>
+    <button id="home" ontouchstart="moveTarget(0, 0, true)"></button>
+    <button id="right" ontouchstart="moveTarget(jumpX, 0)"></button>
+  </div>
 </div>
 
 <script>
@@ -250,6 +257,7 @@
 
   controller.log('Start constructing grid-left and grid-body');
 
+  var win = $(window);
   var grid = $('#grid');
   var gridLeft = $('#grid-left');
   var gridBody = $('#grid-body');
@@ -276,7 +284,7 @@
   var yOffset = 0;
 
   function updateY() {
-    yOffset = window.scrollY - headings.offset().top;
+    yOffset = win.scrollTop() - headings.offset().top;
     frozenCorner.toggle(yOffset > 0);
     frozenHeadings.toggle(yOffset > 0);
     floatingHeadings.hide();
@@ -295,8 +303,8 @@
     }
   }
 
-  $(window).scroll(updateY);
-  $('#grid-body').scroll(updateX);
+  win.scroll(updateY);
+  gridBody.scroll(updateX);
 
   $(window).unload(function() {
     controller.onPageUnload($('#grid-body').scrollLeft(), $(window).scrollTop());
@@ -304,6 +312,63 @@
 
   function od(conceptUuid, startMillis, stopMillis) {
     controller.onObsDialog(conceptUuid, startMillis, stopMillis);
+  }
+
+  var nowColumn = $('.now[scope="col"]');
+  var nowCenter = nowColumn.offset().left + nowColumn.width()/2;
+  var bodyCenter = gridBody.offset().left + gridBody.width()/2;
+  var jumpX = gridBody.width()/2;
+  var jumpY = gridBody.height()/3;
+  var homeX = nowCenter - bodyCenter;
+  var targetX = 0;
+  var targetY = 0;
+
+  function scrollJump(dx, dy, home) {
+    var x = gridBody.scrollLeft();
+    var y = win.scrollTop();
+    if (home) {
+      gridBody.scrollLeft(homeX);
+      updateX();
+    }
+    if (dx != 0) {
+      gridBody.scrollLeft(x + dx);
+      updateX();
+    }
+    if (dy != 0) {
+      win.scrollTop(y + dy);
+      updateY();
+    }
+  }
+
+  function moveTarget(dx, dy, home) {
+    if (home) targetX = homeX;
+    targetX += dx;
+    targetY += dy;
+    scrollStep();
+  }
+
+  var abs = Math.abs;
+
+  function scrollStep() {
+    var x = gridBody.scrollLeft();
+    var y = win.scrollTop();
+    console.log('scroll', x, y);
+    gridBody.scrollLeft(x * 0.6 + targetX * 0.4);
+    win.scrollTop(y * 0.6 + targetY * 0.4);
+    var step = false;
+    if (abs(gridBody.scrollLeft() - x) > 0.5) {
+      updateX();
+      step = true;
+    } else {
+      targetX = x;
+    }
+    if (abs(win.scrollTop() - y) > 0.5) {
+      updateY();
+      step = true;
+    } else {
+      targetY = y;
+    }
+    if (step) window.setTimeout(scrollStep, 30);
   }
 
   controller.log('Finished script');

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -352,7 +352,6 @@
   function scrollStep() {
     var x = gridBody.scrollLeft();
     var y = win.scrollTop();
-    console.log('scroll', x, y);
     gridBody.scrollLeft(x * 0.6 + targetX * 0.4);
     win.scrollTop(y * 0.6 + targetY * 0.4);
     var step = false;


### PR DESCRIPTION
Issues: Closes #338.
Scope: Patient chart

#### User-visible changes

There are five buttons in the lower-right corner: up, down, left, right, and a "home" button that centers the view on the column for the current time.  The buttons have large hit regions, but they are small  semitransparent shapes to minimize interference with reading the chart.

Tapping any of these buttons causes the view to scroll.  There is a little bit of animation to provide visual context, but the animation is designed so that:
  - It always finishes quickly.
  - The final few frames of the animation have the same easing curve regardless of the distance travelled.
  - The animation never impedes the operation of the scroll buttons.

Tapping a button always moves the ultimate destination by a consistent amount, even if an animation is still in progress.

![scroll-buttons](https://user-images.githubusercontent.com/236086/60936295-e75a6580-a2cc-11e9-99af-aaf8dcb92c47.png)
