### PR TITLE
Allow empty forests

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/FakeForestFactory.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/FakeForestFactory.java
@@ -36,7 +36,7 @@ public class FakeForestFactory {
      * @return the constructed {@link LocationForest}
      */
     public static LocationForest build() {
-        return LocationForest.createFromCursor(new FakeTypedCursor<>(
+        return new LocationForest(new FakeTypedCursor<>(
             getSiteLocation(),
             getTriageZoneLocation(),
             getDischargedZoneLocation(),
@@ -71,6 +71,6 @@ public class FakeForestFactory {
     }
 
     public static LocationForest emptyForest() {
-        return LocationForest.createFromCursor(new FakeTypedCursor<>());
+        return new LocationForest(new FakeTypedCursor<>());
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -151,8 +151,7 @@ public class AppModel {
     private @Nullable LocationForest loadForest(String locale) {
         Uri uri = Contracts.getLocalizedLocationsUri(locale);
         try (Cursor cursor = mContentResolver.query(uri, null, null, null, null)) {
-            return LocationForest.createFromCursor(
-                new TypedCursorWithLoader<>(cursor, LocationQueryResult.LOADER));
+            return new LocationForest(new TypedCursorWithLoader<>(cursor, LocationQueryResult.LOADER));
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
@@ -46,12 +46,7 @@ public class LocationForest {
     private final Map<String, Integer> numPatientsInSubtree = new HashMap<>();
     private int totalNumPatients;
 
-    public static LocationForest createFromCursor(TypedCursor<LocationQueryResult> cursor) {
-        if (cursor.get(0) == null) return null;
-        return new LocationForest(cursor);
-    }
-
-    private LocationForest(TypedCursor<LocationQueryResult> cursor) {
+    public LocationForest(TypedCursor<LocationQueryResult> cursor) {
         List<String> uuids = new ArrayList<>();
         Map<String, String> namesByUuid = new HashMap<>();
         Map<String, String> shortIdsByUuid = new HashMap<>();

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -113,7 +113,7 @@ final class LocationListController {
     public void loadForest() {
         setReadyState(ReadyState.LOADING);
         LocationForest forest = mAppModel.getForest(mSettings.getLocaleTag());
-        if (forest != null && forest.size() > 0) {
+        if (forest != null) {
             setForest(forest);
             setReadyState(ReadyState.READY);
         } else {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -15,6 +15,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ScrollView;
 
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.AppSettings;
@@ -41,6 +42,7 @@ public final class LocationListFragment extends ProgressFragment {
     private LocationListController mController;
     private final Ui mUi = new Ui();
     private LocationOptionList mList;
+    private ScrollView mScroll;
 
     public LocationListFragment() {
         // Required empty public constructor
@@ -57,6 +59,7 @@ public final class LocationListFragment extends ProgressFragment {
         LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = super.onCreateView(inflater, container, savedInstanceState);
 
+        mScroll = view.findViewById(R.id.scroll_container);
         mList = new LocationOptionList(view.findViewById(R.id.list_container), false);
         LocationForest forest = mModel.getForest(mSettings.getLocaleTag());
         if (forest != null) mList.setLocations(forest, forest.allNodes());
@@ -77,6 +80,9 @@ public final class LocationListFragment extends ProgressFragment {
         super.onResume();
         if (mController != null) mController.init();
         mList.setOnLocationSelectedListener(location -> mController.onLocationSelected(location));
+        ViewGroup.LayoutParams lp = mScroll.getLayoutParams();
+        lp.width = ViewGroup.LayoutParams.MATCH_PARENT;
+        mScroll.setLayoutParams(lp);
     }
 
     @Override public void onPause() {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationOptionList.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationOptionList.java
@@ -60,7 +60,7 @@ public class LocationOptionList {
         float colorIndex = 0;
         lastParent = null;
         for (Location location : locations) {
-            double size = 0.99 / (1 << (location.depth - 1));
+            double size = forest.isLeaf(location) ? 0.49 : 1;
             Location parent = forest.getParent(location);
             String parentUuid = parent != null ? parent.uuid : null;
 

--- a/app/src/main/res/layout/fragment_location_selection.xml
+++ b/app/src/main/res/layout/fragment_location_selection.xml
@@ -13,6 +13,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
#### User-visible changes

When there are no locations on the server, the app would previously get stuck syncing over and over endlessly.  It no longer does that.

#### Internal changes <!-- optional -->

This PR accommodates the possibility that a `LocationForest` can contain zero locations; this makes the app more robust and lets us avoid passing a `null` to indicate an empty forest.