### PR TITLE
Improve efficiency of forest updating based on patient changes

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/FakeForestFactory.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/FakeForestFactory.java
@@ -36,7 +36,7 @@ public class FakeForestFactory {
      * @return the constructed {@link LocationForest}
      */
     public static LocationForest build() {
-        return new LocationForest(new FakeTypedCursor<>(
+        return LocationForest.createFromCursor(new FakeTypedCursor<>(
             getSiteLocation(),
             getTriageZoneLocation(),
             getDischargedZoneLocation(),
@@ -71,6 +71,6 @@ public class FakeForestFactory {
     }
 
     public static LocationForest emptyForest() {
-        return new LocationForest(new FakeTypedCursor<>());
+        return LocationForest.createFromCursor(new FakeTypedCursor<>());
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/GroupProviderDelegate.java
@@ -134,7 +134,7 @@ class GroupProviderDelegate implements ProviderDelegate<Database> {
         int count = new QueryBuilder(mTable)
             .where(selection, selectionArgs)
             .delete(dbHelper.getWritableDatabase());
-        contentResolver.notifyChange(uri, null, false);
+        if (count > 0) contentResolver.notifyChange(uri, null, false);
         return count;
     }
 
@@ -144,7 +144,7 @@ class GroupProviderDelegate implements ProviderDelegate<Database> {
         int count = new QueryBuilder(mTable)
             .where(selection, selectionArgs)
             .update(dbHelper.getWritableDatabase(), values);
-        contentResolver.notifyChange(uri, null, false);
+        if (count > 0) contentResolver.notifyChange(uri, null, false);
         return count;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/providers/ItemProviderDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/ItemProviderDelegate.java
@@ -74,7 +74,7 @@ public class ItemProviderDelegate implements ProviderDelegate<Database> {
             .where(mIdColumn + "=?", uri.getLastPathSegment())
             .where(selection, selectionArgs)
             .delete(dbHelper.getWritableDatabase());
-        contentResolver.notifyChange(uri, null, false);
+        if (count > 0) contentResolver.notifyChange(uri, null, false);
         return count;
     }
 
@@ -85,7 +85,7 @@ public class ItemProviderDelegate implements ProviderDelegate<Database> {
             .where(mIdColumn + "=?", uri.getLastPathSegment())
             .where(selection, selectionArgs)
             .update(dbHelper.getWritableDatabase(), values);
-        contentResolver.notifyChange(uri, null, false);
+        if (count > 0) contentResolver.notifyChange(uri, null, false);
         return count;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/providers/UsersDelegate.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/UsersDelegate.java
@@ -68,7 +68,7 @@ class UsersDelegate implements ProviderDelegate<Database> {
         int count = new QueryBuilder(Table.USERS)
             .where(selection, selectionArgs)
             .delete(dbHelper.getWritableDatabase());
-        contentResolver.notifyChange(uri, null, false);
+        if (count > 0) contentResolver.notifyChange(uri, null, false);
         return count;
     }
 
@@ -78,7 +78,7 @@ class UsersDelegate implements ProviderDelegate<Database> {
         int count = new QueryBuilder(Table.USERS)
             .where(selection, selectionArgs)
             .update(dbHelper.getWritableDatabase(), values);
-        contentResolver.notifyChange(uri, null, false);
+        if (count > 0) contentResolver.notifyChange(uri, null, false);
         return count;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/FormsSyncWorker.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/FormsSyncWorker.java
@@ -46,7 +46,7 @@ public class FormsSyncWorker implements SyncWorker {
             ops.addAll(getFormUpdateOps(result));
             client.applyBatch(ops);
             LOG.i("Finished updating forms (" + ops.size() + " db ops)");
-            resolver.notifyChange(Contracts.Forms.URI, null, false);
+            if (ops.size() > 0) resolver.notifyChange(Contracts.Forms.URI, null, false);
 
             OdkActivityLauncher.fetchAndCacheAllXforms();
             return true;

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/LocationsSyncWorker.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/LocationsSyncWorker.java
@@ -34,9 +34,11 @@ public class LocationsSyncWorker implements SyncWorker {
     ) throws Throwable {
         ArrayList<ContentProviderOperation> ops = getLocationUpdateOps(result);
         client.applyBatch(ops);
-        resolver.notifyChange(Locations.URI, null, false);
-        resolver.notifyChange(LocationNames.URI, null, false);
-        resolver.notifyChange(LocalizedLocations.URI, null, false);
+        if (ops.size() > 0) {
+            resolver.notifyChange(Locations.URI, null, false);
+            resolver.notifyChange(LocationNames.URI, null, false);
+            resolver.notifyChange(LocalizedLocations.URI, null, false);
+        }
         return true;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/OrdersSyncWorker.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/OrdersSyncWorker.java
@@ -62,6 +62,8 @@ public class OrdersSyncWorker extends IncrementalSyncWorker<JsonOrder> {
 
     @Override public void finalize(
         ContentResolver resolver, SyncResult result, ContentProviderClient client) {
-        resolver.notifyChange(Orders.URI, null, false);
+        if (result.stats.numInserts + result.stats.numDeletes > 0) {
+            resolver.notifyChange(Orders.URI, null, false);
+        }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/PatientsSyncWorker.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/PatientsSyncWorker.java
@@ -69,6 +69,8 @@ public class PatientsSyncWorker extends IncrementalSyncWorker<JsonPatient> {
 
     @Override public void finalize(
         ContentResolver resolver, SyncResult result, ContentProviderClient client) {
-        resolver.notifyChange(Contracts.Patients.URI, null, false);
+        if (result.stats.numInserts + result.stats.numDeletes > 0) {
+            resolver.notifyChange(Contracts.Patients.URI, null, false);
+        }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
@@ -80,6 +80,7 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
 
     /** Changes the state of this fragment, hiding or showing the spinner as necessary. */
     public void setReadyState(ReadyState state) {
+        if (state == mState) return;
         LOG.w("setReadyState %s", state);
 
         mState = state;

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -334,6 +334,9 @@ final class PatientChartController implements ChartRenderer.JsInterface {
             mUi.showError(R.string.no_user);
             return;
         }
+        if (mForest == null) {
+            return;  // we can't submit a form without location information
+        }
 
         // We need to preset the provider and the location so that they don't
         // appear as questions in the form.

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -176,7 +176,9 @@ public class EditPatientDialogFragment extends DialogFragment {
             if (id != null || givenName != null || familyName != null || birthdate != null
                 || sex != Patient.GENDER_UNKNOWN) {
                 LocationForest forest = mModel.getForest(mSettings.getLocaleTag());
-                delta.assignedLocationUuid = Optional.of(forest.getDefaultLocation().uuid);
+                if (forest != null) {
+                    delta.assignedLocationUuid = Optional.of(forest.getDefaultLocation().uuid);
+                }
                 mModel.addPatient(mCrudEventBus, delta);
             }
         } else {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -108,14 +108,8 @@ final class LocationListController {
         mUserCancelRequestPending = false;
         mEventBus.register(mEventBusSubscriber);
         mCrudEventBus.register(mEventBusSubscriber);
-        if (mAppModel.isFullModelAvailable()) {
-            loadForest();
-        } else {
-            LOG.w("Model not available; starting initial sync.");
-            startInitialSync();
-        }
-
         mSyncManager.setPeriodicSync(10, Phase.PATIENTS);
+        loadForest();
     }
 
     public void loadForest() {
@@ -125,7 +119,7 @@ final class LocationListController {
             setForest(forest);
             setReadyState(ReadyState.READY);
         } else {
-            LOG.w("Invalid forest; retrying initial sync.");
+            LOG.w("Forest not available; retrying initial sync.");
             startInitialSync();
         }
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -57,9 +57,9 @@ public final class LocationListFragment extends ProgressFragment {
         LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = super.onCreateView(inflater, container, savedInstanceState);
 
-        LocationForest forest = mModel.getForest(mSettings.getLocaleTag());
         mList = new LocationOptionList(view.findViewById(R.id.list_container), false);
-        mList.setLocations(forest, forest.allNodes());
+        LocationForest forest = mModel.getForest(mSettings.getLocaleTag());
+        if (forest != null) mList.setLocations(forest, forest.allNodes());
         return view;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/PatientSearchController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/PatientSearchController.java
@@ -104,7 +104,6 @@ public class PatientSearchController {
         mFilter = PatientDbFilters.getDefaultFilter();
         mSyncSubscriber = new SyncSubscriber();
         mCreationSubscriber = new CreationSubscriber();
-        mForest = mModel.getForest(mLocale);
     }
 
     /**
@@ -114,6 +113,7 @@ public class PatientSearchController {
     public void init() {
         mGlobalEventBus.register(mSyncSubscriber);
         mCrudEventBus.register(mCreationSubscriber);
+        mForest = mModel.getForest(mLocale);
         mModel.setForestRebuiltListener(this::onForestRebuilt);
     }
 

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -553,7 +553,7 @@ public class FormsProvider extends ContentProvider {
 			throw new IllegalArgumentException("Unknown URI " + uri);
 		}
 
-		getContext().getContentResolver().notifyChange(uri, null);
+		if (count > 0) getContext().getContentResolver().notifyChange(uri, null);
 		return count;
 	}
 
@@ -712,7 +712,7 @@ public class FormsProvider extends ContentProvider {
 			throw new IllegalArgumentException("Unknown URI " + uri);
 		}
 
-		getContext().getContentResolver().notifyChange(uri, null);
+		if (count > 0) getContext().getContentResolver().notifyChange(uri, null);
 		return count;
 	}
 

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -330,7 +330,7 @@ public class InstanceProvider extends ContentProvider {
                 throw new IllegalArgumentException("Unknown URI " + uri);
         }
 
-        getContext().getContentResolver().notifyChange(uri, null);
+        if (count > 0) getContext().getContentResolver().notifyChange(uri, null);
         return count;
     }
 
@@ -385,7 +385,7 @@ public class InstanceProvider extends ContentProvider {
                 throw new IllegalArgumentException("Unknown URI " + uri);
         }
 
-        getContext().getContentResolver().notifyChange(uri, null);
+        if (count > 0) getContext().getContentResolver().notifyChange(uri, null);
         return count;
     }
 


### PR DESCRIPTION
With this PR, when patients are moved from one location to another, the updating of patient counts on the location screens is smooth and pretty responsive.