### PR TITLE
Colour the user icons by name, not by UUID

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -150,7 +150,7 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
             .getActionView()
             .findViewById(R.id.user_initials);
 
-        initials.setBackgroundColor(mUserColorizer.getColorArgb(user.uuid));
+        initials.setBackgroundColor(mUserColorizer.getColorArgb(user.fullName));
         initials.setText(user.getInitials());
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/login/UserListAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/login/UserListAdapter.java
@@ -47,7 +47,7 @@ final class UserListAdapter extends ArrayAdapter<JsonUser> {
         }
 
         JsonUser user = getItem(position);
-        holder.initials.setBackgroundColor(mColorizer.getColorArgb(user.uuid));
+        holder.initials.setBackgroundColor(mColorizer.getColorArgb(user.fullName.trim()));
         holder.initials.setText(user.getInitials());
         holder.fullName.setText(user.fullName);
 


### PR DESCRIPTION
Scope: Login screen, Action bar user icon

#### User-visible changes

This PR changes the colours of the squares representing user accounts.  Previously they were generated based on the UUID, which meant that each time you register yourself as a new user you get a random new colour.  With this change, they are generated based on the name, so if you consistently register yourself with the same name you will consistently get the same colour.