### PR TITLE
Fix the auto-layout of the location hierarchy for deeper trees.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -15,6 +15,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ScrollView;
 
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.AppSettings;
@@ -41,6 +42,7 @@ public final class LocationListFragment extends ProgressFragment {
     private LocationListController mController;
     private final Ui mUi = new Ui();
     private LocationOptionList mList;
+    private ScrollView mScroll;
 
     public LocationListFragment() {
         // Required empty public constructor
@@ -57,6 +59,7 @@ public final class LocationListFragment extends ProgressFragment {
         LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = super.onCreateView(inflater, container, savedInstanceState);
 
+        mScroll = view.findViewById(R.id.scroll_container);
         mList = new LocationOptionList(view.findViewById(R.id.list_container), false);
         LocationForest forest = mModel.getForest(mSettings.getLocaleTag());
         if (forest != null) mList.setLocations(forest, forest.allNodes());
@@ -77,6 +80,9 @@ public final class LocationListFragment extends ProgressFragment {
         super.onResume();
         if (mController != null) mController.init();
         mList.setOnLocationSelectedListener(location -> mController.onLocationSelected(location));
+        ViewGroup.LayoutParams lp = mScroll.getLayoutParams();
+        lp.width = ViewGroup.LayoutParams.MATCH_PARENT;
+        mScroll.setLayoutParams(lp);
     }
 
     @Override public void onPause() {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationOptionList.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationOptionList.java
@@ -60,7 +60,7 @@ public class LocationOptionList {
         float colorIndex = 0;
         lastParent = null;
         for (Location location : locations) {
-            double size = 0.99 / (1 << (location.depth - 1));
+            double size = forest.isLeaf(location) ? 0.49 : 1;
             Location parent = forest.getParent(location);
             String parentUuid = parent != null ? parent.uuid : null;
 

--- a/app/src/main/res/layout/fragment_location_selection.xml
+++ b/app/src/main/res/layout/fragment_location_selection.xml
@@ -13,6 +13,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
#### User-visible changes

The layout of the rectangles for the LocationListActivity previously went awry when there were more than two levels in the hierarchy.  This fixes the layout's overall size to match the width of the window and fixes the sizing of child rectangles within the larger rectangles.