### PR TITLE
Classify each sync as small, medium, or large; add a pref setting for each interval.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -156,6 +156,14 @@ def serverFantastica = '192.168.1.161'
 // use this setting, then the device will talk to a locally running server instance.
 def serverLocalhost = '127.0.0.1'
 
+// The interval at which we check for APK updates.
+def apkCheckIntervalDefault = 120
+
+// These control the periodic sync frequency for various categories of data.
+def smallSyncIntervalDefault = 10  // for syncs that take less than 100 ms
+def mediumSyncIntervalDefault = 30  // for syncs that take up to 500 ms
+def largeSyncIntervalDefault = 120  // for syncs that take up to 2000 ms
+
 // Just for development.  In production builds, these should be overridden
 // using -Pserver=server -PopenmrsUser=user -PopenmrsPassword=pass etc.
 def serverDefault = serverDev
@@ -175,6 +183,10 @@ def packageServerRootUrl = project.findProperty('server') ?
     'http://' + project.server + ':9001' :
     project.findProperty('packageServerRootUrl') ?: packageServerRootUrlDefault
 def requireWifi = project.findProperty('requireWifi') ?: 'false'
+def apkCheckInterval = project.findProperty('apkCheckInterval') ?: apkCheckIntervalDefault
+def smallSyncInterval = project.findProperty('smallSyncInterval') ?: smallSyncIntervalDefault
+def mediumSyncInterval = project.findProperty('mediumSyncInterval') ?: mediumSyncIntervalDefault
+def largeSyncInterval = project.findProperty('largeSyncInterval') ?: largeSyncIntervalDefault
 
 // This is the password used to encrypt the SQLite database on the tablet.
 // In development builds, the password is an empty string, which leaves the
