### PR TITLE
UUID cleanup

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/FakeForestFactory.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/FakeForestFactory.java
@@ -26,9 +26,9 @@ public class FakeForestFactory {
     public static final String SUSPECT_ZONE_NAME = "Suspect";
     public static final String SUSPECT_1_TENT_NAME = "S1";
     public static final String SUSPECT_2_TENT_NAME = "S2";
-    public static final String SUSPECT_ZONE_UUID = "2f1e2418-ede6-481a-ad80-b9939a7fde8e";
-    public static final String TRIAGE_ZONE_UUID = "3f75ca61-ec1a-4739-af09-25a84e3dd237";
-    public static final String DISCHARGED_ZONE_UUID = "d7ca63c3-6ea0-4357-82fd-0910cc17a2cb";
+    public static final String SUSPECT_ZONE_UUID = "test_location_suspect";
+    public static final String TRIAGE_ZONE_UUID = "test_location_triage";
+    public static final String DISCHARGED_ZONE_UUID = "test_location_discharged";
 
     /**
      * Builds an {@link LocationForest} with a facility, the Triage and Discharged zones, and

--- a/app/src/main/java/org/projectbuendia/client/diagnostics/BuendiaApiHealthCheck.java
+++ b/app/src/main/java/org/projectbuendia/client/diagnostics/BuendiaApiHealthCheck.java
@@ -58,10 +58,10 @@ public class BuendiaApiHealthCheck extends HealthCheck {
         HealthIssue.SERVER_NOT_RESPONDING
     );
 
-    // Retrieving a concept should be quick and ensures that the module is both
+    // Retrieving a concept should be quick and ensures that the module is
     // running and has database access.
     private static final String HEALTH_CHECK_ENDPOINT =
-        "/concepts/" + ConceptUuids.GENERAL_CONDITION_UUID;
+        "/concepts/" + ConceptUuids.PULSE_UUID;
 
     private final Object mLock = new Object();
 

--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -52,13 +52,13 @@ import static org.projectbuendia.client.utils.Utils.eq;
  */
 public class AppModel {
     // The UUID of the single OpenMRS form that defines all our charts.
-    public static final String CHART_UUID = "ea43f213-66fb-4af6-8a49-70fd6b9ce5d4";
+    public static final String CHART_UUID = "buendia_chart";
 
     // This is a custom Buendia-specific concept to indicate that a treatment order
     // has been carried out (e.g. a prescribed medication has been administered).
     // The timestamp of an observation for this concept should be the time the order
     // was executed, and the value of the observation should be the UUID of the order.
-    public static final String ORDER_EXECUTED_CONCEPT_UUID = "buendia-concept-order_executed";
+    public static final String ORDER_EXECUTED_CONCEPT_UUID = "buendia_concept_order_executed";
 
     private static final Logger LOG = Logger.create();
     private final ContentResolver mContentResolver;

--- a/app/src/main/java/org/projectbuendia/client/models/ConceptUuids.java
+++ b/app/src/main/java/org/projectbuendia/client/models/ConceptUuids.java
@@ -70,9 +70,8 @@ public class ConceptUuids {
     };
 
 
-    // ==== Pulse; used only for logging messages to the server.
+    // ==== Pulse; used only for health checks and logging messages to the server.
 
-    // TODO(ping): We should do remote logging a different way.
     public static final String PULSE_UUID = toUuid(5087);
 
 

--- a/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
@@ -46,10 +46,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /** A helper class for retrieving and localizing data to show in patient charts. */
 public class ChartDataHelper {
-    @Deprecated
-    public static final String CHART_GRID_UUID = "ea43f213-66fb-4af6-8a49-70fd6b9ce5d4";
-    @Deprecated
-    public static final String CHART_TILES_UUID = "975afbce-d4e3-4060-a25f-afcd0e5564ef";
 
     private final AppSettings mSettings;
     private final ContentResolver mContentResolver;


### PR DESCRIPTION
#### User-visible changes

None.

#### Internal changes <!-- optional -->

This PR removes more of the unused UUIDs from the app, and establishes a convention for Buendia-specific UUIDs.  The pseudo-UUIDs for Buendia-specific objects all start with `buendia_<type>_` and consistently use the underscore as the word separator.  This reduces the number of long random hex strings that we need to keep track of, and makes these UUIDs easier to read and manage when debugging or investigating data issues.
