### PR TITLE
Fix "Clear data" operation; simplify injection.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/AppModule.java
+++ b/app/src/main/java/org/projectbuendia/client/AppModule.java
@@ -68,6 +68,7 @@ import dagger.Provides;
     injects = {
         App.class,
         AppSettings.class,
+        SyncManager.class,
 
         // TODO: Move these into activity-specific modules.
         // Activities

--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -51,6 +51,7 @@ import static org.projectbuendia.client.utils.Utils.eq;
  * not need to worry about the implementation details of this.
  */
 public class AppModel {
+    // The UUID of the single OpenMRS form that defines all our charts.
     public static final String CHART_UUID = "ea43f213-66fb-4af6-8a49-70fd6b9ce5d4";
 
     // This is a custom Buendia-specific concept to indicate that a treatment order
@@ -75,6 +76,8 @@ public class AppModel {
         synchronized (loadedForestLock) {
             loadedForest = null;
             loadedForestLocale = null;
+            onForestRebuiltListener = null;
+            onForestUpdatedListener = null;
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/widgets/EditAndClearDataPreference.java
+++ b/app/src/main/java/org/projectbuendia/client/widgets/EditAndClearDataPreference.java
@@ -16,9 +16,7 @@ import android.preference.EditTextPreference;
 import android.util.AttributeSet;
 
 import org.projectbuendia.client.App;
-import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.R;
-import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.sync.Database;
 import org.projectbuendia.client.utils.Logger;
 
@@ -55,8 +53,8 @@ public class EditAndClearDataPreference extends EditTextPreference {
     private void clearMemoryState() {
         try {
             App.getUserManager().reset();
-            App.getInstance().get(AppModel.class).reset();
-            App.getInstance().get(AppSettings.class).setSyncAccountInitialized(false);
+            App.getModel().reset();
+            App.getSettings().setSyncAccountInitialized(false);
         } catch (Throwable t) {
             LOG.e(t, "Failed to clear in-memory state");
         }


### PR DESCRIPTION
#### User-visible changes

None.

#### Internal changes

The dependency injection setup in this project leads to components acquiring dependencies in many different ways:
  - Getting the singleton instance of `App` and requesting for a member variable (e.g. `HealthMonitor`)
  - Getting the singleton instance of `App` and requesting for a static member that the `App` initializes during `onCreate()` by injecting into itself and then copying the member variable to a static member (e.g. `UserManager`)
  - Getting the singleton instance of `App` and calling its `get` method to get a singleton instance of a specified class (e.g. `App.getInstance().get(AppModel.class)`)
  - Injecting into an object's own member variables (e.g. most Activity classes call `App.getInstance().inject(this)` in their `oncCreate()` method)
  - Receiving the dependency as a constructor argument (e.g. most Controller classes have constructors that take a long list of arguments like this)
  - Direct instantiation

These options are chosen essentially at random, creating a giant mess, as dependency injection usually does.

This PR does not fix the whole problem, but it does make many common objects easier to obtain directly through static methods on the `App`, avoiding timing issues and dependency module configuration hazards.