### PR TITLE
Fix initial cursor focus in the New Patient dialog.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -198,9 +198,13 @@ public class EditPatientDialogFragment extends DialogFragment {
         for (EditText field : fields) {
             if (field.isShown() && field.getText().toString().isEmpty()) {
                 field.requestFocus();
-                break;
+                return;
             }
         }
+
+        // If all fields are populated, default to the end of the given name field.
+        mGivenName.requestFocus();
+        mGivenName.setSelection(mGivenName.getText().length());
     }
 
     @Override public @NonNull Dialog onCreateDialog(Bundle savedInstanceState) {

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -196,14 +196,11 @@ public class EditPatientDialogFragment extends DialogFragment {
         // Set focus.
         EditText[] fields = {mIdPrefix, mId, mGivenName, mFamilyName, mAgeYears, mAgeMonths};
         for (EditText field : fields) {
-            if (field.getText().toString().isEmpty()) {
+            if (field.isShown() && field.getText().toString().isEmpty()) {
                 field.requestFocus();
                 break;
             }
         }
-
-        // Default to focusing on the given name field.
-        mGivenName.requestFocus();
     }
 
     @Override public @NonNull Dialog onCreateDialog(Bundle savedInstanceState) {


### PR DESCRIPTION
Scope: New Patient / Edit Patient dialog

#### User-visible changes

If an ID is needed, the cursor now begins in the ID field (instead of the given name field).

If all fields are populated, the cursor is placed at the end of the given name.

