### PR TITLE
Fix activity stack behaviour with singleTop instead of singleInstance.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,7 +96,7 @@
             android:label="@string/title_patient_list"
             android:parentActivityName=".ui.lists.LocationListActivity"
             android:screenOrientation="userPortrait"
-            android:launchMode="singleInstance">
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.nfc.action.TAG_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -108,7 +108,7 @@
             android:parentActivityName=".ui.lists.FilteredPatientListActivity"
             android:screenOrientation="userPortrait"
             android:uiOptions="splitActionBarWhenNarrow"
-            android:launchMode="singleInstance">
+            android:launchMode="singleTop">
             <meta-data
                 android:name="android.support.UI_OPTIONS"
                 android:value="splitActionBarWhenNarrow" />


### PR DESCRIPTION
Issues: Closes #395.
Scope: Navigation

#### User-visible changes

See #395 for a description of the bad behaviour.  With this fix, leaving and returning to the app brings you back to where you left off, and the mysterious blank activity no longer occurs.
