### PR TITLE
Simplify and tidy up the display of OpenMRS error messages

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsErrorListener.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsErrorListener.java
@@ -11,16 +11,9 @@
 
 package org.projectbuendia.client.net;
 
-import android.graphics.Color;
-import android.view.View;
-import android.widget.Toast;
-
 import com.android.volley.AuthFailureError;
-import com.android.volley.NetworkError;
 import com.android.volley.NoConnectionError;
-import com.android.volley.ParseError;
 import com.android.volley.Response.ErrorListener;
-import com.android.volley.ServerError;
 import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 import com.google.gson.JsonElement;
@@ -29,65 +22,46 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 
 import org.projectbuendia.client.App;
+import org.projectbuendia.client.ui.BigToast;
 import org.projectbuendia.client.utils.Logger;
+import org.projectbuendia.client.utils.Utils;
 
 public class OpenMrsErrorListener implements ErrorListener {
 
     private static final Logger LOG = Logger.create();
 
-    private int statusCode;
-    private String errorType;
-
-    /**
-     * intended to be the Default behavior this method could be overridden to better
-     * suit the request's need.
-     * @param error
-     */
-    @Override
-    public void onErrorResponse(VolleyError error) {
-        displayErrorMessage(parseResponse(error));
+    /** Default error-handling behaviour; can be overridden to suit the situation. */
+    @Override public void onErrorResponse(VolleyError error) {
+        displayVolleyError(error);
     }
 
-
-    public String parseResponse(VolleyError error) {
-        String message = "Empty response";
-        String errorMessage = error.getMessage();
-
-        if (error.networkResponse != null) {
-
-            statusCode = error.networkResponse.statusCode;
-
-            if( error instanceof NetworkError) {
-                errorType = "NetworkError";
-            } else if( error instanceof ServerError) {
-                errorType = "ServerError";
-            } else if( error instanceof AuthFailureError) {
-                errorType = "AuthFailureError";
-            } else if( error instanceof ParseError) {
-                errorType = "ParseError";
-            } else if( error instanceof NoConnectionError) {
-                errorType = "NoConnectionError";
-            } else if( error instanceof TimeoutError) {
-                errorType = "TimeoutError";
-            }
-
-            if(error.networkResponse.data != null) {
-                String body = new String(error.networkResponse.data);
-                errorMessage = extractMessageFromJson(body);
-
-                if(errorMessage != null){
-                    message = errorMessage;
-                } else {
-                    message = body;
-                }
-            }
+    /** Displays a VolleyError as a toast, if it can be made meaningful to the user. */
+    public void displayVolleyError(VolleyError error) {
+        // TODO(ping): Hand off to the HealthMonitor or use the snackbar.
+        LOG.w(error.getClass().getSimpleName() + ": " + error.getMessage());
+        if (error.networkResponse == null ||
+            error instanceof NoConnectionError ||
+            error instanceof AuthFailureError ||
+            error instanceof TimeoutError) {
+            // No toast needed; let the BuendiaApiHealthCheck catch these
+            // and show a message in the snackbar.
+            return;
         }
 
-        return errorType + " : " + statusCode + " " + message;
+        int code = error.networkResponse.statusCode;
+        String message = Utils.orDefault(
+            extractMessageFromJson(error.networkResponse.data),
+            "Sorry, there was a problem communicating with the server [code " + code + "]."
+        );
+
+        BigToast.show(App.getInstance().getApplicationContext(), message);
     }
 
-    /** Parsing the json formatted error response received from the OpenMRS server **/
-    public String extractMessageFromJson(String json) {
+    /** Parses a JSON-formatted error response from the OpenMRS server. **/
+    public String extractMessageFromJson(byte[] data) {
+        if (data == null) return null;
+        String json = new String(data);
+        LOG.i(json);
         String message = null;
         try {
             JsonObject result = new JsonParser().parse(json).getAsJsonObject();
@@ -106,26 +80,4 @@ public class OpenMrsErrorListener implements ErrorListener {
         }
         return message;
     }
-
-    /** display the error message as a toast **/
-    public void displayErrorMessage(String message) {
-        // TODO: refactor this using eventbus and snackbar.
-        Toast toast = Toast.makeText(
-            App.getInstance().getApplicationContext(),
-            message,
-            Toast.LENGTH_LONG
-        );
-        View view = toast.getView();
-        view.setBackgroundColor(Color.RED);
-        toast.show();
-    }
-
-    public int getStatusCode() {
-        return statusCode;
-    }
-
-    public String getErrorType() {
-        return errorType;
-    }
-
 }

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
@@ -149,9 +149,11 @@ public class OpenMrsServer implements Server {
         final Response.ErrorListener errorListener) {
         return new OpenMrsErrorListener() {
             @Override public void onErrorResponse(VolleyError error) {
-                String message = parseResponse(error);
-                displayErrorMessage(message);
-                errorListener.onErrorResponse(new VolleyError(message, error));
+                super.onErrorResponse(error);
+                if (error.getMessage() == null) {
+                    error = new VolleyError("Error", error);
+                }
+                errorListener.onErrorResponse(error);
             }
         };
     }


### PR DESCRIPTION
Scope: Server error messages (in toasts)

#### User-visible changes

OpenMRS errors no longer pop up a terrifying bright red banner.  The incomprehensible and unhelpful error message "0 : Empty response" no longer appears.

#### Internal changes <!-- optional -->

The logic for detecting, formatting, and displaying server API error messages is cleaned up and much simplified.