### PR TITLE
Sign release APKs in CircleCI using 'zestybuendia' keystore.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             export ANDROID_PATH=/opt/android/sdk
             ./gradlew assembleDebug
             mkdir -p /tmp/artifacts
-            cp app/build/outputs/apk/debug/app-debug.apk /tmp/artifacts/buendia-client-${PACKAGE_VERSION}.apk
+            cp app/build/outputs/apk/debug/app-debug.apk /tmp/artifacts/buendia-client-${PACKAGE_VERSION}-debug.apk
 
       - run:
           name: Run Tests
@@ -52,6 +52,66 @@ jobs:
       #- store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
       #path: app/build/test-results
 
+  release:
+    working_directory: ~/client
+    docker:
+      - image: circleci/android:api-23
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - checkout
+
+      - run:
+          name: Init client-lib submodule
+          command: git submodule update --init client-libs
+
+      - run:
+          name: Get package version
+          command: echo "export PACKAGE_VERSION=$(.circleci/get_package_version)" >> $BASH_ENV
+
+      - restore_cache:
+          keys:
+            - buendia-client-v1-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+            - buendia-client-v1-{{ checksum "build.gradle" }}-
+            - buendia-client-v1-{{ checksum "build.gradle" }}-
+      - run:
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: buendia-client-v1-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+
+      - run:
+          name: Save keystore
+          command: |
+            echo "$ANDROID_KEYSTORE" | base64 -d > $ANDROID_KEYSTORE_FILE
+      
+      - run:
+          name: Build release APK
+          command: |
+            export ANDROID_PATH=/opt/android/sdk
+            ./gradlew -PversionNumber=${PACKAGE_VERSION} --no-daemon assembleRelease
+            mkdir -p /tmp/artifacts
+            cp app/build/outputs/apk/release/app-release.apk /tmp/artifacts/buendia-client-${PACKAGE_VERSION}.apk
+
+      - run:
+          name: Verify APK signature
+          command: |
+            keytool -list -printcert -jarfile /tmp/artifacts/buendia-client-${PACKAGE_VERSION}.apk | tee /tmp/cert.txt
+            grep -q Buendia /tmp/cert.txt
+
+      - run:
+          name: Run Tests
+          # lint is slightly busted for us here
+          # command: ./gradlew lint test
+          command: ./gradlew test
+
+      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/ 
+          path: /tmp/artifacts
+          destination: artifacts
+ 
 workflows:
   version: 2
   dev-build:
@@ -68,7 +128,7 @@ workflows:
     # Ensure that tagged releases get their own CircleCI build:
     # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
     jobs:
