### PR TITLE
Prevent form sync during form entry

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -54,6 +54,7 @@ import org.projectbuendia.client.models.Order;
 import org.projectbuendia.client.models.Patient;
 import org.projectbuendia.client.sync.ChartDataHelper;
 import org.projectbuendia.client.sync.SyncManager;
+import org.projectbuendia.client.sync.controllers.FormsSyncPhaseRunnable;
 import org.projectbuendia.client.ui.BaseLoggedInActivity;
 import org.projectbuendia.client.ui.BigToast;
 import org.projectbuendia.client.ui.OdkActivityLauncher;
@@ -344,6 +345,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
 
     @Override protected void onStartImpl() {
         super.onStartImpl();
+        FormsSyncPhaseRunnable.setDisabled(false);
         mController.init();
     }
 
@@ -354,6 +356,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
 
     @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         mIsFetchingXform = false;
+        FormsSyncPhaseRunnable.setDisabled(false);
         mController.onXFormResult(requestCode, resultCode, data);
     }
 
@@ -574,6 +577,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             Preset preset) {
             if (mIsFetchingXform) return;
 
+            FormsSyncPhaseRunnable.setDisabled(true);
             mIsFetchingXform = true;
             OdkActivityLauncher.fetchAndShowXform(
                 PatientChartActivity.this, formUuid, requestCode, patient, preset);


### PR DESCRIPTION
Issues: Closes #329.
Scope: Form sync, form entry activity

#### User-visible changes

The "Index 0 requested" error should no longer occur.

#### Verification performed

Investigation of #329 showed that the "Index 0 requested" error occurs if and only if a form sync takes place while the form entry activity is open (i.e. after the ODK form was launched, but before it is submitted).  The form sync causes rows in ODK's form table to disappear, and then the absence of the row for the current form is what causes the error upon submission.

To verify this, I first confirmed that form syncs were predictably causing this error.  Then I applied this PR and tried submitting forms with our without form syncs occurring during form entry, and confirmed that form submission was always successful (the "Index 0 request" error never appears).

#### Rationale and alternatives considered

Every time the forms are synced, we download all of them, then delete all the forms in our app's local form table, then insert the new forms.  This all happens on _every_ form sync, even if nothing has changed.  I noticed that in ODK's form table, this somehow also causes rows to be repeatedly deleted and inserted, so the ID numbers of the forms creep up and up as long as the app stays open.

So the first approach I took was to try to stop this repeated deletion and insertion from occurring.  I was not able to find an easy way to do that, so I settled for preventing form syncs from happening during form entry.  But, I think it would still be a better long-term solution to make form sync less destructive.