### PR TITLE
Construct only one ChartRenderer; keep and reuse previous HTML

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
@@ -303,8 +303,10 @@ public class ChartDataHelper {
     public List<Chart> getCharts(String uuid) {
         Map<Long, ChartSection> tileGroupsById = new HashMap<>();
         Map<Long, ChartSection> rowGroupsById = new HashMap<>();
-        List<Chart> Charts = new ArrayList<>();
+        List<Chart> charts = new ArrayList<>();
         Chart currentChart = null;
+
+        LOG.start("ChartDataHelper.getCharts");
 
         try (Cursor c = mContentResolver.query(
             ChartItems.CONTENT_URI, null,
@@ -322,7 +324,7 @@ public class ChartDataHelper {
                                 if ((currentChart != null) &&
                                     ((currentChart.tileGroups.size() != 0)
                                     || (currentChart.rowGroups.size() != 0))) {
-                                    Charts.add(currentChart);
+                                    charts.add(currentChart);
                                 }
                                 break;
                             case "TILE_ROW":
@@ -361,8 +363,10 @@ public class ChartDataHelper {
                 }
             }
         }
-        Charts.add(currentChart);
-        return Charts;
+
+        LOG.finish("ChartDataHelper.getCharts");
+        charts.add(currentChart);
+        return charts;
     }
 
     public List<Form> getForms() {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -459,6 +459,7 @@ final class PatientChartController implements ChartRenderer.JsInterface {
 
     @JavascriptInterface public void finish() {
         LOG.finish("ChartJS");
+        LOG.finish("render");
     }
 
     public void setDate(String conceptUuid, LocalDate date) {


### PR DESCRIPTION
This speeds up rendering by retaining previously generated HTML and reusing it when possible.  There is now only one static application-wide ChartRenderer; the app no longer creates and destroys a ChartRenderer every time you open or close the PatientChartActivity.