### PR TITLE
Support multiple periodic syncs.

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/FakeSyncManager.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/FakeSyncManager.java
@@ -34,7 +34,7 @@ public class FakeSyncManager extends SyncManager {
         return mSyncing;
     }
 
-    @Override public void startFullSync() {
+    @Override public void syncAll() {
         mSyncing = true;
     }
 }

--- a/app/src/androidTest/java/org/projectbuendia/client/ui/lists/PatientListControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/lists/PatientListControllerTest.java
@@ -49,7 +49,7 @@ public class PatientListControllerTest {
         // WHEN PatientListController is refreshed
         mController.onRefreshRequested();
         // THEN SyncManager performs sync
-        verify(mMockSyncManager).startFullSync();
+        verify(mMockSyncManager).syncAll();
     }
 
     /** Tests that refreshing multiple times in quick succession results in only one sync. */
@@ -62,7 +62,7 @@ public class PatientListControllerTest {
         mController.onRefreshRequested();
         mController.onRefreshRequested();
         // THEN SyncManager performs one, and only one, sync
-        verify(mMockSyncManager, times(1)).startFullSync();
+        verify(mMockSyncManager, times(1)).syncAll();
     }
 
     /** Tests that refreshing again after a first successful sync results in a new sync. */
@@ -76,7 +76,7 @@ public class PatientListControllerTest {
         mFakeEventBus.post(new SyncSucceededEvent());
         mController.onRefreshRequested();
         // THEN SyncManager performs sync each time
-        verify(mMockSyncManager, times(2)).startFullSync();
+        verify(mMockSyncManager, times(2)).syncAll();
     }
 
     /** Tests that refreshing again after a first failed sync results in a new sync. */
@@ -90,7 +90,7 @@ public class PatientListControllerTest {
         mFakeEventBus.post(new SyncFailedEvent());
         mController.onRefreshRequested();
         // THEN SyncManager performs sync each time
-        verify(mMockSyncManager, times(2)).startFullSync();
+        verify(mMockSyncManager, times(2)).syncAll();
     }
 
     /** Tests that the PatientListController listens for events when initialized. */

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/AddPatientTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/AddPatientTask.java
@@ -103,28 +103,17 @@ public class AddPatientTask extends AsyncTask<Void, Void, PatientAddFailedEvent>
         }
 
         if (json.uuid == null) {
-            LOG.e(
-                "Although the server reported a patient successfully added, it did not return "
-                    + "a UUID for that patient. This indicates a server error.");
-
-            return new PatientAddFailedEvent(
-                PatientAddFailedEvent.REASON_SERVER, null /*exception*/);
+            LOG.e("Server successfully added a new patient but returned no UUID");
+            return new PatientAddFailedEvent(PatientAddFailedEvent.REASON_SERVER, null);
         }
 
         Patient patient = Patient.fromJson(json);
-        Uri uri = mContentResolver.insert(
-            Contracts.Patients.URI, patient.toContentValues());
-
-        // Perform incremental observation sync so we get admission date.
-        mSyncManager.startObservationsAndOrdersSync();
-
+        Uri uri = mContentResolver.insert(Contracts.Patients.URI, patient.toContentValues());
         if (uri == null || uri.equals(Uri.EMPTY)) {
-            return new PatientAddFailedEvent(
-                PatientAddFailedEvent.REASON_CLIENT, null /*exception*/);
+            return new PatientAddFailedEvent(PatientAddFailedEvent.REASON_CLIENT, null);
         }
 
         mUuid = json.uuid;
-
         return null;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/DownloadSinglePatientTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/DownloadSinglePatientTask.java
@@ -71,7 +71,7 @@ public class DownloadSinglePatientTask extends AsyncTask<Void, Void, ItemFetchFa
         RequestFuture<JsonPatient> future = RequestFuture.newFuture();
 
         // Try to download the specified patient from the server.