-      - build:
+      - release:
           filters:
             tags:
               only: /^v.*/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -232,11 +232,20 @@ android {
     }
 
     signingConfigs {
-        release {
-            storeFile file(new File(releaseRepoRoot, 'keys/org.projectbuendia.client.jks'))
-            storePassword ''
-            keyAlias 'org.projectbuendia.client'
-            keyPassword ''
+        if (System.getenv("CI")) {
+            release {
+                keyAlias 'buendia'
+                keyPassword System.getenv('ANDROID_KEYSTORE_PASSWORD')
+                storeFile file(System.getenv('ANDROID_KEYSTORE_FILE'))
+                storePassword System.getenv('ANDROID_KEYSTORE_PASSWORD')
+            }
+        } else {
+            release {
+                storeFile file(new File(releaseRepoRoot, 'keys/org.projectbuendia.client.jks'))
+                storePassword ''
+                keyAlias 'org.projectbuendia.client'
+                keyPassword ''
+            }
         }
     }
 
@@ -277,14 +286,20 @@ gradle.taskGraph.whenReady {
             if (!android.signingConfigs.release.storeFile.exists()) {
                 throw new IllegalStateException("To perform a release build, you must have the release repo cloned at ${releaseRepoRoot}.")
             }
-            if (System.console() == null) {
+
+            if (System.console() == null && !System.getenv("CI")) {
                 throw new IllegalStateException("Assembling the release build only works from command line with the Gradle Daemon disabled. Please run ./gradlew :app:assembleRelease.")
             }
-            def pass = new String(System.console().readPassword("\nPlease enter key passphrase: "))
-            if (!pass) {
-                throw new IllegalArgumentException("You must enter a password to proceed.")
+            if (!android.signingConfigs.release.storePassword || !android.signingConfigs.release.keyPassword) {
+                if (System.getenv("CI")) {
+                    throw new IllegalArgumentException("ANDROID_KEYSTORE_PASSWORD must be set in the environment.")
+                }
+                def pass = new String(System.console().readPassword("\nPlease enter key passphrase: "))
+                if (!pass) {
+                    throw new IllegalArgumentException("You must enter a password to proceed.")
+                }
+                android.signingConfigs.release.storePassword = pass
+                android.signingConfigs.release.keyPassword = pass
             }
-            android.signingConfigs.release.storePassword = pass
-            android.signingConfigs.release.keyPassword = pass
         }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,7 +133,7 @@ logger.info("Version number: ${versionString}")
 logger.info("Version code: ${versionInteger}")
 
 // This is where to look for the .apk signing key.
-def releaseRepoRoot = file('../../release/')
+def clientRoot = file('../')
 
 // OpenMRS server for demos (kept at tip of dev branch, with scratch data).
 def serverDev = 'demo.buendia.org'  // an AWS machine running Linux AMI 2017.09
@@ -241,9 +241,9 @@ android {
             }
         } else {
             release {
-                storeFile file(new File(releaseRepoRoot, 'keys/org.projectbuendia.client.jks'))
+                storeFile file(new File(clientRoot, 'zestybuendia.jks'))
                 storePassword ''
-                keyAlias 'org.projectbuendia.client'
+                keyAlias 'buendia'
                 keyPassword ''
             }
         }
@@ -283,23 +283,23 @@ android {
 gradle.taskGraph.whenReady {
     taskGraph ->
         if (taskGraph.hasTask(':app:assembleRelease')) {
-            if (!android.signingConfigs.release.storeFile.exists()) {
-                throw new IllegalStateException("To perform a release build, you must have the release repo cloned at ${releaseRepoRoot}.")
+            def cfg = android.signingConfigs.release
+            if (!cfg.storeFile.exists()) {
+                throw new IllegalStateException("No keystore found at ${cfg.storeFile}.")
             }
-
-            if (System.console() == null && !System.getenv("CI")) {
-                throw new IllegalStateException("Assembling the release build only works from command line with the Gradle Daemon disabled. Please run ./gradlew :app:assembleRelease.")
-            }
-            if (!android.signingConfigs.release.storePassword || !android.signingConfigs.release.keyPassword) {
+            if (!cfg.storePassword || !cfg.keyPassword) {
                 if (System.getenv("CI")) {
                     throw new IllegalArgumentException("ANDROID_KEYSTORE_PASSWORD must be set in the environment.")
+                }
+                if (System.console() == null) {
+                    throw new IllegalStateException("Assembling the release build only works from command line with the Gradle Daemon disabled. Please run ./gradlew --no-daemon :app:assembleRelease.")
                 }
                 def pass = new String(System.console().readPassword("\nPlease enter key passphrase: "))
                 if (!pass) {
                     throw new IllegalArgumentException("You must enter a password to proceed.")
                 }
-                android.signingConfigs.release.storePassword = pass
-                android.signingConfigs.release.keyPassword = pass
+                cfg.storePassword = pass
+                cfg.keyPassword = pass
             }
         }
 }

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -22,5 +22,6 @@
     <issue id="ConstantConditions" severity="warning" />
     <issue id="InvalidPackage" severity="warning" />
     <issue id="OldTargetApi" severity="warning" />
+    <issue id="ExpiredTargetSdkVersion" severity="warning" />
     <issue id="UnusedDeclaration" severity="warning" />
 </lint>


### PR DESCRIPTION
Scope: Add CircleCI configuration, along with changes to Gradle, to enable building release APKs from a consistent Android developer keystore.

Requested reviewers: @zestyping 

#### User-visible changes

Users will be able to upgrade from this point forward without an "app not found" error.

#### Internal changes

This CircleCI configuration requires the presence of `ANDROID_KEYSTORE` and `ANDROID_KEYSTORE_PASSWORD` variables set in the [project environment](https://circleci.com/gh/projectbuendia/client/edit#env-vars).

The `ANDROID_KEYSTORE` env variable was set by running `base64 < zestybuendia.jks | pbcopy` on a local MacOS laptop, and then pasting the results into the CircleCI config UI.

#### Verification performed

This configuration was tested on CircleCI in [build #115](https://circleci.com/gh/projectbuendia/client/115#artifacts/containers/0).

#### Screenshots

<img width="925" alt="Screen Shot 2019-07-09 at 19 40 33" src="https://user-images.githubusercontent.com/57596/60936288-7346a000-a281-11e9-901d-a2a6686c71ca.png">
