### PR TITLE
Avoid using Period when calculating relative dates and times.

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/utils/date/RelativeDateTimeFormatterTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/utils/date/RelativeDateTimeFormatterTest.java
@@ -13,14 +13,14 @@ package org.projectbuendia.client.utils.date;
 
 import android.support.test.runner.AndroidJUnit4;
 
-import androidx.test.filters.SmallTest;
-
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.projectbuendia.client.utils.RelativeDateTimeFormatter;
+
+import androidx.test.filters.SmallTest;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -44,6 +44,12 @@ public class RelativeDateTimeFormatterTest   {
     }
 
     @Test
+    public void testFormat_17minutesAgo() throws Exception {
+        assertEquals("17 min ago", mFormatter.format(mNow.minusMinutes(17), mNow));
+    }
+
+
+    @Test
     public void testFormat_60minutesAgo() throws Exception {
         assertEquals("60 min ago", mFormatter.format(mNow.minusHours(1), mNow));
     }
@@ -58,6 +64,11 @@ public class RelativeDateTimeFormatterTest   {
         assertEquals("2 days ago", mFormatter.format(mNow.minusDays(2), mNow));
     }
 
+    // Regression test for https://github.com/projectbuendia/client/issues/389
+    @Test public void testFormat_moreThanAMonthAgo() throws Exception {
+        assertEquals("99 days ago", mFormatter.format(mNow.minusDays(99), mNow));
+    }
+
     @Test
     public void testFormatLocalDate_today() {
         assertEquals("today", mFormatter.format(mToday, mToday));
@@ -65,7 +76,6 @@ public class RelativeDateTimeFormatterTest   {
 
     @Before
     public void setup() {
-
         mFormatter = new RelativeDateTimeFormatter();
         mNow = DateTime.parse("2000-01-01T12:00Z");
         mToday = LocalDate.parse("2000-01-01");

--- a/app/src/main/java/org/projectbuendia/client/utils/RelativeDateTimeFormatter.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/RelativeDateTimeFormatter.java
@@ -12,8 +12,9 @@
 package org.projectbuendia.client.utils;
 
 import org.joda.time.DateTime;
+import org.joda.time.Days;
+import org.joda.time.Duration;
 import org.joda.time.LocalDate;
-import org.joda.time.Period;
 
 /**
  * An object that pretty-prints JODA {@link LocalDate}s using relative phrases
@@ -32,8 +33,7 @@ public class RelativeDateTimeFormatter {
         if (date.isAfter(anchor)) {
             return "in the future"; // TODO/i18n
         }
-        Period period = new Period(date, anchor);
-        int daysAgo = period.toStandardDays().getDays();
+        int daysAgo = Days.daysBetween(date, anchor).getDays();
         return daysAgo > 1 ? daysAgo + " days ago" : // TODO/i18n
             daysAgo == 1 ? "yesterday" : "today"; // TODO/i18n
     }
@@ -47,10 +47,11 @@ public class RelativeDateTimeFormatter {
         if (dateTime.isAfter(anchor)) {
             return "in the future"; // TODO/i18n
         }
-        Period period = new Period(dateTime, anchor);
-        int daysAgo = period.toStandardDays().getDays();
-        int hoursAgo = period.toStandardHours().getHours();
-        int minutesAgo = period.toStandardMinutes().getMinutes();
+
+        long millis = new Duration(dateTime, anchor).getMillis();
+        long daysAgo = millis / Utils.DAY;
+        long hoursAgo = millis / Utils.HOUR;
+        long minutesAgo = millis / Utils.MINUTE;
 
         return daysAgo > 1 ? daysAgo + " days ago" : // TODO/i18n
             hoursAgo > 1 ? hoursAgo + " hours ago" : // TODO/i18n

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -73,6 +73,7 @@ public class Utils {
     public static final int SECOND = 1000;  // in ms
     public static final int MINUTE = 60 * SECOND;  // in ms
     public static final int HOUR = 60 * MINUTE;  // in ms
+    public static final int DAY = 24 * HOUR;  // in ms
 
     private static Map<Integer, String> sHttpMethods = initHttpMethods();
     private static Map<Integer, String> initHttpMethods() {


### PR DESCRIPTION
Issues: Closes #389
Scope: Ebola test date display

#### User-visible changes

Patient charts that had their last Ebola test more than a month ago previously could not be opened; they would trigger a crash.

That crash no longer occurs.

#### Internal changes <!-- optional -->

`Period` is not safe to use for date calculations, because months have variable number of days.  If a `Period` is asked to perform any calculation that involves converting months to days, it will throw an exception.

The relevant calculations are now done using `Days` or `Duration` objects.

#### Verification performed

Previously, Patient 1 ("John Doe") would reliably cause a crash every time I tried to open the patient chart.  I confirmed that with this fix, I can open the chart successfully.
