### PR TITLE
Sort and colour-code orders by route of administration.

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -115,6 +115,9 @@ th[scope="rowgroup"] {
 .order .overdose { background: #c8f; }
 .order .overdose .given, .order .overdose .extra-given { color: #c00; }
 
+.route-IV .medication { color: #c60; }
+.route-PO .medication { color: #084; }
+
 th.command { /* should match @style/ActionButton */
   font-weight: bold;
   color: #09e;

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -139,7 +139,7 @@
     </tr>
     {% for order in orders %}
       {% set ins = order.instructions %}
-      <tr class="order">
+      <tr class="order route-{{ins.route}}">
         <th scope="row" onclick="controller.onOrderHeadingPressed('{{order.uuid}}')">
           {% if ins.notes is not empty %}
             <div class="notes">{{ins.notes | slice(0, min(30, ins.notes|length))}}</div>
@@ -151,7 +151,6 @@
         {% set past = true %}
         {% set future = false %}
         {% set started = false %}
-        {% set stopped = false %}
         {% set divisionIndex = 0 %}
         {% set summarize = ins.frequency > numColumnsPerDay %}
 
@@ -165,7 +164,7 @@
               {% set totalScheduled = 0 %}
               {% set totalGiven = 0 %}
               <div class="divisions">
-                {% if started and not stopped %}
+                {% if started %}
                   {% for division in get_order_divisions(order, column.date) %}
                     {% set current = interval_contains(division, now) %}
                     {% if current %} {% set past = false %} {% endif %}
@@ -174,9 +173,6 @@
                     {% set given = counts[divisionIndex] %}
                     {% if given is null %} {% set given = 0 %} {% endif %}
                     {% set status = (given < scheduled) ? 'underdose' : (given > scheduled) ? 'overdose' : (scheduled > 0) ? 'full-dose' : '' %}
-                    {% if order.isSeries and interval_contains(division, order.stop) %}
-                      {% set stopped = true %}
-                    {% endif %}
 
                     <div class="division {{past ? 'past' : ''}} {{current ? 'now' : ''}} {{future ? 'future' : ''}} {{status}} {{stop ? 'stop' : ''}}"
                         onclick="controller.onOrderCellPressed('{{order.uuid}}', {{column.start.millis}})">

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -68,6 +68,8 @@ import org.projectbuendia.client.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -555,6 +557,13 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
         Map<String, Obs> latestObservations =
             new HashMap<>(mChartHelper.getLatestObservations(mPatientUuid));
         List<Order> orders = mChartHelper.getOrders(mPatientUuid);
+        Collections.sort(orders, new Comparator<Order>() {
+            @Override public int compare(Order a, Order b) {
+                int result = a.instructions.route.compareTo(b.instructions.route);
+                if (result != 0) return result;
+                return a.start.compareTo(b.start);
+            }
+        });
         mOrdersByUuid = new HashMap<>();
         for (Order order : orders) {
             mOrdersByUuid.put(order.uuid, order);


### PR DESCRIPTION
Scope: Patient chart

#### User-visible changes

Orders are now grouped by route of administration (and then ordered by start time within these groups).  IV treatments are colour-coded orange; PO treatments are colour-coded green.  (Open to colour suggestions!  There's some risk of clashing with the meanings of the colours for underdose, overdose, etc.)

![route-colours](https://user-images.githubusercontent.com/236086/60937404-83d23700-a2d0-11e9-827b-90e2f710683e.png)
