### PR TITLE
Make "Apply and clear local data" perform a proper reset

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -68,6 +68,14 @@ public class AppModel {
     private Receiver<LocationForest> onForestRebuiltListener = null;
     private Receiver<LocationForest> onForestUpdatedListener = null;
 
+    /** Clears all in-memory model state. */
+    public void reset() {
+        synchronized (loadedForestLock) {
+            loadedForest = null;
+            loadedForestLocale = null;
+        }
+    }
+
     /**
      * Returns true iff the model has previously been fully downloaded from the server--that is, if
      * locations, patients, users, charts, and observations were all downloaded at some point. Note

--- a/app/src/main/java/org/projectbuendia/client/widgets/EditAndClearDataPreference.java
+++ b/app/src/main/java/org/projectbuendia/client/widgets/EditAndClearDataPreference.java
@@ -18,10 +18,16 @@ import android.util.AttributeSet;
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.R;
+import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.sync.Database;
+import org.projectbuendia.client.utils.Logger;
+
+import java.io.File;
 
 /** Custom Android preference widget that clears the database if new text is entered. */
 public class EditAndClearDataPreference extends EditTextPreference {
+    private static Logger LOG = Logger.create();
+
     public EditAndClearDataPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
         setPositiveButtonText(R.string.clear_data_button);
@@ -30,11 +36,50 @@ public class EditAndClearDataPreference extends EditTextPreference {
     public void onDialogClosed(boolean positive) {
         super.onDialogClosed(positive);
         if (positive) {
+            clearDatabase();
+            clearMemoryState();
+            clearOdkState();
+        }
+    }
+
+    private void clearDatabase() {
+        try {
             Database db = new Database(App.getInstance().getApplicationContext());
             db.clear();
             db.close();
-            App.getUserManager().reset();
-            App.getInstance().get(AppSettings.class).setSyncAccountInitialized(false);
+        } catch (Throwable t) {
+            LOG.e(t, "Failed to clear database");
         }
+    }
+
+    private void clearMemoryState() {
+        try {
+            App.getUserManager().reset();
+            App.getInstance().get(AppModel.class).reset();
+            App.getInstance().get(AppSettings.class).setSyncAccountInitialized(false);
+        } catch (Throwable t) {
+            LOG.e(t, "Failed to clear in-memory state");
+        }
+    }
+
+    private void clearOdkState() {
+        try {
+            File filesDir = App.getInstance().getApplicationContext().getFilesDir();
+            File odkDir = new File(filesDir, "odk");
+            File odkTempDir = new File(filesDir, "odk-deleted." + System.currentTimeMillis());
+            odkDir.renameTo(odkTempDir);
+            recursivelyDelete(odkTempDir);
+        } catch (Throwable t) {
+            LOG.e(t, "Failed to clear ODK state");
+        }
+    }
+
+    private void recursivelyDelete(File path) {
+        if (path.isDirectory()) {
+            for (File child : path.listFiles()) {
+                recursivelyDelete(child);
+            }
+        }
+        path.delete();
     }
 }


### PR DESCRIPTION
Prior to this PR, it was possible for a bug in the server to drop incompatible XForm data in the `odk/` directory that would cause the app to malfunction persistently, even after using "Apply and clear local data".

With this PR, it now clears the in-memory forest and the `odk/` directory as well as the SQLite database.