### PR TITLE
Add tick marks indicating when each order was executed.

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -101,22 +101,38 @@ th[scope="rowgroup"] {
 /* Orders */
 .order th { padding: 0 4px 0 16px; line-height: 1.1em; vertical-align: middle; }
 .medication { font-weight: bold; }
-.order td { position: relative; }
+.route-IV .medication { color: #c60; }
+.route-PO .medication { color: #084; }
+
+.order td { position: relative; }  /* contains positioned .divisions and .summary */
 .order .divisions, .order .summary {
     position: absolute; top: 0; left: 0; bottom: 0; right: 0;
 }
-.order .divisions { display: flex; flex-direction: row; }
+
+.order .divisions { display: flex; flex-direction: row; }  /* contains flexed .division */
 .order .division { flex-basis: 0; flex-grow: 1; }
 
-.order .scheduled { background: #ddd; }
-.order .past.underdose { background: #fda; }
-.order .now.underdose { background: #faa; }
-.order .full-dose { background: #afa; }
-.order .overdose { background: #c8f; }
+.order .past.underdose { background: #fed; }
+.order .now.underdose { background: #fcc; }
+.order .future.underdose { background: #eee; }
+.order .full-dose { background: #dfd; }
+.order .overdose { background: #ecf; }
 .order .overdose .given, .order .overdose .extra-given { color: #c00; }
 
-.route-IV .medication { color: #c60; }
-.route-PO .medication { color: #084; }
+.division { position: relative; }  /* contains positioned .execution */
+.execution {
+  width: 0.3rem;
+  margin-left: 0.15rem;
+  position: absolute;
+  top: 70%;
+  bottom: 0;
+  opacity: 0.4;
+  background: #000;
+}
+.past.underdose .execution { background: #f80; }
+.now.underdose .execution { background: #f00; }
+.full-dose .execution { background: #080; }
+.overdose .execution { background: #80f; }
 
 th.command { /* should match @style/ActionButton */
   font-weight: bold;

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -74,7 +74,7 @@
       {% set prevStop = columns[0].start %}
       {% for column in columns %}
         {% if column.start != prevStop %}
-          <th scope="rowgroup" class="gap" rowspan={{rows.size + 1}}>&nbsp;</th>
+          <th scope="rowgroup" class="gap" rowspan={{(rows | length) + 1}}>&nbsp;</th>
         {% endif %}
         {% if column.start == column.dayStart %}
           <th scope="rowgroup" colspan={{numColumnsPerDay}}>&nbsp;</th>
@@ -129,7 +129,7 @@
       {% set prevStop = columns[0].start %}
       {% for column in columns %}
         {% if column.start != prevStop %}
-          <th scope="rowgroup" class="gap" rowspan={{rows.size + 1}}>&nbsp;</th>
+          <th scope="rowgroup" class="gap" rowspan={{(rows | length) + 1}}>&nbsp;</th>
         {% endif %}
         {% if column.start == column.dayStart %}
           <th scope="rowgroup" colspan={{numColumnsPerDay}}>&nbsp;</th>
@@ -147,19 +147,20 @@
           <div class="medication">{{ins.medication}}&nbsp;{{ins.route}}</div>
           <div>{{ins.dosage}}&nbsp;</div>
         </th>
-        {% set counts = executionCounts[order.uuid] %}
+        {% set executionHistory = executionHistories[order.uuid] %}
         {% set past = true %}
         {% set future = false %}
         {% set started = false %}
         {% set divisionIndex = 0 %}
-        {% set summarize = ins.frequency > numColumnsPerDay %}
+        {% set showPerDivisionCounts = numColumnsPerDay >= ins.frequency %}
 
         {% for column in columns %}
           {% if column.start == column.dayStart %}
             {% if column.date == order.startDay %}
               {% set started = true %}
             {% endif %}
-            <td class="day" colspan={{numColumnsPerDay}}>
+            <td class="day" colspan={{numColumnsPerDay}}
+                onclick="controller.onOrderCellPressed('{{order.uuid}}', {{column.start.millis}})">
               &nbsp; {# ensure uniform height #}
               {% set totalScheduled = 0 %}
               {% set totalGiven = 0 %}
@@ -170,18 +171,20 @@
                     {% if current %} {% set past = false %} {% endif %}
 
                     {% set scheduled = count_scheduled_doses(order, division) %}
-                    {% set given = counts[divisionIndex] %}
-                    {% if given is null %} {% set given = 0 %} {% endif %}
+                    {% set executionTimes = executionHistory[divisionIndex] %}
+                    {% set given = executionTimes | length %}
                     {% set status = (given < scheduled) ? 'underdose' : (given > scheduled) ? 'overdose' : (scheduled > 0) ? 'full-dose' : '' %}
 
-                    <div class="division {{past ? 'past' : ''}} {{current ? 'now' : ''}} {{future ? 'future' : ''}} {{status}} {{stop ? 'stop' : ''}}"
-                        onclick="controller.onOrderCellPressed('{{order.uuid}}', {{column.start.millis}})">
-                      {% if summarize %}
-                        {# leave blank #}
-                      {% elseif given == scheduled and given > 0 %}
-                        <span class="given">{{given}}</span>
-                      {% elseif given + scheduled > 0 %}
-                        <span class="given">{{given}}</span>/{{scheduled}}
+                    <div class="division {{past ? 'past' : ''}} {{current ? 'now' : ''}} {{future ? 'future' : ''}} {{status}} {{stop ? 'stop' : ''}}">
+                      {% for percentage in executionTimes %}
+                        <div class="execution" style="left: {{percentage}}%"></div>
+                      {% endfor %}
+                      {% if showPerDivisionCounts and given + scheduled > 0 %}
+                        {% if given == scheduled %}
+                          <span class="given">{{given}}</span>
+                        {% else %}
+                          <span class="given">{{given}}</span>/{{scheduled}}
+                        {% endif %}
                       {% else %}
                         &nbsp; {# ensure uniform height #}
                       {% endif %}
@@ -192,9 +195,8 @@
                     {% set totalGiven = totalGiven + given %}
                     {% set divisionIndex = divisionIndex + 1 %}
                   {% endfor %}
-                  {% if summarize %}
-                    <div class="summary"
-                        onclick="controller.onOrderCellPressed('{{order.uuid}}', {{column.start.millis}})">
+                  {% if not showPerDivisionCounts %}
+                    <div class="summary">
                       {% if totalGiven == totalScheduled and totalGiven > 0 %}
                         <span class="given">{{totalGiven}}</span>
                       {% elseif totalGiven + totalScheduled > 0 %}

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ExecutionHistory.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ExecutionHistory.java
@@ -1,0 +1,70 @@
+package org.projectbuendia.client.ui.chart;
+
+import android.support.annotation.NonNull;
+import android.util.SparseArray;
+
+import com.google.common.collect.ImmutableList;
+
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.projectbuendia.client.models.Order;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A sparse infinite list that maps division indexes to the execution times
+ * contained in each division.  To optimize for use in CSS in the chart HTML, each
+ * execution time is represented as an integer percentage of the division interval.
+ */
+public class ExecutionHistory extends AbstractList<List<Integer>> {
+    private final Order order;
+    private final SparseArray<List<Integer>> timesByIndex = new SparseArray<>();
+
+    private static final List<Integer> EMPTY_LIST = ImmutableList.of();
+
+    /** Constructs a read-only, empty execution history. */
+    public ExecutionHistory() {
+        this.order = null;
+    }
+
+    /** Constructs an appendable execution history. */
+    public ExecutionHistory(Order order) {
+        this.order = order;
+    }
+
+    /** Adds an execution time to the set of times for this order. */
+    public void add(DateTime time) {
+        if (order == null) {
+            throw new UnsupportedOperationException();
+        }
+        int index = order.getDivisionIndex(time);
+        if (timesByIndex.get(index) == null) {
+            timesByIndex.put(index, new ArrayList<Integer>());
+        }
+        Interval division = order.getDivision(index);
+        long startMillis = division.getStartMillis();
+        long durationMillis = division.toDurationMillis();
+        int percentage = (int) (100 * (time.getMillis() - startMillis) / durationMillis);
+        timesByIndex.get(index).add(percentage);
+    }
+
+    /** Sorts all the lists of execution times within each division. */
+    public void sort() {
+        for (int i = 0; i < timesByIndex.size(); i++) {
+            Collections.sort(timesByIndex.valueAt(i));
+        }
+    }
+
+    /** Gets the list of execution times for a given division index. */
+    @Override public @NonNull List<Integer> get(int index) {
+        return timesByIndex.get(index, EMPTY_LIST);
+    }
+
+    /** Returns MAX_VALUE to avoid ever throwing IndexOutOfBoundsException. */
+    @Override public int size() {
+        return Integer.MAX_VALUE;
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -557,13 +557,6 @@ final class PatientChartController implements ChartRenderer.GridJsInterface {
         Map<String, Obs> latestObservations =
             new HashMap<>(mChartHelper.getLatestObservations(mPatientUuid));
         List<Order> orders = mChartHelper.getOrders(mPatientUuid);
-        Collections.sort(orders, new Comparator<Order>() {
-            @Override public int compare(Order a, Order b) {
-                int result = a.instructions.route.compareTo(b.instructions.route);
-                if (result != 0) return result;
-                return a.start.compareTo(b.start);
-            }
-        });
         mOrdersByUuid = new HashMap<>();
         for (Order order : orders) {
             mOrdersByUuid.put(order.uuid, order);

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PebbleExtension.java
@@ -308,6 +308,20 @@ public class PebbleExtension extends AbstractExtension {
         }
     }
 
+    static class GetOrderExecutionHistoryFunction implements Function {
+        @Override public List<String> getArgumentNames() {
+            return ImmutableList.of("order_uuid", "column");
+        }
+
+        @Override public Object execute(Map<String, Object> args) {
+            // TODO/robustness: Check types before casting.
+            String orderUuid = (String) args.get("order_uuid");
+            Column column = (Column) args.get("column");
+            Integer count = column.executionCountsByOrderUuid.get(orderUuid);
+            return count == null ? 0 : count;
+        }
+    }
+
     static class GetOrderExecutionCountFunction implements Function {
         @Override public List<String> getArgumentNames() {
             return ImmutableList.of("order_uuid", "column");

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -100,7 +100,7 @@ public class Utils {
     }
 
     /** The same operation as map.getOrDefault(key), which is only available in API 24+. */
-    public static <K, V> V getOrDefault(Map<K, V> map, K key, V defaultValue) {
+    public static <K, V> V getOrDefault(Map<K, V> map, Object key, V defaultValue) {
         return map.containsKey(key) ? map.get(key) : defaultValue;
     }
 
@@ -120,6 +120,16 @@ public class Utils {
             array[i++] = item;
         }
         return array;
+    }
+
+    /** Provides Math.floorMod for Android versions prior to API level 24, d > 0. */
+    public static int floorMod(int x, int d) {
+        return ((x % d) + d) % d;
+    }
+
+    /** Provides Math.floorDiv for Android versions prior to API level 24, d > 0. */
+    public static int floorDiv(int x, int d) {
+        return (x - floorMod(x, d)) / d;
     }
 
 
@@ -475,7 +485,6 @@ public class Utils {
         }
         return (String) id;
     }
-
 
 
     // ==== Ordering ====


### PR DESCRIPTION
Scope: Patient chart

#### User-visible changes

In each treatment row, there are now small ticks in each order division cell indicating when treatment orders were carried out.

The shading of the cells is lighter (purple/pink/green/orange/grey indicating dosing status) and the tick marks are more saturated colours that match the shading.

The tick marks are drawn partially transparent, so that when many tick marks are squished together, the mark appears more intense.

#### Internal changes

We now pass a list of order execution times, instead of just the number of executions, to the Pebble template.  Some new logic had to be added to `Order` to compute the division boundaries and indexes.

#### Screenshots

Some examples:

![elijah-ticks-detail-1](https://user-images.githubusercontent.com/236086/60963677-b81a1780-a311-11e9-94a4-2d3c8589d1e0.png)

![elijah-ticks-detail-2](https://user-images.githubusercontent.com/236086/60963678-b8b2ae00-a311-11e9-841f-2b49e3934b9f.png)

![garvey-ticks-detail](https://user-images.githubusercontent.com/236086/60963679-b8b2ae00-a311-11e9-8a72-b760d5e8d8b0.png)

![darth-overlapping-ticks-detail](https://user-images.githubusercontent.com/236086/60964401-82762e00-a313-11e9-9b5e-8b6ae4e72efa.png)

It's a bit subtle, but if you look closely at the last example above, you can see that the transparency of the ticks makes the stack of 7 ticks appear darker than the stack of 2 ticks nearby.