### PR TITLE
Build our own sync scheduler, to replace the Android SyncAdapter

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/FakeSyncManager.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/FakeSyncManager.java
@@ -30,11 +30,7 @@ public class FakeSyncManager extends SyncManager {
         mSyncing = syncing;
     }
 
-    @Override public boolean isSyncPending() {
-        return false;
-    }
-
-    @Override public boolean isSyncActive() {
+    @Override public boolean isSyncRunningOrPending() {
         return mSyncing;
     }
 

--- a/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.projectbuendia.client.FakeAppLocationTreeFactory;
 import org.projectbuendia.client.FakeSyncManager;
+import org.projectbuendia.client.R;
 import org.projectbuendia.client.events.actions.SyncCancelRequestedEvent;
 import org.projectbuendia.client.events.data.AppLocationTreeFetchedEvent;
 import org.projectbuendia.client.events.sync.SyncCanceledEvent;
@@ -341,9 +342,9 @@ public final class LocationListControllerTest {
         LocationTree locationTree = FakeAppLocationTreeFactory.build();
         mFakeEventBus.post(new AppLocationTreeFetchedEvent(locationTree));
         // WHEN a periodic sync reports progress
-        mFakeEventBus.post(new SyncProgressEvent(10, "Foo synced"));
+        mFakeEventBus.post(new SyncProgressEvent(10, R.string.syncing_users));
         // THEN the activity does not notify the UI
-        verify(mMockFragmentUi, times(0)).showIncrementalSyncProgress(10, "Foo synced");
+        verify(mMockFragmentUi, times(0)).showIncrementalSyncProgress(10, R.string.syncing_users);
     }
 
     /** Tests that 'sync failed' messages are ignored when the data model is already available. */

--- a/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
@@ -71,7 +71,7 @@ public final class LocationListControllerTest {
         // WHEN the controller is initialized
         mController.init();
         // THEN the controller does not start a new sync
-        assertFalse(mFakeSyncManager.isSyncActive());
+        assertFalse(mFakeSyncManager.isSyncRunningOrPending());
     }
 
     /** Tests that init kicks off a sync if the data model is unavailable. */
@@ -85,7 +85,7 @@ public final class LocationListControllerTest {
         // WHEN the controller is initialized
         mController.init();
         // THEN the controller requests a sync
-        assertTrue(mFakeSyncManager.isSyncActive());
+        assertTrue(mFakeSyncManager.isSyncRunningOrPending());
     }
 
     /** Tests that suspend() unregisters any subscribers from the event bus. */
@@ -191,7 +191,7 @@ public final class LocationListControllerTest {
         LocationTree locationTree = FakeAppLocationTreeFactory.emptyTree();
         mFakeEventBus.post(new AppLocationTreeFetchedEvent(locationTree));
         // THEN the controller starts a new sync
-        assertTrue(mFakeSyncManager.isSyncActive());
+        assertTrue(mFakeSyncManager.isSyncRunningOrPending());
     }
 
     /** Tests that loading an empty location tree does not hide the sync failed dialog. */
@@ -234,7 +234,7 @@ public final class LocationListControllerTest {
         LocationTree locationTree = FakeAppLocationTreeFactory.build();
         mFakeEventBus.post(new AppLocationTreeFetchedEvent(locationTree));
         // THEN the controller does not start a new sync
-        assertTrue(!mFakeSyncManager.isSyncActive());
+        assertTrue(!mFakeSyncManager.isSyncRunningOrPending());
     }
 
     /**

--- a/app/src/main/java/org/projectbuendia/client/App.java
+++ b/app/src/main/java/org/projectbuendia/client/App.java
@@ -12,6 +12,7 @@
 package org.projectbuendia.client;
 
 import android.app.Application;
+import android.content.ContentProviderClient;
 import android.preference.PreferenceManager;
 
 import com.android.volley.VolleyLog;
@@ -23,6 +24,7 @@ import org.odk.collect.android.application.Collect;
 import org.projectbuendia.client.diagnostics.HealthMonitor;
 import org.projectbuendia.client.net.OpenMrsConnectionDetails;
 import org.projectbuendia.client.net.Server;
+import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.user.UserManager;
 
 import javax.inject.Inject;
@@ -34,6 +36,7 @@ public class App extends Application {
 
     /** The current instance of the application. */
     private static App sInstance;
+    private static ContentProviderClient sContentProviderClient;
     private static UserManager sUserManager;
     private static Server sServer;
     private static OpenMrsConnectionDetails sConnectionDetails;
@@ -45,6 +48,10 @@ public class App extends Application {
 
     public static synchronized App getInstance() {
         return sInstance;
+    }
+
+    public static synchronized ContentProviderClient getContentProviderClient() {
+        return sContentProviderClient;
     }
 
     public static synchronized UserManager getUserManager() {
@@ -82,6 +89,7 @@ public class App extends Application {
 
         synchronized (App.class) {
             sInstance = this;
+            sContentProviderClient = getContentResolver().acquireContentProviderClient(Contracts.Users.CONTENT_URI);
             sUserManager = mUserManager; // TODO: Remove when Daggered.
             sConnectionDetails = mOpenMrsConnectionDetails; // TODO: Remove when Daggered.
             sServer = mServer; // TODO: Remove when Daggered.

--- a/app/src/main/java/org/projectbuendia/client/AppModule.java
+++ b/app/src/main/java/org/projectbuendia/client/AppModule.java
@@ -25,6 +25,7 @@ import org.projectbuendia.client.sync.SyncAdapterSyncScheduler;
 import org.projectbuendia.client.sync.ChartDataHelper;
 import org.projectbuendia.client.sync.SyncAccountService;
 import org.projectbuendia.client.sync.SyncManager;
+import org.projectbuendia.client.sync.ThreadedSyncScheduler;
 import org.projectbuendia.client.ui.BaseActivity;
 import org.projectbuendia.client.ui.SettingsActivity;
 import org.projectbuendia.client.ui.UpdateNotificationController;
@@ -111,9 +112,11 @@ public final class AppModule {
     }
 
     @Provides
-    @Singleton SyncManager provideSyncManager() {
+    @Singleton SyncManager provideSyncManager(AppSettings settings) {
         return new SyncManager(
-            new SyncAdapterSyncScheduler(SyncAccountService.getAccount(), Contracts.CONTENT_AUTHORITY)
+            settings.getUseSyncAdapter() ?
+                new SyncAdapterSyncScheduler(SyncAccountService.getAccount(), Contracts.CONTENT_AUTHORITY) :
+                new ThreadedSyncScheduler(mApp.getApplicationContext())
         );
     }
 

--- a/app/src/main/java/org/projectbuendia/client/AppModule.java
+++ b/app/src/main/java/org/projectbuendia/client/AppModule.java
@@ -18,7 +18,10 @@ import android.preference.PreferenceManager;
 import org.projectbuendia.client.diagnostics.DiagnosticsModule;
 import org.projectbuendia.client.events.EventsModule;
 import org.projectbuendia.client.models.AppModelModule;
+import org.projectbuendia.client.models.tasks.AddPatientTask;
 import org.projectbuendia.client.net.NetModule;
+import org.projectbuendia.client.providers.Contracts;
+import org.projectbuendia.client.sync.SyncAdapterSyncScheduler;
 import org.projectbuendia.client.sync.ChartDataHelper;
 import org.projectbuendia.client.sync.SyncAccountService;
 import org.projectbuendia.client.sync.SyncManager;
@@ -26,8 +29,8 @@ import org.projectbuendia.client.ui.BaseActivity;
 import org.projectbuendia.client.ui.SettingsActivity;
 import org.projectbuendia.client.ui.UpdateNotificationController;
 import org.projectbuendia.client.ui.chart.PatientChartActivity;
-import org.projectbuendia.client.ui.dialogs.GoToPatientDialogFragment;
 import org.projectbuendia.client.ui.dialogs.EditPatientDialogFragment;
+import org.projectbuendia.client.ui.dialogs.GoToPatientDialogFragment;
 import org.projectbuendia.client.ui.lists.BaseSearchablePatientListActivity;
 import org.projectbuendia.client.ui.lists.FilteredPatientListActivity;
 import org.projectbuendia.client.ui.lists.LocationListActivity;
@@ -77,7 +80,8 @@ import dagger.Provides;
         UpdateNotificationController.class,
         LoginActivity.class,
         LoginFragment.class,
-        SettingsActivity.class
+        SettingsActivity.class,
+        AddPatientTask.class
     },
     staticInjections = {
         SyncAccountService.class
@@ -107,8 +111,10 @@ public final class AppModule {
     }
 
     @Provides
-    @Singleton SyncManager provideSyncManager(AppSettings settings) {
-        return new SyncManager(settings);
+    @Singleton SyncManager provideSyncManager() {
+        return new SyncManager(
+            new SyncAdapterSyncScheduler(SyncAccountService.getAccount(), Contracts.CONTENT_AUTHORITY)
+        );
     }
 
     @Provides

--- a/app/src/main/java/org/projectbuendia/client/AppSettings.java
+++ b/app/src/main/java/org/projectbuendia/client/AppSettings.java
@@ -79,17 +79,24 @@ public class AppSettings {
         return mSharedPreferences.getInt("apk_update_interval_secs", APK_UPDATE_INTERVAL_DEFAULT);
     }
 
-    /** Gets the flag for whether to save filled-in forms locally. */
+    /** Gets the setting for whether to save filled-in forms locally. */
     public boolean getKeepFormInstancesLocally() {
         return mSharedPreferences.getBoolean("keep_form_instances", false);
     }
 
+    /** Returns true if the app should skip directly to a patient chart on startup. */
     public boolean shouldSkipToPatientChart() {
         return !getStartingPatientId().isEmpty();
     }
 
+    /** Gets the patient ID of the chart to skip directly to on startup, or "". */
     public @NonNull String getStartingPatientId() {
         return mSharedPreferences.getString("starting_patient_id", "").trim();
+    }
+
+    /** Gets the setting for whether to use the unreliable SyncAdapter framework. */
+    public boolean getUseSyncAdapter() {
+        return mSharedPreferences.getBoolean("use_sync_adapter", false);
     }
 
     /** Gets the flag indicating whether the sync account has been initialized. */

--- a/app/src/main/java/org/projectbuendia/client/events/sync/SyncProgressEvent.java
+++ b/app/src/main/java/org/projectbuendia/client/events/sync/SyncProgressEvent.java
@@ -11,17 +11,15 @@
 
 package org.projectbuendia.client.events.sync;
 
-import android.support.annotation.Nullable;
-
 /** An event bus event giving details on the last-reported progress of an in-progress sync. */
 public class SyncProgressEvent {
     /** The progress completed so far, as a percentage. */
     public int progress;
-    /** A label describing the current sync status. */
-    @Nullable public String label;
+    /** The resource ID of a string label describing the current sync status. */
+    public int messageId;
 
-    public SyncProgressEvent(int progress, @Nullable String label) {
+    public SyncProgressEvent(int progress, int messageId) {
         this.progress = progress;
-        this.label = label;
+        this.messageId = messageId;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
@@ -213,12 +213,11 @@ public class BuendiaSyncEngine implements SyncEngine {
     }
 
     private void broadcastSyncProgress(int progress, @StringRes int messageId) {
-        String label = context.getResources().getString(messageId);
         context.sendBroadcast(
             new Intent(context, SyncManager.SyncStatusBroadcastReceiver.class)
                 .putExtra(SyncManager.SYNC_STATUS, SyncManager.IN_PROGRESS)
                 .putExtra(SyncManager.SYNC_PROGRESS, progress)
-                .putExtra(SyncManager.SYNC_PROGRESS_LABEL, label)
+                .putExtra(SyncManager.SYNC_MESSAGE_ID, messageId)
                 .addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
         );
     }

--- a/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
@@ -101,6 +101,7 @@ public class BuendiaSyncEngine implements SyncEngine {
 
     /** Not thread-safe but, by default, this will never be called multiple times in parallel. */
     @Override public void sync(Bundle options, ContentProviderClient client, SyncResult result) {
+        isCancelled = false;
         broadcastSyncStatus(SyncManager.STARTED);
 
         Intent syncFailedIntent =
@@ -200,7 +201,9 @@ public class BuendiaSyncEngine implements SyncEngine {
     private synchronized void checkCancellation(String when) throws CancellationException {
         if (isCancelled) {
             isCancelled = false;
-            throw new CancellationException("Sync cancelled " + when);
+            String message = "Sync cancelled " + when;
+            LOG.w(message);
+            throw new CancellationException(message);
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
@@ -23,7 +23,6 @@ import android.os.IBinder;
 
 import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.BuildConfig;
-import org.projectbuendia.client.sync.BuendiaSyncEngine.SyncOption;
 import org.projectbuendia.client.utils.Logger;
 
 import javax.inject.Inject;
@@ -38,7 +37,6 @@ public class SyncAccountService extends Service {
 
     public static final String ACCOUNT_NAME = "sync";
     private static final Logger LOG = Logger.create();
-    private static final int SYNC_PERIOD_SEC = 5*60;  // 5 minutes (in seconds)
     @Inject static AppSettings sSettings;
     @Inject static SyncManager sSyncManager;
 
@@ -63,7 +61,7 @@ public class SyncAccountService extends Service {
             // Enable a periodic full sync for the account with a period of SYNC_PERIOD_SEC.
             Bundle options = new Bundle();
             options.putBoolean(SyncOption.FULL_SYNC.name(), true);
-            sSyncManager.setPeriodicSync(options, SYNC_PERIOD_SEC);
+            sSyncManager.initPeriodicSyncs();
             return true;
         }
         return false;

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
@@ -23,6 +23,7 @@ import android.os.IBinder;
 
 import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.BuildConfig;
+import org.projectbuendia.client.sync.BuendiaSyncEngine.SyncOption;
 import org.projectbuendia.client.utils.Logger;
 
 import javax.inject.Inject;

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
@@ -16,7 +16,6 @@ import android.accounts.Account;
 import android.accounts.AccountAuthenticatorResponse;
 import android.accounts.AccountManager;
 import android.app.Service;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -24,9 +23,7 @@ import android.os.IBinder;
 
 import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.BuildConfig;
-import org.projectbuendia.client.providers.Contracts;
-import org.projectbuendia.client.sync.SyncAdapter.SyncOption;
-import org.projectbuendia.client.sync.SyncAdapter.SyncPhase;
+import org.projectbuendia.client.sync.BuendiaSyncEngine.SyncOption;
 import org.projectbuendia.client.utils.Logger;
 
 import javax.inject.Inject;
@@ -41,15 +38,16 @@ public class SyncAccountService extends Service {
 
     public static final String ACCOUNT_NAME = "sync";
     private static final Logger LOG = Logger.create();
-    private static final long SYNC_PERIOD = 5*60;  // 5 minutes (in seconds)
+    private static final int SYNC_PERIOD_SEC = 5*60;  // 5 minutes (in seconds)
     @Inject static AppSettings sSettings;
+    @Inject static SyncManager sSyncManager;
 
     private Authenticator mAuthenticator;
 
     /** Sets up the sync account for this app. */
     public static void initialize(Context context) {
         if (createAccount(context) || !sSettings.getSyncAccountInitialized()) {
-            startFullSync();
+            sSyncManager.startFullSync();
             sSettings.setSyncAccountInitialized(true);
         }
     }
@@ -62,50 +60,18 @@ public class SyncAccountService extends Service {
         Account account = getAccount();
         AccountManager accountManager = (AccountManager) context.getSystemService(ACCOUNT_SERVICE);
         if (accountManager.addAccountExplicitly(account, null, null)) {
-            // Enable automatic sync for the account with a period of SYNC_PERIOD.
-            ContentResolver.setIsSyncable(account, Contracts.CONTENT_AUTHORITY, 1);
-            ContentResolver.setSyncAutomatically(account, Contracts.CONTENT_AUTHORITY, true);
-            Bundle b = new Bundle();
-            b.putBoolean(SyncOption.FULL_SYNC.name(), true);
-            ContentResolver.addPeriodicSync(account, Contracts.CONTENT_AUTHORITY, b, SYNC_PERIOD);
+            // Enable a periodic full sync for the account with a period of SYNC_PERIOD_SEC.
+            Bundle options = new Bundle();
+            options.putBoolean(SyncOption.FULL_SYNC.name(), true);
+            sSyncManager.setPeriodicSync(options, SYNC_PERIOD_SEC);
             return true;
         }
         return false;
     }
 
-    /** Starts a full sync. */
-    public static void startFullSync() {
-        Bundle b = new Bundle();
-        // Request aggressively that the sync should start straight away.
-        b.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
-        b.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
-
-        // Fetch everything
-        b.putBoolean(SyncOption.FULL_SYNC.name(), true);
-        LOG.i("Requesting full sync");
-        ContentResolver.requestSync(getAccount(), Contracts.CONTENT_AUTHORITY, b);
-    }
-
     /** Gets the app's sync account (call initialize() before using this). */
     public static Account getAccount() {
         return new Account(ACCOUNT_NAME, BuildConfig.ACCOUNT_TYPE);
-    }
-
-    /** Starts an sync of just the observations and orders. */
-    public static void startObservationsAndOrdersSync() {
-        // Start by canceling any existing syncs, which may delay this one.
-        ContentResolver.cancelSync(getAccount(), Contracts.CONTENT_AUTHORITY);
-
-        Bundle b = new Bundle();
-        // Request aggressively that the sync should start straight away.
-        b.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
-        b.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
-
-        // Fetch just the newly added observations.
-        b.putBoolean(SyncPhase.SYNC_OBSERVATIONS.name(), true);
-        b.putBoolean(SyncPhase.SYNC_ORDERS.name(), true);
-        LOG.i("Requesting incremental observations / orders sync");
-        ContentResolver.requestSync(getAccount(), Contracts.CONTENT_AUTHORITY, b);
     }
 
     @Override public void onCreate() {

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterService.java
@@ -11,33 +11,60 @@
 
 package org.projectbuendia.client.sync;
 
+import android.accounts.Account;
 import android.app.Service;
+import android.content.AbstractThreadedSyncAdapter;
+import android.content.ContentProviderClient;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SyncResult;
+import android.os.Bundle;
 import android.os.IBinder;
-import android.util.Log;
+
+import org.projectbuendia.client.utils.Logger;
 
 /** A service that holds a singleton SyncAdapter and provides it to the OS on request. */
 public class SyncAdapterService extends Service {
-
-    private static SyncAdapter syncAdapter = null;
+    private static final Logger LOG = Logger.create();
     private static final Object lock = new Object();
+    private static SyncAdapter adapter = null;
 
     public static SyncAdapter getSyncAdapter() {
-        return syncAdapter;
+        return adapter;
     }
 
     @Override public void onCreate() {
-        Log.i("SyncAdapterService", "onCreate");
+        LOG.i("onCreate");
         super.onCreate();
         synchronized (lock) {
-            if (syncAdapter == null) {
-                syncAdapter = new SyncAdapter(getApplicationContext(), true);
+            if (adapter == null) {
+                Context context = getApplicationContext();
+                adapter = new SyncAdapter(context, new BuendiaSyncEngine(context));
             }
         }
     }
 
     @Override public IBinder onBind(Intent intent) {
-        Log.i("SyncAdapter", "onBind");
-        return syncAdapter.getSyncAdapterBinder();
+        LOG.i("onBind");
+        return adapter.getSyncAdapterBinder();
+    }
+
+    /** A wrapper around a SyncEngine that fits the SyncAdapter framework. */
+    private static class SyncAdapter extends AbstractThreadedSyncAdapter {
+        private final SyncEngine engine;
+
+        public SyncAdapter(Context context, SyncEngine engine) {
+            super(context, true);
+            this.engine = engine;
+        }
+
+        @Override public void onSyncCanceled() {
+            engine.cancel();
+        }
+
+        @Override public void onPerformSync(Account account, Bundle extras,
+            String authority, ContentProviderClient client, SyncResult result) {
+            engine.sync(extras, client, result);
+        }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterSyncScheduler.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterSyncScheduler.java
@@ -31,6 +31,7 @@ public class SyncAdapterSyncScheduler implements SyncScheduler {
         if (periodSec > 0) {
             ContentResolver.setIsSyncable(account, authority, 1);
             ContentResolver.setSyncAutomatically(account, authority, true);
+            ContentResolver.setMasterSyncAutomatically(true);
             ContentResolver.addPeriodicSync(account, authority, options, periodSec);
         } else {
             ContentResolver.setSyncAutomatically(account, authority, false);

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterSyncScheduler.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAdapterSyncScheduler.java
@@ -1,0 +1,49 @@
+package org.projectbuendia.client.sync;
+
+import android.accounts.Account;
+import android.content.ContentResolver;
+import android.content.PeriodicSync;
+import android.os.Bundle;
+
+/**
+ * A SyncScheduler that schedules sync operations by making requests to Android's
+ * SyncAdapter framework and praying that it calls the sync engine... someday.
+ * See SyncAdapterService, through which the Android system invokes the SyncEngine.
+ */
+public class SyncAdapterSyncScheduler implements SyncScheduler {
+    private final Account account;
+    private final String authority;
+
+    public SyncAdapterSyncScheduler(Account account, String authority) {
+        this.account = account;
+        this.authority = authority;
+    }
+
+    @Override public void requestSync(Bundle options) {
+        ContentResolver.requestSync(account, authority, options);
+    }
+
+    @Override public void stopSyncing() {
+        ContentResolver.cancelSync(account, authority);
+    }
+
+    @Override public void setPeriodicSync(Bundle options, int periodSec) {
+        if (periodSec > 0) {
+            ContentResolver.setIsSyncable(account, authority, 1);
+            ContentResolver.setSyncAutomatically(account, authority, true);
+            ContentResolver.addPeriodicSync(account, authority, options, periodSec);
+        } else {
+            ContentResolver.setSyncAutomatically(account, authority, false);
+            try {
+                for (PeriodicSync ps : ContentResolver.getPeriodicSyncs(account, authority)) {
+                    ContentResolver.removePeriodicSync(account, authority, ps.extras);
+                }
+            } catch (SecurityException e) { /* ignore */ }
+        }
+    }
+
+    @Override public boolean isRunningOrPending() {
+        return ContentResolver.isSyncActive(account, authority) ||
+            ContentResolver.isSyncPending(account, authority);
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncEngine.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncEngine.java
@@ -6,6 +6,9 @@ import android.os.Bundle;
 
 /** Performs the heavy lifting of a sync (network and database operations). */
 interface SyncEngine {
+    /** Runs a sync as a long blocking operation. */
     void sync(Bundle options, ContentProviderClient client, SyncResult result);
+
+    /** Called by other threads to request cancellation of any currently running sync. */
     void cancel();
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncEngine.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncEngine.java
@@ -1,0 +1,11 @@
+package org.projectbuendia.client.sync;
+
+import android.content.ContentProviderClient;
+import android.content.SyncResult;
+import android.os.Bundle;
+
+/** Performs the heavy lifting of a sync (network and database operations). */
+interface SyncEngine {
+    void sync(Bundle options, ContentProviderClient client, SyncResult result);
+    void cancel();
+}

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
@@ -32,7 +32,7 @@ import de.greenrobot.event.EventBus;
 public class SyncManager {
     private static final Logger LOG = Logger.create();
 
-    private static final int FULL_SYNC_PERIOD_SEC = 5 * 60;  // 5 minutes
+    private static final int FULL_SYNC_PERIOD_SEC = 3 * 60;  // 3 minutes
 
     static final String SYNC_STATUS = "sync-status";
     static final int STARTED = 1;

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
@@ -32,6 +32,8 @@ import de.greenrobot.event.EventBus;
 public class SyncManager {
     private static final Logger LOG = Logger.create();
 
+    private static final int FULL_SYNC_PERIOD_SEC = 5 * 60;  // 5 minutes
+
     static final String SYNC_STATUS = "sync-status";
     static final int STARTED = 1;
     static final int COMPLETED = 2;
@@ -68,6 +70,14 @@ public class SyncManager {
 
     public boolean isSyncRunningOrPending() {
         return mScheduler.isRunningOrPending();
+    }
+
+    /** Sets up regularly repeating syncs that run all the time. */
+    public void initPeriodicSyncs() {
+        // Run a full sync every FULL_SYNC_PERIOD_SEC.
+        Bundle options = new Bundle();
+        options.putBoolean(SyncOption.FULL_SYNC.name(), true);
+        setPeriodicSync(options, FULL_SYNC_PERIOD_SEC);
     }
 
     /** Starts a full sync as soon as possible. */

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncManager.java
@@ -47,7 +47,7 @@ public class SyncManager {
      * Intent extras using this key are nullable strings representing the current sync status.
      * They are localized and are suitable for presentation to the user.
      */
-    static final String SYNC_PROGRESS_LABEL = "sync-progress-label";
+    static final String SYNC_MESSAGE_ID = "sync-message-id";
 
     private final SyncScheduler mScheduler;
 
@@ -129,9 +129,9 @@ public class SyncManager {
                     break;
                 case IN_PROGRESS:
                     int progress = intent.getIntExtra(SYNC_PROGRESS, 0);
-                    String label = intent.getStringExtra(SYNC_PROGRESS_LABEL);
-                    LOG.i("SyncStatus: IN_PROGRESS (%d%%, %s)", progress, label);
-                    EventBus.getDefault().post(new SyncProgressEvent(progress, label));
+                    int messageId = intent.getIntExtra(SYNC_MESSAGE_ID, 0);
+                    LOG.i("SyncStatus: IN_PROGRESS (%d%%, %s)", progress, context.getString(messageId));
+                    EventBus.getDefault().post(new SyncProgressEvent(progress, messageId));
                     break;
                 case CANCELED:
                     LOG.i("SyncStatus: CANCELED");

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncScheduler.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncScheduler.java
@@ -1,0 +1,22 @@
+package org.projectbuendia.client.sync;
+
+import android.os.Bundle;
+
+/** SyncManager-facing interface for scheduling and cancelling sync operations. */
+public interface SyncScheduler {
+    /** Queues a request for a sync to begin when the sync engine is available. */
+    void requestSync(Bundle options);
+
+    /** Aborts any sync in progress and cancels any currently queued requests. */
+    void stopSyncing();
+
+    /**
+     * Starts, changes, or stops the periodic sync schedule.  There can be at most
+     * one such repeating loop; any periodic sync from a previous call is replaced
+     * with this new one.  Specifying a period of zero stops the periodic sync.
+     */
+    void setPeriodicSync(Bundle options, int periodSec);
+
+    /** Returns true if a sync is currently running or pending on the queue. */
+    boolean isRunningOrPending();
+}

--- a/app/src/main/java/org/projectbuendia/client/sync/ThreadedSyncScheduler.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ThreadedSyncScheduler.java
@@ -1,0 +1,158 @@
+package org.projectbuendia.client.sync;
+
+import android.content.ContentProviderClient;
+import android.content.Context;
+import android.content.SyncResult;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+
+import java.util.Queue;
+
+import dagger.internal.ArrayQueue;
+
+// TODO(WIP)
+/** An implementation of SyncScheduler that runs the SyncEngine on a background thread. */
+public class ThreadedSyncScheduler implements SyncScheduler {
+    private final SyncThread thread;
+
+    // Message command codes
+    private static final int QUEUE_SYNC = 1;
+    private static final int CANCEL_RUNNING_AND_QUEUED_SYNCS = 2;
+    private static final int SET_PERIODIC_SYNC = 3;
+
+    public ThreadedSyncScheduler(Context context) {
+        thread = new SyncThread(context);
+        thread.start();
+    }
+
+    @Override public void requestSync(Bundle options) {
+        thread.send(QUEUE_SYNC, options);
+    }
+
+    @Override public void stopSyncing() {
+        thread.send(CANCEL_RUNNING_AND_QUEUED_SYNCS, null);
+    }
+
+    @Override public void setPeriodicSync(Bundle options, int periodSec) {
+        thread.send(SET_PERIODIC_SYNC, options);
+    }
+
+    @Override public boolean isRunningOrPending() {
+        return thread.countPendingRequests() > 0 || thread.isSyncRunning;
+    }
+
+    protected static class SyncThread extends Thread {
+        // ==== Fields that belong to external threads ====
+
+        private final Context extContext;
+
+        // ==== Fields that belong to this thread ====
+
+        private final Queue<Bundle> queue = new ArrayQueue<>();
+        private final Runnable checkQueueRunnable = null;//new CheckQueueRunnable();
+        private Handler handler;
+        private SyncEngine engine;
+        private boolean isCancelRequested = false;
+        private boolean isSyncRunning = false;
+        private long nextPeriodicSyncTime = -1;
+
+        // ==== Methods exposed to external threads ====
+
+        public SyncThread(Context context) {
+            extContext = context;
+        }
+
+        public void send(int command, Bundle options) {
+            Message message = handler.obtainMessage(command);
+            message.setData(options);
+            handler.sendMessage(message);
+        }
+
+        public boolean getIsSyncRunning() {
+            return isSyncRunning;
+        }
+
+        public boolean getIsCancelRequested() {
+            return isCancelRequested;
+        }
+
+        public int countPendingRequests() {
+            synchronized (queue) {
+                return queue.size();
+            }
+        }
+
+        // ==== Methods that run inside this thread ====
+
+        @Override public void run() {
+            Looper.prepare();
+
+            final Runnable consume;
+
+            final Runnable performRequest = new Runnable() {
+                @Override public void run() {
+                    Bundle options = null;
+                    synchronized (queue) {
+                        if (!queue.isEmpty()) {
+                            options = queue.remove();
+                        }
+                    }
+                    ContentProviderClient client = null;
+                    SyncResult result = null;
+                    if (options != null) {
+                        engine.sync(options, client, result);
+                    }
+                    handler.post(null);
+                }
+            };
+
+            engine = new BuendiaSyncEngine(extContext);
+            handler = new Handler(new Handler.Callback() {
+                @Override public boolean handleMessage(Message message) {
+                    Bundle options = message.getData();
+                    if (message.what == QUEUE_SYNC) {
+                        addRequest(options);
+                        handler.post(null);
+                        return true;
+                    }
+                    if (message.what == CANCEL_RUNNING_AND_QUEUED_SYNCS) {
+                        cancelAllRequests();
+                        return true;
+                    }
+                    if (message.what == SET_PERIODIC_SYNC) {
+                        int periodSec = options.getInt("periodSec");
+                        options.remove("periodSec");
+                        setPeriodicSync(options, periodSec);
+                        return true;
+                    }
+                    return false;
+                }
+            });
+            Looper.loop();
+        }
+
+        private void addRequest(Bundle options) {
+            synchronized (queue) {
+                queue.add(options);
+            }
+        }
+
+        private void cancelAllRequests() {
+            synchronized (queue) {
+                if (isSyncRunning) {
+                    isCancelRequested = true;
+                }
+                queue.clear();
+            }
+        }
+
+        private void setPeriodicSync(Bundle options, int timeout) {
+
+        }
+
+
+
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/sync/ThreadedSyncScheduler.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ThreadedSyncScheduler.java
@@ -8,39 +8,48 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 
-import java.util.Queue;
+import org.projectbuendia.client.App;
+import org.projectbuendia.client.utils.Logger;
 
-import dagger.internal.ArrayQueue;
-
-// TODO(WIP)
 /** An implementation of SyncScheduler that runs the SyncEngine on a background thread. */
 public class ThreadedSyncScheduler implements SyncScheduler {
+    private static Logger LOG = Logger.create();
+
     private final SyncThread thread;
 
-    // Message command codes
-    private static final int QUEUE_SYNC = 1;
-    private static final int CANCEL_RUNNING_AND_QUEUED_SYNCS = 2;
-    private static final int SET_PERIODIC_SYNC = 3;
+    // Command codes
+    private static final int REQUEST_SYNC = 1;
+    private static final int SET_PERIODIC_SYNC = 2;
+    private static final int LOOP_TICK = 3;
+
+    // Bundle keys
+    private static final String KEY_PERIOD_SEC = "org.projectbuendia.PERIOD_SEC";
+    private static final String KEY_LOOP_ID = "org.projectbuendia.LOOP_ID";
 
     public ThreadedSyncScheduler(Context context) {
+        LOG.i("> new SyncThread");
         thread = new SyncThread(context);
         thread.start();
     }
 
     @Override public void requestSync(Bundle options) {
-        thread.send(QUEUE_SYNC, options);
+        LOG.i("> requestSync()");
+        thread.send(REQUEST_SYNC, options);
     }
 
     @Override public void stopSyncing() {
-        thread.send(CANCEL_RUNNING_AND_QUEUED_SYNCS, null);
+        LOG.i("> stopSyncing()");
+        thread.stopSyncing();
     }
 
     @Override public void setPeriodicSync(Bundle options, int periodSec) {
+        LOG.i("> setPeriodicSync(options=%s, periodSec=%d)", options, periodSec);
+        options.putInt(KEY_PERIOD_SEC, periodSec);
         thread.send(SET_PERIODIC_SYNC, options);
     }
 
     @Override public boolean isRunningOrPending() {
-        return thread.countPendingRequests() > 0 || thread.isSyncRunning;
+        return thread.isSyncRunning() || thread.hasPendingRequests();
     }
 
     protected static class SyncThread extends Thread {
@@ -50,13 +59,10 @@ public class ThreadedSyncScheduler implements SyncScheduler {
 
         // ==== Fields that belong to this thread ====
 
-        private final Queue<Bundle> queue = new ArrayQueue<>();
-        private final Runnable checkQueueRunnable = null;//new CheckQueueRunnable();
-        private Handler handler;
-        private SyncEngine engine;
-        private boolean isCancelRequested = false;
-        private boolean isSyncRunning = false;
-        private long nextPeriodicSyncTime = -1;
+        private Handler handler = null;
+        private SyncEngine engine = null;
+        private boolean running = false;
+        private int activeLoopId = 0;
 
         // ==== Methods exposed to external threads ====
 
@@ -65,94 +71,95 @@ public class ThreadedSyncScheduler implements SyncScheduler {
         }
 
         public void send(int command, Bundle options) {
+            LOG.i("> send(command=" + command + ")");
             Message message = handler.obtainMessage(command);
             message.setData(options);
             handler.sendMessage(message);
         }
 
-        public boolean getIsSyncRunning() {
-            return isSyncRunning;
+        public boolean isSyncRunning() {
+            LOG.i("> isSyncRunning() = " + running);
+            return running;
         }
 
-        public boolean getIsCancelRequested() {
-            return isCancelRequested;
+        public boolean hasPendingRequests() {
+            LOG.i("> hasPendingRequests() = " + handler.hasMessages(REQUEST_SYNC));
+            return handler.hasMessages(REQUEST_SYNC);
         }
 
-        public int countPendingRequests() {
-            synchronized (queue) {
-                return queue.size();
-            }
+        public void stopSyncing() {
+            handler.removeMessages(REQUEST_SYNC);
+            engine.cancel();
         }
 
         // ==== Methods that run inside this thread ====
 
         @Override public void run() {
-            Looper.prepare();
+            LOG.i("* run())");
+            try {
+                engine = new BuendiaSyncEngine(extContext);
+                Looper.prepare();
 
-            final Runnable consume;
+                handler = new Handler(new Handler.Callback() {
+                    @Override public boolean handleMessage(Message message) {
+                        Bundle options = message.getData();
+                        LOG.i("* handleMessage(what=" + message.what + ", options=" + options + ")");
+                        int periodSec = options.getInt(KEY_PERIOD_SEC, 0);
+                        int loopId = options.getInt(KEY_LOOP_ID, 0);
 
-            final Runnable performRequest = new Runnable() {
-                @Override public void run() {
-                    Bundle options = null;
-                    synchronized (queue) {
-                        if (!queue.isEmpty()) {
-                            options = queue.remove();
+                        switch (message.what) {
+                            case REQUEST_SYNC:
+                                LOG.i("* REQUEST_SYNC");
+                                runSync(options);
+                                return true;
+
+                            case SET_PERIODIC_SYNC:
+                                activeLoopId++;
+                                LOG.i("* SET_PERIODIC_SYNC: periodSec=%d, activeLoopId is now %d", periodSec, activeLoopId);
+
+                                if (periodSec > 0) {
+                                    options.putInt(KEY_LOOP_ID, activeLoopId);
+                                    Message nextMessage = handler.obtainMessage(LOOP_TICK);
+                                    nextMessage.setData(options);
+                                    LOG.i("* scheduling LOOP_TICK(%d) message in %d sec", activeLoopId, periodSec);
+                                    handler.sendMessageDelayed(nextMessage, periodSec*1000);
+                                }
+                                return true;
+
+                            case LOOP_TICK:
+                                LOG.i("* LOOP_TICK(%d), activeLoopId=%d, periodSec=%d", loopId, activeLoopId, periodSec);
+                                if (loopId == activeLoopId) {
+                                    runSync(options);
+                                    LOG.i("* scheduling LOOP_TICK(%d) message in %d sec", loopId, periodSec);
+                                    handler.sendMessageDelayed(Message.obtain(message), periodSec*1000);
+                                } else {
+                                    LOG.i("* loopId=%d is no longer active; ignoring", loopId);
+                                }
+                                return true;
                         }
+                        return false;
                     }
-                    ContentProviderClient client = null;
-                    SyncResult result = null;
-                    if (options != null) {
-                        engine.sync(options, client, result);
-                    }
-                    handler.post(null);
-                }
-            };
+                });
 
-            engine = new BuendiaSyncEngine(extContext);
-            handler = new Handler(new Handler.Callback() {
-                @Override public boolean handleMessage(Message message) {
-                    Bundle options = message.getData();
-                    if (message.what == QUEUE_SYNC) {
-                        addRequest(options);
-                        handler.post(null);
-                        return true;
-                    }
-                    if (message.what == CANCEL_RUNNING_AND_QUEUED_SYNCS) {
-                        cancelAllRequests();
-                        return true;
-                    }
-                    if (message.what == SET_PERIODIC_SYNC) {
-                        int periodSec = options.getInt("periodSec");
-                        options.remove("periodSec");
-                        setPeriodicSync(options, periodSec);
-                        return true;
-                    }
-                    return false;
-                }
-            });
-            Looper.loop();
-        }
-
-        private void addRequest(Bundle options) {
-            synchronized (queue) {
-                queue.add(options);
+                Looper.loop();
+            } catch (Throwable t) {
+                LOG.e(t, "run() aborted");
+            } finally {
+                LOG.i("run() terminated");
             }
         }
 
-        private void cancelAllRequests() {
-            synchronized (queue) {
-                if (isSyncRunning) {
-                    isCancelRequested = true;
-                }
-                queue.clear();
+        private void runSync(Bundle options) {
+            ContentProviderClient client = App.getContentProviderClient();
+            SyncResult result = new SyncResult();
+            running = true;
+            try {
+                LOG.i("* engine.sync(options=%s)", options);
+                engine.sync(options, client, result);
+            } finally {
+                LOG.i("* engine.sync() terminated");
+                running = false;
             }
         }
-
-        private void setPeriodicSync(Bundle options, int timeout) {
-
-        }
-
-
-
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/IncrementalSyncPhaseRunnable.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/IncrementalSyncPhaseRunnable.java
@@ -31,7 +31,7 @@ import org.projectbuendia.client.net.Common;
 import org.projectbuendia.client.net.GsonRequest;
 import org.projectbuendia.client.net.OpenMrsConnectionDetails;
 import org.projectbuendia.client.providers.Contracts;
-import org.projectbuendia.client.sync.SyncAdapter;
+import org.projectbuendia.client.sync.BuendiaSyncEngine;
 import org.projectbuendia.client.utils.Logger;
 
 import java.lang.reflect.ParameterizedType;
@@ -87,7 +87,7 @@ public abstract class IncrementalSyncPhaseRunnable<T> implements SyncPhaseRunnab
 
         beforeSyncStarted(contentResolver, syncResult, providerClient);
 
-        String syncToken = SyncAdapter.getLastSyncToken(providerClient, dbTable);
+        String syncToken = BuendiaSyncEngine.getLastSyncToken(providerClient, dbTable);
         LOG.i("Using sync token `%s`", syncToken);
 
         IncrementalSyncResponse<T> response;
@@ -106,7 +106,7 @@ public abstract class IncrementalSyncPhaseRunnable<T> implements SyncPhaseRunnab
         } while (response.more);
 
         LOG.i("Saving new sync token `%s`", syncToken);
-        SyncAdapter.storeSyncToken(providerClient, dbTable, response.syncToken);
+        BuendiaSyncEngine.storeSyncToken(providerClient, dbTable, response.syncToken);
 
         afterSyncFinished(contentResolver, syncResult, providerClient);
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
@@ -192,9 +192,9 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
         mProgressBar.setProgress(progress);
     }
 
-    protected void setProgressLabel(String label) {
+    protected void setProgressMessage(int messageId) {
         switchToHorizontalProgressBar();
-        mProgressBarLabel.setText(label);
+        mProgressBarLabel.setText(messageId);
     }
 
     protected void switchToCircularProgressBar() {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -87,13 +87,11 @@ final class PatientChartController implements ChartRenderer.JsInterface {
     static final String EBOLA_LAB_TEST_FORM_UUID = "buendia-form-ebola_lab_test";
 
     /**
-     * Period between observation syncs while the chart view is active.  It would be nice for
-     * this to be even shorter (20 s? 10 s?) but currently the table scroll position resets on
-     * each sync, if any data has changed.
-     * TODO: Try reducing this period to improve responsiveness, but be wary of the table scrolling
-     * whenever data is refreshed.
+     * Period between observation syncs while the chart view is active.  It would
+     * be nice for this to be even shorter (10 s?) but currently the table scroll
+     * position resets on each sync if any data has changed.
      */
-    private static final int OBSERVATION_SYNC_PERIOD_MILLIS = 60000;
+    private static final int OBSERVATION_SYNC_PERIOD_MILLIS = 20000;
 
     private Patient mPatient = Patient.builder().build();
     private LocationTree mLocationTree;

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
@@ -37,7 +37,7 @@ import org.projectbuendia.client.events.data.ItemFetchedEvent;
 import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.models.Patient;
 import org.projectbuendia.client.providers.Contracts.Patients;
-import org.projectbuendia.client.sync.SyncAccountService;
+import org.projectbuendia.client.sync.SyncManager;
 import org.projectbuendia.client.utils.RelativeDateTimeFormatter;
 import org.projectbuendia.client.utils.Utils;
 
@@ -52,6 +52,7 @@ import de.greenrobot.event.EventBus;
 public class GoToPatientDialogFragment extends DialogFragment {
     @Inject AppModel mAppModel;
     @Inject Provider<CrudEventBus> mCrudEventBusProvider;
+    @Inject SyncManager mSyncManager;
     @InjectView(R.id.go_to_patient_id) EditText mPatientId;
     @InjectView(R.id.go_to_patient_result) TextView mPatientSearchResult;
     private LayoutInflater mInflater;
@@ -121,7 +122,7 @@ public class GoToPatientDialogFragment extends DialogFragment {
 
             // Perform incremental observation sync to get the patient's admission date
             // and any other recent observations.
-            SyncAccountService.startObservationsAndOrdersSync();
+            mSyncManager.startObservationsAndOrdersSync();
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
@@ -153,6 +153,8 @@ public abstract class BaseSearchablePatientListActivity extends BaseLoggedInActi
                 }
             }
         }
+
+        mSyncManager.initPeriodicSyncs();
     }
 
     @Override protected void onResumeImpl() {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -94,7 +94,7 @@ final class LocationListController {
 
         void setBusyLoading(boolean busy);
 
-        void showIncrementalSyncProgress(int progress, String label);
+        void showIncrementalSyncProgress(int progress, int messageId);
 
         void resetSyncProgress();
 
@@ -278,7 +278,7 @@ final class LocationListController {
         public void onEventMainThread(SyncProgressEvent event) {
             if (mWaitingOnSync) {
                 for (LocationFragmentUi fragmentUi : mFragmentUis) {
-                    fragmentUi.showIncrementalSyncProgress(event.progress, event.label);
+                    fragmentUi.showIncrementalSyncProgress(event.progress, event.messageId);
                 }
             }
         }

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -131,7 +131,7 @@ final class LocationListController {
         } else {
             LOG.i("Data model unavailable; waiting on sync.");
             mWaitingOnSync = true;
-            if (!mSyncManager.isSyncActive() && !mSyncManager.isSyncPending()) {
+            if (!mSyncManager.isSyncRunningOrPending()) {
                 LOG.i("No sync detected, forcing new sync.");
                 onSyncRetry();
             }

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -12,7 +12,6 @@
 package org.projectbuendia.client.ui.lists;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -129,10 +128,10 @@ public final class LocationListFragment extends ProgressFragment {
             changeState(busy ? State.LOADING : State.LOADED);
         }
 
-        @Override public void showIncrementalSyncProgress(int progress, @Nullable String label) {
+        @Override public void showIncrementalSyncProgress(int progress, int messageId) {
             setProgress(progress);
-            if (label != null) {
-                setProgressLabel(label);
+            if (messageId > 0) {
+                setProgressMessage(messageId);
             }
         }
 
@@ -141,7 +140,7 @@ public final class LocationListFragment extends ProgressFragment {
         }
 
         @Override public void showSyncCancelRequested() {
-            setProgressLabel(getString(R.string.cancelling_sync));
+            setProgressMessage(R.string.cancelling_sync);
         }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -15,6 +15,9 @@ import android.app.Dialog;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
+import android.os.Parcel;
 import android.view.View;
 
 import com.android.volley.AuthFailureError;
@@ -41,6 +44,7 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -437,6 +441,37 @@ public class Utils {
         }
     }
 
+    /** Puts an integer into a Bundle in a chainable way. */
+    public static Bundle putInt(String key, int value, Bundle bundle) {
+        bundle.putInt(key, value);
+        return bundle;
+    }
+
+    /** Puts a String into a Bundle in a chainable way. */
+    public static Bundle putString(String key, String value, Bundle bundle) {
+        bundle.putString(key, value);
+        return bundle;
+    }
+
+    /** Puts a Bundle into a Bundle in a chainable way. */
+    public static Bundle putBundle(String key, Bundle value, Bundle bundle) {
+        bundle.putBundle(key, value);
+        return bundle;
+    }
+
+    /** Builds a Message with a Bundle of data. */
+    public static Message newMessage(Handler handler, int what, Bundle data) {
+        Message message = handler.obtainMessage(what);
+        message.setData(data);
+        return message;
+    }
+
+    /** Serializes a Bundle to a String. */
+    public static String toString(Bundle bundle) {
+        Parcel parcel = Parcel.obtain();
+        bundle.writeToParcel(parcel, 0);
+        return new String(parcel.marshall(), StandardCharsets.ISO_8859_1);
+    }
 
     // ==== User interface ====
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -347,6 +347,8 @@ S\'il vous plaît patienter pendant que les données du patient et l\'emplacemen
   <string name="pref_desc_require_wifi">Désactivez cette option pour permettre l\'application de travailler avec des non-wifi (ou émulé captif Bluetooth) en réseau.</string>
   <string name="pref_title_starting_patient_id">Commencer avec le dossier du patient avec l\'ID</string>
   <string name="pref_desc_starting_patient_id">Entrez un ID du patient pour ouvrir l\'application avec le dossier du patient</string>
+  <string name="pref_title_use_sync_adapter">Utiliser l\'ancien framework SyncAdapter</string>
+  <string name="pref_desc_use_sync_adapter">Activez cette option pour utiliser SyncAdapter (qui necessité une connexion Internet) au lieu du ThreadedSyncScheduler intégré.  L\'app doit être redémarrée pour que cette modification soit prise en compte.</string>
 
   <!-- Dialog button for accepting a setting that clears the local database -->
   <string name="clear_data_button">Appliquer et effacer les données locales</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,6 +354,8 @@
   <string name="pref_desc_require_wifi">Turn this off to allow the app to work with non-wifi (emulated or Bluetooth tethered) networking.</string>
   <string name="pref_title_starting_patient_id">Start with patient ID</string>
   <string name="pref_desc_starting_patient_id">Set an ID here to go directly to a patient chart on startup.</string>
+  <string name="pref_title_use_sync_adapter">Use the old SyncAdapter framework</string>
+  <string name="pref_desc_use_sync_adapter">Turn this on to use SyncAdapter (which requires Internet connectivity) instead of the built-in ThreadedSyncScheduler.  The app must be restarted for this change to take effect.</string>
 
   <!-- Dialog button for accepting a setting that clears the local database -->
   <string name="clear_data_button">Apply and clear local data</string>

--- a/app/src/main/res/xml/pref_developer.xml
+++ b/app/src/main/res/xml/pref_developer.xml
@@ -23,4 +23,11 @@
         android:summary="@string/pref_desc_starting_patient_id"
         android:defaultValue="" />
 
+    <!-- Whether to use the SyncAdapter framework; default is to use our own scheduler. -->
+    <CheckBoxPreference
+        android:key="use_sync_adapter"
+        android:title="@string/pref_title_use_sync_adapter"
+        android:summary="@string/pref_desc_use_sync_adapter"
+        android:defaultValue="false" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Issues: Closes #403.
Scope: Sync

#### User-visible changes

This addresses a long-standing headache for us—the Android SyncAdapter is notoriously unreliable, often choosing to delay for a long time before syncing or refusing to sync at all according to its whims.  In particular, when there is no Internet connection, newer versions of Android will disable the SyncAdapter entirely, enforcing the insane first-world assumption that without Internet no app should ever need to sync at all.

With this change, the app should always sync reliably regardless of the presence of an Internet connection.

The sync frequency is also increased.  Observations on the patient chart now sync every 20 seconds (rather than 60 seconds), and the patient list is updated every 3 minutes (instead of 5 minutes).  It used to be that we could not rely on the SyncAdapter to do anything promptly; but now that we have direct control, we can set the repeating sync period and expect it to happen on schedule.

#### Internal changes 

Two new interfaces, `SyncEngine` and `SyncScheduler`, are factored out.  The new scheduler, `ThreadedSyncScheduler`, is swappable with the old implementation, which has been factored into `SyncAdapterSyncScheduler`.

