### PR TITLE
Preset the location_id and provider_id in the form using UUIDs in the XForm

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
@@ -157,26 +157,14 @@ public final class PatientChartControllerTest {
             any(Encounter.class));
     }
 
-    /** Tests that requesting an xform through clicking 'add observation' shows loading dialog. */
+    /** Tests that selecting a form from the menu shows loading dialog. */
     @Test
     @UiThreadTest
-    public void testAddObservation_showsLoadingDialog() {
-        // GIVEN controller is initialized
-        mController.init();
-        // WHEN 'add observation' is pressed
-        mController.onAddObservationPressed();
-        // THEN the controller displays the loading dialog
-        verify(mMockUi).showFormLoadingDialog(true);
-    }
-
-    /** Tests that requesting an xform through clicking on a vital shows loading dialog. */
-    @Test
-    @UiThreadTest
-    public void testVitalClick_showsLoadingDialog() {
+    public void testOpenForm_showsLoadingDialog() {
         // GIVEN controller is initialized
         mController.init();
         // WHEN a vital is pressed
-        mController.onAddObservationPressed("foo");
+        mController.onOpenFormPressed("foo");
         // THEN the controller displays the loading dialog
         verify(mMockUi).showFormLoadingDialog(true);
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/OdkActivityLauncher.java
@@ -154,7 +154,7 @@ public class OdkActivityLauncher {
      * @param formId          the id of the form to fetch
      * @param patient         the {@link org.odk.collect.android.model.Patient} that this form entry will
      *                        correspond to
-     * @param fields          a {@link Preset} object with any form fields that should be
+     * @param preset          a {@link Preset} object with any form fields that should be
      *                        pre-populated
      */
     public static void showOdkCollect(
@@ -162,7 +162,7 @@ public class OdkActivityLauncher {
         int requestCode,
         long formId,
         @Nullable org.odk.collect.android.model.Patient patient,
-        @Nullable Preset fields) {
+        @Nullable Preset preset) {
         Intent intent = new Intent(callingActivity, FormEntryActivity.class);
         Uri formUri = ContentUris.withAppendedId(FormsProviderAPI.FormsColumns.CONTENT_URI, formId);
         intent.setData(formUri);
@@ -170,8 +170,8 @@ public class OdkActivityLauncher {
         if (patient != null) {
             intent.putExtra("patient", patient);
         }
-        if (fields != null) {
-            intent.putExtra("fields", fields);
+        if (preset != null) {
+            intent.putExtra("fields", preset);
         }
         callingActivity.startActivityForResult(intent, requestCode);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,7 @@
   <string name="patient_list_fragment_sync_error">Error syncing patient data. Please check settings or try again.</string>
   <string name="api_health_problem">Unable to contact the server.  Please see the bar along the bottom of the screen for more information about the problem.</string>
   <string name="sync_failed_back">Back</string>
+  <string name="no_user">No user is logged in.</string>
   <string name="encounter_add_failed_unknown_reason">An unknown error occurred.</string>
   <string name="encounter_add_failed_unknown_server_error">Unknown error occurred on server.</string>
   <string name="encounter_add_failed_interrupted">Network request was interrupted.</string>

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/model/Preset.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/model/Preset.java
@@ -6,9 +6,7 @@ import android.os.Parcelable;
 import org.joda.time.DateTime;
 import org.odk.collect.android.utilities.Parcels;
 
-/**
- * An object that contains the prepopulatable fields
- */
+/** A Parcelable data object that specifies preset values for certain form fields. */
 public class Preset implements Parcelable {
 
     public static final int UNSPECIFIED = -1;
@@ -16,19 +14,19 @@ public class Preset implements Parcelable {
     public static final int YES = 2;
     public static final int NO = 3;
 
-    public DateTime encounterTime;
-    public String locationName;
-    public String clinicianName;
+    public DateTime encounterDatetime;  // the preset value for encounter.encounter_datetime
+    public String locationUuid;  // UUID of the preset value for encounter.location_id
+    public String providerUuid;  // UUID of the preset value for encounter.provider_id
     public int pregnant = UNSPECIFIED;
     public int ivFitted = UNSPECIFIED;
-    public String targetGroup;
+    public String targetGroup;  // text of a section heading in the form to scroll to
 
     public Preset() {}
 
     public Preset(Parcel in) {
-        encounterTime = Parcels.readNullableDateTime(in);
-        locationName = Parcels.readNullableString(in);
-        clinicianName = Parcels.readNullableString(in);
+        encounterDatetime = Parcels.readNullableDateTime(in);
+        locationUuid = Parcels.readNullableString(in);
+        providerUuid = Parcels.readNullableString(in);
         pregnant = in.readInt();
         ivFitted = in.readInt();
         targetGroup = Parcels.readNullableString(in);
@@ -41,9 +39,9 @@ public class Preset implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        Parcels.writeNullableDateTime(dest, encounterTime);
-        Parcels.writeNullableString(dest, locationName);
-        Parcels.writeNullableString(dest, clinicianName);
+        Parcels.writeNullableDateTime(dest, encounterDatetime);
+        Parcels.writeNullableString(dest, locationUuid);
+        Parcels.writeNullableString(dest, providerUuid);
         dest.writeInt(pregnant);
         dest.writeInt(ivFitted);
         Parcels.writeNullableString(dest, targetGroup);


### PR DESCRIPTION
This is the companion to https://github.com/projectbuendia/buendia/pull/155.  The encounter provider and encounter location fields are now automatically set correctly, and these questions are always hidden.  The `Preset` mechanism is tidied up and simplified.
