### PR TITLE
Improve order dialog; show order frequency in the grid

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -70,7 +70,7 @@ th.gap {
 }
 
 /* Left margin */
-#grid-left th { padding-left: 16px; min-width: 20rem; max-width: 20rem; }
+#grid-left th { padding-left: 16px; min-width: 22rem; max-width: 22rem; }
 
 /* Grid text: should match @style/text */
 th, td, .division, .summary {
@@ -111,9 +111,7 @@ th[scope="rowgroup"] {
   color: #09e;
 }
 #grid-left .order th { padding: 0 4px 0 16px; line-height: 1.1em; vertical-align: middle; }
-.medication { font-weight: bold; }
-.route-IV .medication { color: #c60; }
-.route-PO .medication { color: #084; }
+.dosing { color: #888; }
 
 .order td { position: relative; }  /* contains positioned .divisions and .summary */
 .order .divisions, .order .summary {

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -154,8 +154,15 @@
           {% if ins.notes is not empty %}
             <div class="notes">{{ins.notes | slice(0, min(30, ins.notes|length))}}</div>
           {% endif %}
-          <div class="medication">{{ins.medication}}&nbsp;{{ins.route}}</div>
-          <div>{{ins.dosage}}&nbsp;</div>
+          <div class="medication">{{ins.medication}}</div>
+          <div class="dosing">
+            <span class="dosage">{{ins.dosage}}</span
+              >{% if ins.route is not empty %}
+                <span class="route">{{ins.route}}</span
+              >{% endif %}{% if ins.frequency > 0 %},
+                <span class="frequency">{{ins.frequency}}/day</span>
+              {% endif %}
+          </div>
         </th>
         {% set executionHistory = executionHistories[order.uuid] %}
         {% set past = true %}

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -178,6 +178,7 @@
           android:id="@+id/order_notes"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:layout_marginBottom="12sp"
           android:layout_column="1"
           android:layout_span="2"
           android:layout_weight="1"

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -42,7 +42,9 @@
           android:layout_weight="1"
           android:ems="15"
           android:inputType="textCapSentences|textNoSuggestions"
-          android:maxLength="80" />
+          android:maxLength="80"
+          android:imeOptions="actionNext"
+          android:nextFocusDown="@id/order_dosage" />
     </TableRow>
 
     <TableRow
@@ -65,12 +67,15 @@
           android:layout_weight="1"
           android:ems="15"
           android:inputType="textNoSuggestions"
-          android:maxLength="40"/>
+          android:maxLength="40"
+          android:imeOptions="actionNext"
+          android:nextFocusRight="@id/order_frequency" />
 
       <EditText
           android:id="@+id/order_route"
           style="?android:attr/spinnerStyle"
           android:editable="false"
+          android:focusable="false"
           android:textSize="19sp"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
@@ -97,7 +102,9 @@
           android:digits="0123456789"
           android:ems="3"
           android:inputType="numberDecimal"
-          android:maxLength="2"/>
+          android:maxLength="2"
+          android:imeOptions="actionNext"
+          android:nextFocusDown="@id/order_give_for_days"/>
 
       <TextView
           android:id="@+id/order_times_per_day_label"
@@ -128,7 +135,9 @@
           android:digits="0123456789"
           android:ems="3"
           android:inputType="numberDecimal"
-          android:maxLength="2"/>
+          android:maxLength="2"
+          android:imeOptions="actionNext"
+          android:nextFocusDown="@id/order_notes"/>
 
       <TextView
           android:id="@+id/order_give_for_days_label"
@@ -173,8 +182,12 @@
           android:layout_span="2"
           android:layout_weight="1"
           android:ems="15"
-          android:inputType="textCapSentences|textNoSuggestions"
-          android:maxLength="40"/>
+          android:inputType="textMultiLine|textCapSentences|textNoSuggestions"
+          android:lines="2"
+          android:minLines="2"
+          android:maxLines="2"
+          android:gravity="top|start"
+          android:imeOptions="actionNone" />
     </TableRow>
 
   </TableLayout>


### PR DESCRIPTION
Issues: <!-- If this closes an issue, write "Closes #123" here. -->
Scope: <!-- What components or activities are affected? -->
Requested reviewers: <!-- Tag reviewers here. -->

#### User-visible changes

The "Next" keyboard button now works properly.

The order frequency now appears in the first column of the grid (e.g. "100 mg PO 3/day").

The orders are no longer coloured according to route of administration (the orange/green colours were too easily confused with the orange/green shading in the grid indicating the dosing status).

The order dialog now allows two lines for entering notes.