### PR TITLE
Show section headings for groups of rows in the grid.

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -45,23 +45,26 @@ th, td { border: 1px solid transparent; border-width: 0 1px 1px 0; }
 
 /* Grid lines */
 thead th.day { border-top-color: #666; }
-thead tr:last-child th { border-bottom-color: #666; }
+thead tr:last-child th, thead th.gap { border-bottom-color: #666; }
 thead th { border-right-color: #ddd; }
 
-tbody.orders th[scope="rowgroup"] { border-top-color: #666; }
+th[scope="rowgroup"] { border-top: 1px solid #666; }
+tbody.observations tr:first-child th { border-top: none; }
 tbody th, tbody td { border-bottom-color: #ddd; }
 
-tbody th, .corner, .day, .day-last, .gap { border-right: 1px solid #666; }
-tbody td { border-right: 1px solid #ddd; }
+tbody th, .corner, .day, .day-last, .gap { border-right-color: #666; }
+tbody td, th[scope="rowgroup"] { border-right-color: #ddd; }
 .division { border-right: 1px solid #ddd; }
 .division:last-child { border-right: none; }
 .command { border-right: transparent; }
 
+/* Row shading */
+tr.obs, tr.order { background: #f8f8f8; }
+
 /* Column shading */
 .now { font-weight: bold; background: #e0f0ff; }
 
-th.gap, th[scope="rowgroup"].gap {
-  min-width: 1.5rem;
+th.gap {
   background: repeating-linear-gradient(
       45deg, #fff, #fff 10px, #eee 10px, #eee 20px);
 }
@@ -78,9 +81,10 @@ th, td, .division, .summary {
   overflow: hidden;
 }
 
-/* Grid cells */
+/* Grid cell sizes */
 thead th, .obs td, .order td { text-align: center; min-width: 6rem; max-width: 6rem; }
 tbody th, tbody td { height: 4.5rem; }
+th.gap, th[scope="rowgroup"].gap { min-width: 1.5rem; max-width: 1.5rem; }
 
 /* Column headings: should match @style/text.caption */
 thead th {
@@ -91,15 +95,19 @@ thead th {
 
 /* Row headings: should match @style/text.caps */
 th[scope="rowgroup"] {
-  font-size: 1.4rem;
+  font-size: 1.5rem;
   font-weight: bold;
   padding-top: 1.6em;
   text-transform: uppercase;
-  background: #eee;
+  background: #fff;
+  color: #900;
 }
 
 /* Orders */
-.order th { padding: 0 4px 0 16px; line-height: 1.1em; vertical-align: middle; }
+.orders th[scope="rowgroup"] {
+  color: #09e;
+}
+#grid-left .order th { padding: 0 4px 0 16px; line-height: 1.1em; vertical-align: middle; }
 .medication { font-weight: bold; }
 .route-IV .medication { color: #c60; }
 .route-PO .medication { color: #084; }
@@ -114,7 +122,7 @@ th[scope="rowgroup"] {
 
 .order .past.underdose { background: #fed; }
 .order .now.underdose { background: #fcc; }
-.order .future.underdose { background: #eee; }
+.order .future.underdose { background: #ddd; }
 .order .full-dose { background: #dfd; }
 .order .overdose { background: #ecf; }
 .order .overdose .given, .order .overdose .extra-given { color: #c00; }
@@ -136,6 +144,7 @@ th[scope="rowgroup"] {
 .overdose .execution { background: #80f; }
 
 th.command { /* should match @style/ActionButton */
+  font-size: 1.5rem;
   font-weight: bold;
   color: #09e;
   text-transform: uppercase;

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -67,57 +67,66 @@
   </thead>
 
   <tbody class="observations">
-    <tr>
-      <th scope="rowgroup">
-        Observations
-      </th>
-      {% set prevStop = columns[0].start %}
-      {% for column in columns %}
-        {% if column.start != prevStop %}
-          <th scope="rowgroup" class="gap" rowspan={{(rows | length) + 1}}>&nbsp;</th>
-        {% endif %}
-        {% if column.start == column.dayStart %}
-          <th scope="rowgroup" colspan={{numColumnsPerDay}}>&nbsp;</th>
-        {% endif %}
-        {% set prevStop = column.stop %}
-      {% endfor %}
-    </tr>
-    {% for row in rows %}
-    {% set id = row.item.conceptIds | first %}
-    <tr class="obs">
-        <th scope="row" onclick="od('{{row.item.conceptUuids[0]}}','','');">
-          {{row.item.label}}
+    {% for group in rowGroups %}
+      <tr>
+        <th scope="rowgroup">
+          {{group.title is not empty ? group.title : 'Observations'}}
         </th>
+        {% set prevStop = columns[0].start %}
         {% for column in columns %}
-          {% set points = get_all_points(row=row, column=column) %}
-          {% if points is empty %}
-            {% set summaryValue = null %}
-          {% elseif row.item.type == 'yes_no' %}
-            {% set summaryValue = points | values | max %}
-          {% else %}
-            {% set summaryValue = (points | last).value %}
+          {% if column.start != prevStop %}
+            <th scope="rowgroup" class="gap">&nbsp;</th>
           {% endif %}
-          {% set class = summaryValue | format_values(row.item.cssClass) %}
-          {% set style = summaryValue | format_values(row.item.cssStyle) %}
-          <td class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}} {{class}}"
-            style="{{style}}"
-            onclick="{% if points is not empty and row.item.type.string != 'text_icon' %}
-                       od('{{row.item.conceptUuids[0]}}','{{column.start.millis}}','{{column.stop.millis}}');
-                     {% endif %}">
-          {% if points is empty %}
-            &nbsp;
-          {% elseif row.item.type == 'text_icon' %}
-            <div>&#x1f4dd;</div>
-          {% else %}
-            {% set output = summaryValue | format_value(row.item.format) %}
-            {% if output is empty %}
-              {% set output = summaryValue | format_value(row.item.captionFormat) %}
-            {% endif %}
-            {% if output is empty %}&nbsp;{% else %}{{output}}{% endif %}
+          {% if column.start == column.dayStart %}
+            <th scope="rowgroup" colspan={{numColumnsPerDay}}>&nbsp;</th>
           {% endif %}
-        </td>
+          {% set prevStop = column.stop %}
         {% endfor %}
       </tr>
+      {% set top = true %}
+      {% for row in group.rows %}
+        {% set id = row.item.conceptIds | first %}
+        <tr class="obs">
+          <th scope="row" onclick="od('{{row.item.conceptUuids[0]}}','','');">
+            {{row.item.label}}
+          </th>
+          {% set prevStop = columns[0].start %}
+          {% for column in columns %}
+            {% if top and column.start != prevStop %}
+              <th class="gap" rowspan={{group.rows | length}}>&nbsp;</th>
+            {% endif %}
+            {% set points = get_all_points(row=row, column=column) %}
+            {% if points is empty %}
+              {% set summaryValue = null %}
+            {% elseif row.item.type == 'yes_no' %}
+              {% set summaryValue = points | values | max %}
+            {% else %}
+              {% set summaryValue = (points | last).value %}
+            {% endif %}
+            {% set class = summaryValue | format_values(row.item.cssClass) %}
+            {% set style = summaryValue | format_values(row.item.cssStyle) %}
+            <td class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}} {{class}}"
+              style="{{style}}"
+              onclick="{% if points is not empty and row.item.type.string != 'text_icon' %}
+                         od('{{row.item.conceptUuids[0]}}','{{column.start.millis}}','{{column.stop.millis}}');
+                       {% endif %}">
+              {% if points is empty %}
+                &nbsp;
+              {% elseif row.item.type == 'text_icon' %}
+                <div>&#x1f4dd;</div>
+              {% else %}
+                {% set output = summaryValue | format_value(row.item.format) %}
+                {% if output is empty %}
+                  {% set output = summaryValue | format_value(row.item.captionFormat) %}
+                {% endif %}
+                {% if output is empty %}&nbsp;{% else %}{{output}}{% endif %}
+              {% endif %}
+            </td>
+            {% set prevStop = column.stop %}
+          {% endfor %}
+        </tr>
+        {% set top = false %}
+      {% endfor %}
     {% endfor %}
   </tbody>
 
@@ -129,7 +138,7 @@
       {% set prevStop = columns[0].start %}
       {% for column in columns %}
         {% if column.start != prevStop %}
-          <th scope="rowgroup" class="gap" rowspan={{(rows | length) + 1}}>&nbsp;</th>
+          <th scope="rowgroup" class="gap">&nbsp;</th>
         {% endif %}
         {% if column.start == column.dayStart %}
           <th scope="rowgroup" colspan={{numColumnsPerDay}}>&nbsp;</th>
@@ -137,6 +146,7 @@
         {% set prevStop = column.stop %}
       {% endfor %}
     </tr>
+    {% set top = true %}
     {% for order in orders %}
       {% set ins = order.instructions %}
       <tr class="order route-{{ins.route}}">
@@ -154,7 +164,11 @@
         {% set divisionIndex = 0 %}
         {% set showPerDivisionCounts = numColumnsPerDay >= ins.frequency %}
 
+        {% set prevStop = columns[0].start %}
         {% for column in columns %}
+          {% if column.start != prevStop and top %}
+            <th class="gap" rowspan={{orders | length}}>&nbsp;</th>
+          {% endif %}
           {% if column.start == column.dayStart %}
             {% if column.date == order.startDay %}
               {% set started = true %}
@@ -210,8 +224,10 @@
               </div>
             </td>
           {% endif %}
+          {% set prevStop = column.stop %}
         {% endfor %}
       </tr>
+      {% set top = false %}
     {% endfor %}
 
     <tr>

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -170,8 +170,7 @@ public class ChartRenderer {
             }
         };
         List<List<Tile>> mTileRows = new ArrayList<>();
-        List<Row> mRows = new ArrayList<>();
-        Map<String, Row> mRowsByUuid = new HashMap<>();  // unordered, keyed by concept UUID
+        List<RowGroup> mRowGroups = new ArrayList<>();
         SortedMap<Long, Column> mColumnsByStartMillis = new TreeMap<>();  // ordered by start millis
         Set<String> mConceptsToDump = new HashSet<>();  // concepts whose data to dump in JSON
 
@@ -202,11 +201,12 @@ public class ChartRenderer {
                 }
                 mTileRows.add(tileRow);
             }
+
             for (ChartSection section : chart.rowGroups) {
+                RowGroup rowGroup = new RowGroup(section.label);
+                mRowGroups.add(rowGroup);
                 for (ChartItem item : section.items) {
-                    Row row = new Row(item);
-                    mRows.add(row);
-                    mRowsByUuid.put(item.conceptUuids[0], row);
+                    rowGroup.rows.add(new Row(item));
                     if (!item.script.trim().isEmpty()) {
                         mConceptsToDump.addAll(Arrays.asList(item.conceptUuids));
                     }
@@ -350,7 +350,7 @@ public class ChartRenderer {
             Map<String, Object> context = new HashMap<>();
             context.put("now", mNow);
             context.put("tileRows", mTileRows);
-            context.put("rows", mRows);
+            context.put("rowGroups", mRowGroups);
             context.put("columns", Lists.newArrayList(mColumnsByStartMillis.values()));
             context.put("nowColumn", mNowColumn);
             context.put("numColumnsPerDay", getSegmentStartTimes().length);

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/RowGroup.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/RowGroup.java
@@ -1,0 +1,15 @@
+package org.projectbuendia.client.ui.chart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Descriptor for a group of rows in the patient history grid. */
+public class RowGroup {
+    public String title;
+    public List<Row> rows;
+
+    public RowGroup(String title) {
+        this.title = title;
+        this.rows = new ArrayList<>();
+    }
+}


### PR DESCRIPTION
Issues: #339 (but not collapsible)
Scope: Patient chart
Requested reviewers: @ivangayton 

#### User-visible changes

The grid sections in the profile are now shown as lightly shaded groups in the chart grid with section headings.  The section heading rows take visual precedence over the column-gap diagonal striping, though light grid lines carry through.

### Screenshots

![grid-sections-1](https://user-images.githubusercontent.com/236086/61029837-41862400-a3bc-11e9-9283-6dee4f3379e7.png)

![grid-sections-2](https://user-images.githubusercontent.com/236086/61029841-477c0500-a3bc-11e9-8a75-0656e8370b16.png)
