### PR TITLE
Fix up how location names are displayed

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/PatientListTypedCursorAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/PatientListTypedCursorAdapter.java
@@ -98,21 +98,14 @@ public class PatientListTypedCursorAdapter extends BaseExpandableListAdapter {
     @Override public View getGroupView(
         int groupPosition, boolean isExpanded, View convertView, ViewGroup parent) {
         Location location = getGroup(groupPosition);
-
-        int patientCount = getChildrenCount(groupPosition);
-        String tentName = location.toString();
-
-        if (convertView == null) {
-            convertView = newGroupView();
-        }
+        View view = convertView != null ? convertView : newGroupView();
 
         ExpandableListView expandableListView = (ExpandableListView) parent;
         expandableListView.expandGroup(groupPosition);
-
-        TextView item = convertView.findViewById(R.id.patient_list_tent_tv);
-        item.setText(PatientCountDisplay.getPatientCountTitle(mContext, patientCount, tentName));
-
-        return convertView;
+        TextView item = view.findViewById(R.id.patient_list_tent_tv);
+        item.setText(PatientCountDisplay.getPatientCountTitle(
+            mContext, getChildrenCount(groupPosition), location.name));
+        return view;
     }
 
     @Override public Location getGroup(int groupPosition) {

--- a/app/src/main/java/org/projectbuendia/client/ui/SectionedSpinnerAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SectionedSpinnerAdapter.java
@@ -110,7 +110,8 @@ public class SectionedSpinnerAdapter<T> extends ArrayAdapter<T> {
     }
 
     @Override public int getViewTypeCount() {
-        return 2;
+        // For targetSdkVersion >= LOLLIPOP (21), this is required to return 1.
+        return 1;
     }
 
     /**

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -495,7 +495,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
 
         public void updatePatientLocationUi(LocationForest forest, Patient patient) {
             Location location = forest.get(patient.locationUuid);
-            String locationText = Utils.toStringOrDefault(location, "Unknown"); // TODO/i18n
+            String locationText = location != null ? location.name : getString(R.string.unknown);
 
             mPatientLocationView.setValue(locationText);
             mPatientLocationView.setIcon(createIcon(FontAwesomeIcons.fa_map_marker, R.color.chart_tile_icon));

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/PatientLocationDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/PatientLocationDialogFragment.java
@@ -103,11 +103,8 @@ public class PatientLocationDialogFragment extends DialogFragment {
             null, c.str(R.string.all_present_patients), numPatients - numDischarged, fg, bg, 1));
         for (Location location : forest.allNodes()) {
             if (!eq(location, discharged)) {
-                // A parenthesized number can be included at the front of the location name
-                // to determine its sorting order; the number will not be displayed.
-                String displayName = location.name.replaceAll("^\\(.*?\\)\\s*", "");
                 options.add(new LocationOption(
-                    location.uuid, displayName, forest.countPatientsIn(location), fg, bg, 0.5));
+                    location.uuid, location.name, forest.countPatientsIn(location), fg, bg, 0.5));
             }
         }
         if (discharged != null) {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListAdapter.java
@@ -97,7 +97,7 @@ public class LocationListAdapter extends ArrayAdapter<Location> {
             .resolve(mContext.getResources());
 
         long count = mForest.countPatientsIn(location);
-        holder.mButton.setTitle(location.toString());
+        holder.mButton.setTitle(location.name);
         holder.mButton.setSubtitle("" + count);
         holder.mButton.setBackgroundColor(zone.getBackgroundColor());
         holder.mButton.setTextColor(zone.getForegroundColor());


### PR DESCRIPTION
Issues: Closes #414.

Location names may be prefixed with extra information in square brackets.  This information is not displayed on the client, but:

  - It is considered when sorting; thus you can control the sort order of locations by putting "[1]", "[2]", etc. in front.  The sort is alphanumeric, so "[2]" will properly come before "[11]".
  - It allows you to specify the default location with an asterisk, e.g. "[2*] Triage"