-        LOG.i("Downloading single patient %s from server...", mPatientId);
+        LOG.i("Downloading single patient %s from server", mPatientId);
         mServer.getPatient(mPatientId, future, future);
         JsonPatient json;
         try {
@@ -92,14 +92,13 @@ public class DownloadSinglePatientTask extends AsyncTask<Void, Void, ItemFetchFa
         try (Cursor c = mContentResolver.query(Patients.URI, null,
             Patients.ID + " = ?", new String[] {mPatientId}, null)) {
             if (c.moveToNext()) {
-                LOG.i("Updating existing local patient.");
                 uri = Patients.URI.buildUpon().appendPath(mPatientId).build();
                 mContentResolver.update(uri, patient.toContentValues(),
                     Patients.ID + " = ?", new String[] {mPatientId});
+                LOG.i("Updated local patient %s", mPatientId);
             } else {
-                LOG.i("Adding new local copy of patient.");
-                uri = mContentResolver.insert(
-                    Patients.URI, patient.toContentValues());
+                uri = mContentResolver.insert(Patients.URI, patient.toContentValues());
+                LOG.i("Added new local patient %s", mPatientId);
             }
         }
 

--- a/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncAdapterService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncAdapterService.java
@@ -62,9 +62,9 @@ public class BuendiaSyncAdapterService extends Service {
             engine.cancel();
         }
 
-        @Override public void onPerformSync(Account account, Bundle extras,
+        @Override public void onPerformSync(Account account, Bundle options,
             String authority, ContentProviderClient client, SyncResult result) {
-            engine.sync(SyncAdapterSyncScheduler.getOptions(extras), client, result);
+            engine.sync(options, client, result);
         }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
@@ -125,11 +125,11 @@ public class BuendiaSyncEngine implements SyncEngine {
             return;
         }
 
-        Phase[] phases = getPhases(options);
+        Phase[] phases = options != null ? getPhases(options) : new Phase[0];
         boolean fullSync = Sets.newHashSet(phases).equals(Sets.newHashSet(Phase.ALL));
         LOG.start("sync", "phases=%s, fullSync=%s", Utils.repr(phases), fullSync);
 
-        broadcastSyncProgress(0, R.string.sync_in_progress);
+        //broadcastSyncProgress(0, R.string.sync_in_progress);
 
         BuendiaProvider provider = (BuendiaProvider) client.getLocalContentProvider();
         try (DatabaseTransaction tx = provider.startTransaction(SAVEPOINT_NAME)) {
@@ -141,7 +141,7 @@ public class BuendiaSyncEngine implements SyncEngine {
                 int p = 0;
                 for (Phase phase : phases) {
                     checkCancellation("before " + phase);
-                    broadcastSyncProgress(p * 100 / phases.length, phase.message);
+                    //broadcastSyncProgress(p * 100 / phases.length, phase.message);
                     phase.runnable.sync(contentResolver, result, client);
                     LOG.elapsed("sync", "Completed phase %s", phase);
                     p++;

--- a/app/src/main/java/org/projectbuendia/client/sync/BundleWrapper.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/BundleWrapper.java
@@ -1,0 +1,48 @@
+package org.projectbuendia.client.sync;
+
+import android.os.Bundle;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BundleWrapper {
+    private Bundle bundle;
+
+    public BundleWrapper(Bundle bundle) {
+        this.bundle = bundle;
+    }
+
+    public Bundle getBundle() {
+        return bundle;
+    }
+
+    @Override public int hashCode() {
+        List<String> keys = new ArrayList<>(bundle.keySet());
+        Collections.sort(keys);
+        Object[] pairs = new Object[keys.size() * 2];
+        int i = 0;
+        for (String key : keys) {
+            pairs[i++] = key;
+            pairs[i++] = bundle.get(key);
+        }
+        return Arrays.hashCode(pairs);
+    }
+
+    @Override public boolean equals(Object obj) {
+        if (obj instanceof BundleWrapper) {
+            BundleWrapper other = (BundleWrapper) obj;
+            if (!bundle.keySet().equals(other.bundle.keySet())) {
+                return false;
+            }
+            for (String key : bundle.keySet()) {
+                if (!bundle.get(key).equals(other.bundle.get(key))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncAccountService.java
@@ -45,7 +45,7 @@ public class SyncAccountService extends Service {
     /** Sets up the sync account for this app. */
     public static void initialize(Context context) {
         if (createAccount(context) || !sSettings.getSyncAccountInitialized()) {
-            sSyncManager.startFullSync();
+            sSyncManager.syncAll();
             sSettings.setSyncAccountInitialized(true);
         }
     }

--- a/app/src/main/java/org/projectbuendia/client/sync/SyncScheduler.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/SyncScheduler.java
@@ -11,9 +11,12 @@ public interface SyncScheduler<T> {
     void stopSyncing();
 
     /**
-     * Starts, changes, or stops the periodic sync schedule.  There can be at most
-     * one such repeating loop; any periodic sync from a previous call is replaced
-     * with this new one.  Specifying a period of zero stops the periodic sync.
+     * Starts, changes, or stops a periodic sync schedule.  There can be at most
+     * one such repeating loop for each set of options; if this bundle of options
+     * has the same contents as that from a previous call, the repeating loop set
+     * by the previous call is terminated and a new loop is started with the given
+     * period.  When a loop starts, the first sync occurs after the first period
+     * has elapsed.  Specifying a period of zero stops the loop.
      */
     void setPeriodicSync(int periodSec, Bundle options);
 

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/ObservationsSyncPhaseRunnable.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/ObservationsSyncPhaseRunnable.java
@@ -36,38 +36,34 @@ public class ObservationsSyncPhaseRunnable extends IncrementalSyncPhaseRunnable<
     private static final Logger LOG = Logger.create();
 
     public ObservationsSyncPhaseRunnable() {
-        super(
-                "observations",
-                Contracts.Table.OBSERVATIONS,
-                JsonObservation.class);
+        super("observations", Contracts.Table.OBSERVATIONS, JsonObservation.class);
     }
 
     @Override
     protected ArrayList<ContentProviderOperation> getUpdateOps(
-            JsonObservation[] list, SyncResult syncResult) {
-        int deletes = 0;
-        int inserts = 0;
+            JsonObservation[] observations, SyncResult syncResult) {
+        int numInserts = 0;
+        int numDeletes = 0;
         ArrayList<ContentProviderOperation> ops = new ArrayList<>();
-        for (JsonObservation observation: list) {
+        for (JsonObservation observation : observations) {
             if (observation.voided) {
                 Uri uri = Observations.URI.buildUpon().appendPath(observation.uuid).build();
                 ops.add(ContentProviderOperation.newDelete(uri).build());
-                deletes++;
+                numDeletes++;
             } else {
                 ops.add(ContentProviderOperation.newInsert(Observations.URI)
                         .withValues(getObsValuesToInsert(observation)).build());
-                inserts++;
+                numInserts++;
             }
         }
-        LOG.d("Observations processed! Inserts: %d, Deletes: %d", inserts, deletes);
-        syncResult.stats.numInserts += inserts;
-        syncResult.stats.numDeletes += deletes;
+        LOG.d("Observations: %d inserts, %d deletes", numInserts, numDeletes);
+        syncResult.stats.numInserts += numInserts;
+        syncResult.stats.numDeletes += numDeletes;
         return ops;
     }
 
     /** Converts an encounter data response into appropriate inserts in the encounters table. */
-    public static ContentValues getObsValuesToInsert(
-            JsonObservation observation) {
+    public static ContentValues getObsValuesToInsert(JsonObservation observation) {
         ContentValues cvs = new ContentValues();
         cvs.put(Observations.UUID, observation.uuid);
         cvs.put(Observations.PATIENT_UUID, observation.patient_uuid);

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/OrdersSyncPhaseRunnable.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/OrdersSyncPhaseRunnable.java
@@ -21,17 +21,14 @@ public class OrdersSyncPhaseRunnable extends IncrementalSyncPhaseRunnable<JsonOr
     private static final Logger LOG = Logger.create();
 
     public OrdersSyncPhaseRunnable() {
-        super(
-                "orders",
-                Contracts.Table.ORDERS,
-                JsonOrder.class);
+        super("orders", Contracts.Table.ORDERS, JsonOrder.class);
     }
 
     @Override
     protected ArrayList<ContentProviderOperation> getUpdateOps(
             JsonOrder[] orders, SyncResult syncResult) {
-        int numDeletes = 0;
         int numInserts = 0;
+        int numDeletes = 0;
         ArrayList<ContentProviderOperation> ops = new ArrayList<>(orders.length);
         for (JsonOrder order : orders) {
             if (order.voided) {
@@ -42,9 +39,9 @@ public class OrdersSyncPhaseRunnable extends IncrementalSyncPhaseRunnable<JsonOr
                 numInserts++;
             }
         }
-        syncResult.stats.numDeletes += numDeletes;
+        LOG.d("Orders: %d inserts, %d deletes", numInserts, numDeletes);
         syncResult.stats.numInserts += numInserts;
-        LOG.d("Orders processed! Inserts: %d, Deletes: %d", numInserts, numDeletes);
+        syncResult.stats.numDeletes += numDeletes;
         return ops;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
@@ -54,7 +54,6 @@ public class SettingsActivity extends PreferenceActivity {
      * Controls whether to always show the simplified UI, where settings are
      * arranged in a single list without a left navigation panel.
      */
-    private static final boolean ALWAYS_SIMPLE_PREFS = false;
     static final String[] PREF_KEYS = {
         "server",
         "openmrs_user",
@@ -65,7 +64,6 @@ public class SettingsActivity extends PreferenceActivity {
         "keep_form_instances",
         "starting_patient_id",
         "xform_update_client_cache",
-        "incremental_observation_update",
         "require_wifi"
     };
     static boolean updatingPrefValues = false;
@@ -148,12 +146,12 @@ public class SettingsActivity extends PreferenceActivity {
     }
 
     @Override public boolean onIsMultiPane() {
-        return isXLargeTablet(this) && !isSimplePreferences(this);
+        return isXLargeTablet(this) && !useSimplePreferences(this);
     }
 
     @Override @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public void onBuildHeaders(List<Header> target) {
-        if (!isSimplePreferences(this)) {
+        if (!useSimplePreferences(this)) {
             loadHeadersFromResource(R.xml.pref_headers, target);
         }
     }
@@ -245,23 +243,17 @@ public class SettingsActivity extends PreferenceActivity {
      * that a simplified, single-pane UI should be shown.
      */
     private void setupSimplePreferencesScreen() {
-        if (!isSimplePreferences(this)) return;
-
-        // The simplified UI uses the old PreferenceActivity API instead of PreferenceFragment.
-        addPreferencesFromResource(R.xml.pref_general);
-        addPreferencesFromResource(R.xml.pref_advanced);
-        addPreferencesFromResource(R.xml.pref_developer);
-        initPrefs(this);
+        if (useSimplePreferences(this)) {
+            // The simplified UI uses the old PreferenceActivity API instead of PreferenceFragment.
+            addPreferencesFromResource(R.xml.pref_general);
+            addPreferencesFromResource(R.xml.pref_advanced);
+            addPreferencesFromResource(R.xml.pref_developer);
+            initPrefs(this);
+        }
     }
 
-    /**
-     * Determines whether the simplified settings UI should be shown. This is
-     * true if this is forced via {@link #ALWAYS_SIMPLE_PREFS}, or the device
-     * doesn't have newer APIs like {@link PreferenceFragment}, or the device
-     * doesn't have an extra-large screen. In these cases, a single-pane
-     * "simplified" settings UI should be shown.
-     */
-    private static boolean isSimplePreferences(Context context) {
+    /** Determines whether the simplified settings UI should be shown. */
+    private static boolean useSimplePreferences(Context context) {
         return !isXLargeTablet(context);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -104,16 +104,15 @@ public class ChartRenderer {
             mView.loadUrl("file:///android_asset/no_chart.html");
             return;
         }
-        LOG.i("Rendering %d observations, %d orders, zoom index %d", observations.size(), orders.size(), mSettings.getChartZoomIndex());
         if (mLastChartName.equals(chart.name) &&
             mLastRenderedZoomIndex == mSettings.getChartZoomIndex() &&
             observations.equals(mLastRenderedObs) &&
             orders.equals(mLastRenderedOrders)) {
-            LOG.i("Data and zoom index have not changed; skipping render");
+            LOG.i("%d observations, %d orders, and zoom index %d unchanged; skipping render", observations.size(), orders.size(), mSettings.getChartZoomIndex());
             return;
         }
 
-        LOG.start("render");
+        LOG.start("render", "%d observations, %d orders, zoom index %d", observations.size(), orders.size(), mSettings.getChartZoomIndex());
 
         // setDefaultFontSize is supposed to take a size in sp, but in practice
         // the fonts don't change size when the user font size preference changes.

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
@@ -119,10 +119,6 @@ public class GoToPatientDialogFragment extends DialogFragment {
             mPatientSearchResult.setText(patient.givenName + " " + patient.familyName +
                 " (" + patient.gender + ", " + Utils.birthdateToAge(
                 patient.birthdate, App.getInstance().getResources()) + ")");
-
-            // Perform incremental observation sync to get the patient's admission date
-            // and any other recent observations.
-            mSyncManager.startObservationsAndOrdersSync();
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -151,7 +151,7 @@ final class LocationListController {
         for (LocationFragmentUi fragmentUi : mFragmentUis) {
             fragmentUi.resetSyncProgress();
         }
-        mSyncManager.startFullSync();
+        mSyncManager.syncAll();
     }
 
     private void updateUi() {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/PatientListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/PatientListController.java
@@ -76,7 +76,7 @@ public class PatientListController {
             mUi.showApiHealthProblem();
         } else if (!mInitiatedFullSync) {
             LOG.d("onRefreshRequested");
-            mSyncManager.startFullSync();
+            mSyncManager.syncAll();
             mInitiatedFullSync = true;
         }
     }

--- a/app/src/main/java/org/projectbuendia/client/utils/Logger.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Logger.java
@@ -141,7 +141,7 @@ public final class Logger {
         startTimes.put(key, now);
         lastTimes.put(key, now);
         String formatted = formatIfNeeded(message, args);
-        Log.d(tag, "[" + key + "- 0 ms: " + formatted);
+        Log.d(tag, "[_" + key + "__ 0 ms: " + formatted);
     }
 
     public void elapsed(String key, String message, Object... args) {
@@ -166,7 +166,7 @@ public final class Logger {
             String formatted = formatIfNeeded(message, args);
             String timing = "+" + (now - last);
             if (!start.equals(last)) timing += " = " + (now - start);
-            String prefix = "-" + key + (finish ? "]" : "-");
+            String prefix = "__" + key + (finish ? "_]" : "__");
             Log.d(tag, prefix + " " + timing + " ms: " + formatted);
             lastTimes.put(key, now);
         }


### PR DESCRIPTION

#### Internal changes <!-- optional -->

The new sync infrastructure now supports multiple concurrent repeating syncs with different periods.  We can use this mechanism to update the patient list more frequently when displaying the patient list, and the observations more frequently when displaying the chart, all while performing full syncs periodically to pick up other changes to forms or chart items.