@@ -215,13 +227,18 @@ android {
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         testApplicationId appId + '.test'
 
-        // Set the default values of preferences.
+        // Set the default values of preferences.  (Note: The third arg to resValue
+        // must always be a string; it will be converted to the specified data type.)
         resValue 'string', 'server_default', server
         resValue 'string', 'openmrs_root_url_default', openmrsRootUrl
         resValue 'string', 'openmrs_user_default', openmrsUser
         resValue 'string', 'openmrs_password_default', openmrsPassword
         resValue 'string', 'package_server_root_url_default', packageServerRootUrl
-        resValue 'bool', 'require_wifi_default', requireWifi
+        resValue 'bool', 'require_wifi_default', '' + requireWifi
+        resValue 'integer', 'apk_check_interval_default', '' + apkCheckInterval
+        resValue 'integer', 'small_sync_interval_default', '' + smallSyncInterval
+        resValue 'integer', 'medium_sync_interval_default', ''+ mediumSyncInterval
+        resValue 'integer', 'large_sync_interval_default', '' + largeSyncInterval
 
         // Allow different sync adapters to be defined for debug and release builds.
         resValue 'string', 'content_authority', contentAuthority

--- a/app/src/main/java/org/projectbuendia/client/AppModule.java
+++ b/app/src/main/java/org/projectbuendia/client/AppModule.java
@@ -68,6 +68,7 @@ import dagger.Provides;
     injects = {
         App.class,
         AppSettings.class,
+        SyncManager.class,
 
         // TODO: Move these into activity-specific modules.
         // Activities

--- a/app/src/main/java/org/projectbuendia/client/AppSettings.java
+++ b/app/src/main/java/org/projectbuendia/client/AppSettings.java
@@ -17,7 +17,6 @@ import android.support.annotation.NonNull;
 
 /** Type-safe access to application settings. */
 public class AppSettings {
-    static final int APK_UPDATE_INTERVAL_DEFAULT = 90; // default to 1.5 minutes.
     SharedPreferences mSharedPreferences;
     Resources mResources;
 
@@ -71,12 +70,13 @@ public class AppSettings {
     }
 
     /**
-     * Gets the minimum period between checks for APK updates, in seconds.
-     * Repeated calls to UpdateManager.checkForUpdate() within this period
-     * will not check the package server for new updates.
+     Gets the minimum period between checks for APK updates, in seconds.
+     Repeated calls to UpdateManager.checkForUpdate() within this period
+     will not check the package server for new updates.
      */
     public int getApkUpdateInterval() {
-        return mSharedPreferences.getInt("apk_update_interval_secs", APK_UPDATE_INTERVAL_DEFAULT);
+        return mSharedPreferences.getInt("apk_update_interval",
+            mResources.getInteger(R.integer.apk_check_interval_default));
     }
 
     /** Gets the setting for whether to save filled-in forms locally. */
@@ -119,4 +119,28 @@ public class AppSettings {
     public String getLocaleTag() {
         return "en";
     }
+
+    /** Gets the interval for fast incremental syncs (patients, orders, observations). */
+    // Syncs in this category should typically take less than 100 ms.
+    public int getSmallSyncInterval() {
+        return mSharedPreferences.getInt("small_sync_interval",
+            mResources.getInteger(R.integer.small_sync_interval_default));
+    }
+
+    /** Gets the interval for syncs that are non-incremental but small (locations, users). */
+    // This category is for syncs expected to take up to 500 ms, for data
+    // that changes (on average) less than once an hour.
+    public int getMediumSyncInterval() {
+       return mSharedPreferences.getInt("medium_sync_interval",
+           mResources.getInteger(R.integer.medium_sync_interval_default));
+    }
+
+    /** Gets the interval for syncs that are non-incremental and large (concepts, forms). */
+    // This category is for syncs expected to take up to 2000 ms, for data
+    // that changes (on average) less than once a day.
+    public int getLargeSyncInterval() {
+        return mSharedPreferences.getInt("large_sync_interval",
+            mResources.getInteger(R.integer.large_sync_interval_default));
+    }
 }
+

--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -51,6 +51,7 @@ import static org.projectbuendia.client.utils.Utils.eq;
  * not need to worry about the implementation details of this.
  */
 public class AppModel {
+    // The UUID of the single OpenMRS form that defines all our charts.
     public static final String CHART_UUID = "ea43f213-66fb-4af6-8a49-70fd6b9ce5d4";
 
     // This is a custom Buendia-specific concept to indicate that a treatment order
@@ -75,6 +76,8 @@ public class AppModel {
         synchronized (loadedForestLock) {
             loadedForest = null;
             loadedForestLocale = null;
+            onForestRebuiltListener = null;
+            onForestUpdatedListener = null;
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/sync/ThreadedSyncScheduler.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ThreadedSyncScheduler.java
@@ -112,6 +112,10 @@ public class ThreadedSyncScheduler implements SyncScheduler {
 
                         case SET_PERIODIC_SYNC:
                             LOG.d("* handleMessage(SET_PERIODIC_SYNC, %s), loop=%s", data, loop);
+                            if (periodSec == loop.periodSec) {
+                                LOG.d("* requested period (%s sec) is already in effect", periodSec);
+                                return true;
+                            }
                             loop.set(periodSec);
                             LOG.d("* activeLoopId is now %d for options=%s", loop.activeLoopId, options);
 

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
@@ -423,6 +423,7 @@ public abstract class BaseActivity extends FragmentActivity {
         }
         EventBus.getDefault().registerSticky(this);
         App.getInstance().getHealthMonitor().start();
+        App.getInstance().getSyncManager().initPeriodicSyncs();
         Utils.logEvent("resumed_activity", "class", this.getClass().getSimpleName());
     }
 
@@ -430,7 +431,6 @@ public abstract class BaseActivity extends FragmentActivity {
         EventBus.getDefault().unregister(this);
         App.getInstance().getHealthMonitor().stop();
         pausedScaleStep = sScaleStep;
-
         super.onPause();
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
@@ -61,7 +61,10 @@ public class SettingsActivity extends PreferenceActivity {
         "openmrs_password",
         "openmrs_root_url",
         "package_server_root_url",
-        "apk_update_interval_secs",
+        "apk_update_interval",
+        "small_sync_interval",
+        "medium_sync_interval",
+        "large_sync_interval",
         "keep_form_instances",
         "starting_patient_id",
         "xform_update_client_cache",
@@ -208,7 +211,10 @@ public class SettingsActivity extends PreferenceActivity {
             case "openmrs_user":
             case "openmrs_root_url":
             case "package_server_root_url":
-            case "apk_update_interval_secs":
+            case "apk_update_interval":
+            case "small_sync_interval":
+            case "medium_sync_interval":
+            case "large_sync_interval":
                 pref.setSummary(str);
         }
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
@@ -143,8 +143,6 @@ public abstract class BaseSearchablePatientListActivity extends BaseLoggedInActi
                 }
             }
         }
-
-        mSyncManager.initPeriodicSyncs();
     }
 
     @Override protected void onResumeImpl() {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -21,7 +21,6 @@ import org.projectbuendia.client.events.sync.SyncSucceededEvent;
 import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.models.Location;
 import org.projectbuendia.client.models.LocationForest;
-import org.projectbuendia.client.sync.BuendiaSyncEngine.Phase;
 import org.projectbuendia.client.sync.SyncManager;
 import org.projectbuendia.client.ui.ReadyState;
 import org.projectbuendia.client.utils.EventBusRegistrationInterface;
@@ -108,7 +107,6 @@ final class LocationListController {
         mUserCancelRequestPending = false;
         mEventBus.register(mEventBusSubscriber);
         mCrudEventBus.register(mEventBusSubscriber);
-        mSyncManager.setPeriodicSync(10, Phase.PATIENTS);
         loadForest();
     }
 
@@ -164,7 +162,6 @@ final class LocationListController {
 
     /** Frees any resources used by the controller. */
     public void suspend() {
-        mSyncManager.setPeriodicSync(0, Phase.PATIENTS);
         mCrudEventBus.unregister(mEventBusSubscriber);
         mEventBus.unregister(mEventBusSubscriber);
     }

--- a/app/src/main/java/org/projectbuendia/client/widgets/EditAndClearDataPreference.java
+++ b/app/src/main/java/org/projectbuendia/client/widgets/EditAndClearDataPreference.java
@@ -16,9 +16,7 @@ import android.preference.EditTextPreference;
 import android.util.AttributeSet;
 
 import org.projectbuendia.client.App;
-import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.R;
-import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.sync.Database;
 import org.projectbuendia.client.utils.Logger;
 
@@ -55,8 +53,8 @@ public class EditAndClearDataPreference extends EditTextPreference {
     private void clearMemoryState() {
         try {
             App.getUserManager().reset();
-            App.getInstance().get(AppModel.class).reset();
-            App.getInstance().get(AppSettings.class).setSyncAccountInitialized(false);
+            App.getModel().reset();
+            App.getSettings().setSyncAccountInitialized(false);
         } catch (Throwable t) {
             LOG.e(t, "Failed to clear in-memory state");
         }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -340,7 +340,7 @@ S\'il vous plaît patienter pendant que les données du patient et l\'emplacemen
   <string name="pref_title_openmrs_root_url">URL de base d\'OpenMRS</string>
   <string name="pref_title_package_server_url">URL du serveur des packages</string>
 
-  <string name="pref_title_apk_update_interval_secs">APK mise à jour intervalle de vérification (secondes)</string>
+  <string name="pref_title_apk_update_interval">APK mise à jour intervalle de vérification (secondes)</string>
   <string name="pref_title_keep_form_instances">Instances de formulaire de stocker localement</string>
   <string name="pref_desc_keep_form_instances">Normalement formes seront supprimés après avoir été envoyé au serveur. Sélectionnez cette option pour les garder pour le débogage.</string>
   <string name="pref_title_require_wifi">Exiger connexion wifi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,7 +348,11 @@
   <string name="pref_title_openmrs_root_url">OpenMRS base URL</string>
   <string name="pref_title_package_server_url">Package server URL</string>
 
-  <string name="pref_title_apk_update_interval_secs">APK update check interval (seconds)</string>
+  <string name="pref_title_apk_update_interval">App update check interval (seconds)</string>
+  <string name="pref_title_small_sync_interval">Small sync interval (seconds)</string>
+  <string name="pref_title_medium_sync_interval">Medium sync interval (seconds)</string>
+  <string name="pref_title_large_sync_interval">Large sync interval (seconds)</string>
+
   <string name="pref_title_keep_form_instances">Store form instances locally</string>
   <string name="pref_desc_keep_form_instances">Normally forms will be deleted after being sent to the server. Select this to keep them for debugging.</string>
   <string name="pref_title_require_wifi">Require Wi-Fi connection</string>

--- a/app/src/main/res/xml/pref_advanced.xml
+++ b/app/src/main/res/xml/pref_advanced.xml
@@ -1,31 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <org.projectbuendia.client.widgets.EditAndClearDataPreference
-        android:key="openmrs_root_url"
-        android:title="@string/pref_title_openmrs_root_url"
-        android:defaultValue="@string/openmrs_root_url_default"
-        android:selectAllOnFocus="true"
-        android:inputType="text"
-        android:capitalize="none"
-        android:singleLine="true"
-        android:maxLines="1" />
+    <PreferenceCategory
+        android:title="@string/pref_header_advanced">
 
-    <!-- The server URL to use for software update packages -->
-    <EditTextPreference
-        android:key="package_server_root_url"
-        android:title="@string/pref_title_package_server_url"
-        android:defaultValue="@string/package_server_root_url_default"
-        android:selectAllOnFocus="true"
-        android:inputType="text"
-        android:capitalize="none"
-        android:singleLine="true"
-        android:maxLines="1" />
+        <org.projectbuendia.client.widgets.EditAndClearDataPreference
+            android:key="openmrs_root_url"
+            android:title="@string/pref_title_openmrs_root_url"
+            android:defaultValue="@string/openmrs_root_url_default"
+            android:selectAllOnFocus="true"
+            android:inputType="text"
+            android:capitalize="none"
+            android:singleLine="true"
+            android:maxLines="1" />
 
-    <!-- The delay interval in seconds between looking for APK updates -->
-    <org.projectbuendia.client.widgets.EditIntegerPreference
-        android:key="apk_update_interval_secs"
-        android:title="@string/pref_title_apk_update_interval_secs"
-        android:defaultValue="90" /> <!-- default to 1.5 minutes -->
+        <!-- The server URL to use for software update packages -->
+        <EditTextPreference
+            android:key="package_server_root_url"
+            android:title="@string/pref_title_package_server_url"
+            android:defaultValue="@string/package_server_root_url_default"
+            android:selectAllOnFocus="true"
+            android:inputType="text"
+            android:capitalize="none"
+            android:singleLine="true"
+            android:maxLines="1" />
+
+        <!-- The delay interval in seconds between looking for APK updates -->
+        <org.projectbuendia.client.widgets.EditIntegerPreference
+            android:key="apk_update_interval"
+            android:title="@string/pref_title_apk_update_interval"
+            android:defaultValue="@integer/apk_check_interval_default" />
+
+        <!-- The delay interval in seconds between small (< 100 ms) syncs -->
+        <org.projectbuendia.client.widgets.EditIntegerPreference
+            android:key="small_sync_interval"
+            android:title="@string/pref_title_small_sync_interval"
+            android:defaultValue="@integer/small_sync_interval_default" />
+
+        <!-- The delay interval in seconds between medium-sized (< 500 ms) syncs -->
+        <org.projectbuendia.client.widgets.EditIntegerPreference
+            android:key="medium_sync_interval"
+            android:title="@string/pref_title_medium_sync_interval"
+            android:defaultValue="@integer/medium_sync_interval_default" />
+
+        <!-- The delay interval in seconds between large (< 2000 ms) syncs -->
+        <org.projectbuendia.client.widgets.EditIntegerPreference
+            android:key="large_sync_interval"
+            android:title="@string/pref_title_large_sync_interval"
+            android:defaultValue="@integer/large_sync_interval_default" />
+
+    </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/pref_developer.xml
+++ b/app/src/main/res/xml/pref_developer.xml
@@ -1,32 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- Whether to save filled in forms locally. Normally we won't want to (the file system will fill up
-     but it is useful when developing or debugging -->
-    <CheckBoxPreference
-        android:key="keep_form_instances"
-        android:title="@string/pref_title_keep_form_instances"
-        android:summary="@string/pref_desc_keep_form_instances"
-        android:defaultValue="false" />
+    <PreferenceCategory
+        android:title="@string/pref_header_developer">
 
-    <!-- Whether to assume that no wifi means no network at all -->
-    <CheckBoxPreference
-        android:key="require_wifi"
-        android:title="@string/pref_title_require_wifi"
-        android:summary="@string/pref_desc_require_wifi"
-        android:defaultValue="@bool/require_wifi_default" />
+        <!-- Whether to save filled in forms locally. Normally we won't want to (the file system will fill up
+         but it is useful when developing or debugging -->
+        <CheckBoxPreference
+            android:key="keep_form_instances"
+            android:title="@string/pref_title_keep_form_instances"
+            android:summary="@string/pref_desc_keep_form_instances"
+            android:defaultValue="false" />
 
-    <!-- Whether to launch directly into a patient chart, for faster UX iteration. -->
-    <EditTextPreference
-        android:key="starting_patient_id"
-        android:title="@string/pref_title_starting_patient_id"
-        android:summary="@string/pref_desc_starting_patient_id" />
+        <!-- Whether to assume that no wifi means no network at all -->
+        <CheckBoxPreference
+            android:key="require_wifi"
+            android:title="@string/pref_title_require_wifi"
+            android:summary="@string/pref_desc_require_wifi"
+            android:defaultValue="@bool/require_wifi_default" />
 
-    <!-- Whether to use the SyncAdapter framework; default is to use our own scheduler. -->
-    <CheckBoxPreference
-        android:key="use_sync_adapter"
-        android:title="@string/pref_title_use_sync_adapter"
-        android:summary="@string/pref_desc_use_sync_adapter"
-        android:defaultValue="false" />
+        <!-- Whether to launch directly into a patient chart, for faster UX iteration. -->
+        <EditTextPreference
+            android:key="starting_patient_id"
+            android:title="@string/pref_title_starting_patient_id"
+            android:summary="@string/pref_desc_starting_patient_id" />
 
+        <!-- Whether to use the SyncAdapter framework; default is to use our own scheduler. -->
+        <CheckBoxPreference
+            android:key="use_sync_adapter"
+            android:title="@string/pref_title_use_sync_adapter"
+            android:summary="@string/pref_desc_use_sync_adapter"
+            android:defaultValue="false" />
+
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -14,39 +14,44 @@
     <!-- NOTE: EditTextPreference accepts EditText attributes. -->
     <!-- NOTE: EditTextPreference's summary should be set to its value by the activity code. -->
 
-    <!-- The hostname to use as both OpenMRS server and package server -->
+    <PreferenceCategory
+        android:title="@string/pref_header_general">
 
-    <org.projectbuendia.client.widgets.EditAndClearDataPreference
-        android:key="server"
-        android:title="@string/pref_title_server"
-        android:defaultValue="@string/server_default"
-        android:selectAllOnFocus="true"
-        android:inputType="text"
-        android:digits="abcdefghijklmnopqrstuvwxyz0123456789."
-        android:capitalize="none"
-        android:singleLine="true"
-        android:maxLines="1" />
+        <!-- The hostname to use as both OpenMRS server and package server -->
 
-    <!-- The user to use for OpenMRS requests -->
-    <org.projectbuendia.client.widgets.EditAndClearDataPreference
-        android:key="openmrs_user"
-        android:title="@string/pref_title_openmrs_user"
-        android:defaultValue="@string/openmrs_user_default"
-        android:selectAllOnFocus="true"
-        android:inputType="text"
-        android:capitalize="none"
-        android:singleLine="true"
-        android:maxLines="1" />
+        <org.projectbuendia.client.widgets.EditAndClearDataPreference
+            android:key="server"
+            android:title="@string/pref_title_server"
+            android:defaultValue="@string/server_default"
+            android:selectAllOnFocus="true"
+            android:inputType="text"
+            android:digits="abcdefghijklmnopqrstuvwxyz0123456789."
+            android:capitalize="none"
+            android:singleLine="true"
+            android:maxLines="1" />
 
-    <!-- The password to use for OpenMRS requests -->
-    <org.projectbuendia.client.widgets.EditAndClearDataPreference
-        android:key="openmrs_password"
-        android:title="@string/pref_title_openmrs_password"
-        android:defaultValue="@string/openmrs_password_default"
-        android:selectAllOnFocus="true"
-        android:inputType="textPassword"
-        android:capitalize="none"
-        android:singleLine="true"
-        android:maxLines="1" />
+        <!-- The user to use for OpenMRS requests -->
+        <org.projectbuendia.client.widgets.EditAndClearDataPreference
+            android:key="openmrs_user"
+            android:title="@string/pref_title_openmrs_user"
+            android:defaultValue="@string/openmrs_user_default"
+            android:selectAllOnFocus="true"
+            android:inputType="text"
+            android:capitalize="none"
+            android:singleLine="true"
+            android:maxLines="1" />
+
+        <!-- The password to use for OpenMRS requests -->
+        <org.projectbuendia.client.widgets.EditAndClearDataPreference
+            android:key="openmrs_password"
+            android:title="@string/pref_title_openmrs_password"
+            android:defaultValue="@string/openmrs_password_default"
+            android:selectAllOnFocus="true"
+            android:inputType="textPassword"
+            android:capitalize="none"
+            android:singleLine="true"
+            android:maxLines="1" />
+
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Scope: Preferences, SyncManager

#### User-visible changes

There are three new preference settings in the "Advanced" section that control the sync interval for small, medium, and large phases.

There are also headings shown above each of the three settings sections when they are all combined on page.

#### Internal changes

The ThreadedSyncScheduler now checks if a request for a periodic sync interval would not change anything, and skips processing.  This makes it safe to re-request the periodic sync loops every time an activity resumes: the loop continues on schedule, and the request doesn't trigger extra syncs.