### PR TITLE
Rework the LocationForest for robustness, making all location lists dynamic

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
@@ -31,7 +31,6 @@ import org.projectbuendia.client.ui.ReadyState;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,7 +57,7 @@ public final class LocationListControllerTest {
         // WHEN the controller is initialized
         mController.init();
         // THEN the controller asks the location manager to provide the location forest
-        verify(mMockAppModel).getForest(any());
+        verify(mMockAppModel).getForest();
     }
 
     /** Tests that init does not result in a new sync if data model is available. */
@@ -67,7 +66,7 @@ public final class LocationListControllerTest {
     public void testInit_DoesNotStartSyncWhenDataModelAvailable() {
         // GIVEN initialized data model and an available forest
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN the controller is initialized
         mController.init();
         // THEN the controller does not start a new sync
@@ -107,7 +106,7 @@ public final class LocationListControllerTest {
         // GIVEN a valid location forest and sync not in progress
         mFakeSyncManager.setSyncing(false);
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // GIVEN an initialized controller with a fragment attached
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -122,7 +121,7 @@ public final class LocationListControllerTest {
         // GIVEN a valid location forest while sync is still in progress
         mFakeSyncManager.setSyncing(true);
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN a controller starts with a fragment attached
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -143,7 +142,7 @@ public final class LocationListControllerTest {
         // THEN the controller shows the sync progress bar
         verify(mMockFragmentUi).setReadyState(ReadyState.SYNCING);
         // WHEN the sync succeeds
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         mFakeEventBus.post(new SyncSucceededEvent());
         // THEN the controller shows the spinner, loads the tree, and hides the spinner
         verify(mMockFragmentUi, atLeast(0)).setReadyState(ReadyState.LOADING);
@@ -173,7 +172,7 @@ public final class LocationListControllerTest {
     public void testSyncSuccessHidesSyncDialog() {
         // GIVEN an initialized controller with an incomplete model
         when(mMockAppModel.isFullModelAvailable()).thenReturn(false);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
         // WHEN a sync fails, the sync failed dialog is shown
@@ -197,7 +196,7 @@ public final class LocationListControllerTest {
         mController.attachFragmentUi(mMockFragmentUi);
         // WHEN an empty location forest is loaded after sync completed
         mFakeEventBus.post(new SyncSucceededEvent());
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // THEN the controller starts a new sync
         assertTrue(mFakeSyncManager.isSyncRunningOrPending());
     }
@@ -207,7 +206,7 @@ public final class LocationListControllerTest {
     @UiThreadTest
     public void testFetchingIncompleteForest_retainsSyncFailedDialog() {
         // GIVEN an empty forest
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.emptyForest());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.emptyForest());
         // WHEN the controller starts up and a fragment is attached
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -221,7 +220,7 @@ public final class LocationListControllerTest {
     public void testFetchingIncompleteForest_retainsLoadingDialog() {
         // GIVEN an empty forest
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.emptyForest());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.emptyForest());
         // WHEN the controller starts up and a fragment is attached
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -235,7 +234,7 @@ public final class LocationListControllerTest {
     public void testFetchingPopulatedForest_doesNotCauseNewSync() {
         // GIVEN a valid model and a populated forest
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN the controller starts up and a fragment is attached
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -253,7 +252,7 @@ public final class LocationListControllerTest {
         // GIVEN a sync in progress and a valid location forest
         mFakeSyncManager.setSyncing(true);
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN a fragment is attached to a new controller
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -271,7 +270,7 @@ public final class LocationListControllerTest {
         // GIVEN a sync in progress and an empty location forest
         mFakeSyncManager.setSyncing(true);
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.emptyForest());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.emptyForest());
         // WHEN a fragment is attached to a new controller
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -320,7 +319,7 @@ public final class LocationListControllerTest {
         mController.init();
         // WHEN user initiates a sync cancellation right before the data model is fetched
         mFakeEventBus.post(new SyncCancelRequestedEvent());
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         mFakeEventBus.post(new SyncCancelledEvent());
         // THEN the activity is closed
         verify(mMockUi).finish();
@@ -344,7 +343,7 @@ public final class LocationListControllerTest {
     public void testSyncFailed_ignoredWhenDataModelAvailable() {
         // GIVEN an initialized controller with a location forest
         when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         mController.init();
         // WHEN a periodic sync fails
         mFakeEventBus.post(new SyncFailedEvent());

--- a/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/lists/LocationListControllerTest.java
@@ -53,7 +53,7 @@ public final class LocationListControllerTest {
     @UiThreadTest
     public void testInit_RequestsLoadLocationsWhenDataModelAvailable() {
         // GIVEN initialized data model and the controller hasn't previously fetched the location forest
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         // WHEN the controller is initialized
         mController.init();
         // THEN the controller asks the location manager to provide the location forest
@@ -65,7 +65,7 @@ public final class LocationListControllerTest {
     @UiThreadTest
     public void testInit_DoesNotStartSyncWhenDataModelAvailable() {
         // GIVEN initialized data model and an available forest
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN the controller is initialized
         mController.init();
@@ -80,7 +80,7 @@ public final class LocationListControllerTest {
         // GIVEN uninitialized data model,the controller hasn't previously fetched the location
         // forest, and no sync is already in progress
         mFakeSyncManager.setSyncing(false);
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(false);
+        when(mMockAppModel.isReady()).thenReturn(false);
         // WHEN the controller is initialized
         mController.init();
         // THEN the controller requests a sync
@@ -105,7 +105,7 @@ public final class LocationListControllerTest {
     public void testLoadLocations_HidesSpinner() {
         // GIVEN a valid location forest and sync not in progress
         mFakeSyncManager.setSyncing(false);
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // GIVEN an initialized controller with a fragment attached
         mController.init();
@@ -120,7 +120,7 @@ public final class LocationListControllerTest {
     public void testLoadLocations_DoesNotShowSpinnerWhenSyncInProgress() {
         // GIVEN a valid location forest while sync is still in progress
         mFakeSyncManager.setSyncing(true);
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN a controller starts with a fragment attached
         mController.init();
@@ -135,7 +135,7 @@ public final class LocationListControllerTest {
     public void testSpinnerHiddenAfterSyncCompletes() {
         // GIVEN an incomplete model while sync is still in progress
         mFakeSyncManager.setSyncing(true);
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(false);
+        when(mMockAppModel.isReady()).thenReturn(false);
         // WHEN a controller starts with a fragment attached
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -171,7 +171,7 @@ public final class LocationListControllerTest {
     @UiThreadTest
     public void testSyncSuccessHidesSyncDialog() {
         // GIVEN an initialized controller with an incomplete model
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(false);
+        when(mMockAppModel.isReady()).thenReturn(false);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         mController.init();
         mController.attachFragmentUi(mMockFragmentUi);
@@ -219,7 +219,7 @@ public final class LocationListControllerTest {
     @UiThreadTest
     public void testFetchingIncompleteForest_retainsLoadingDialog() {
         // GIVEN an empty forest
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.emptyForest());
         // WHEN the controller starts up and a fragment is attached
         mController.init();
@@ -233,7 +233,7 @@ public final class LocationListControllerTest {
     @UiThreadTest
     public void testFetchingPopulatedForest_doesNotCauseNewSync() {
         // GIVEN a valid model and a populated forest
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN the controller starts up and a fragment is attached
         mController.init();
@@ -251,7 +251,7 @@ public final class LocationListControllerTest {
     public void testAttachFragmentUi_doesNotShowSpinnerDuringSyncWhenLocationsPresent() {
         // GIVEN a sync in progress and a valid location forest
         mFakeSyncManager.setSyncing(true);
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN a fragment is attached to a new controller
         mController.init();
@@ -269,7 +269,7 @@ public final class LocationListControllerTest {
     public void testAttachFragmentUi_showsSpinnerDuringSyncWhenForestEmpty() {
         // GIVEN a sync in progress and an empty location forest
         mFakeSyncManager.setSyncing(true);
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.emptyForest());
         // WHEN a fragment is attached to a new controller
         mController.init();
@@ -287,7 +287,7 @@ public final class LocationListControllerTest {
     public void testAttachFragmentUi_showsSpinnerDuringSyncWhenLocationsNotPresent() {
         // GIVEN an initialized controller with a sync in progress and no location forest
         mFakeSyncManager.setSyncing(true);
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(false);
+        when(mMockAppModel.isReady()).thenReturn(false);
         mController.init();
         // WHEN a fragment is attached
         mController.attachFragmentUi(mMockFragmentUi);
@@ -342,7 +342,7 @@ public final class LocationListControllerTest {
     @UiThreadTest
     public void testSyncFailed_ignoredWhenDataModelAvailable() {
         // GIVEN an initialized controller with a location forest
-        when(mMockAppModel.isFullModelAvailable()).thenReturn(true);
+        when(mMockAppModel.isReady()).thenReturn(true);
         when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         mController.init();
         // WHEN a periodic sync fails

--- a/app/src/androidTest/java/org/projectbuendia/client/ui/lists/PatientFilterControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/lists/PatientFilterControllerTest.java
@@ -21,7 +21,6 @@ import org.projectbuendia.client.FakeForestFactory;
 import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.ui.matchers.SimpleSelectionFilterMatchers;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,9 +42,9 @@ public class PatientFilterControllerTest {
     @UiThreadTest
     public void testSetupActionBarAsync_passesLocationFilters() {
         // GIVEN a valid location forest
-        when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+        when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         // WHEN the PatientFilterController starts
-        mController = new PatientFilterController(mMockUi, mMockAppModel, LOCALE);
+        mController = new PatientFilterController(mMockUi, mMockAppModel);
         // THEN location filters are passed to the Ui
         verify(mMockUi).populateActionBar(
             argThat(new SimpleSelectionFilterMatchers.ContainsFilterWithName("Triage")));

--- a/app/src/androidTest/java/org/projectbuendia/client/ui/lists/PatientSearchControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/lists/PatientSearchControllerTest.java
@@ -48,7 +48,6 @@ import static org.mockito.Mockito.when;
 @RunWith(AndroidJUnit4.class)
 @SmallTest
 public class PatientSearchControllerTest {
-    private static final String LOCALE = "en";
     private PatientSearchController mController;
     private FakeEventBus mFakeCrudEventBus;
     private FakeEventBus mFakeGlobalEventBus;
@@ -267,10 +266,10 @@ public class PatientSearchControllerTest {
 
     public void initController(boolean withForest) {
         if (withForest) {
-            when(mMockAppModel.getForest(any())).thenReturn(FakeForestFactory.build());
+            when(mMockAppModel.getForest()).thenReturn(FakeForestFactory.build());
         }
         mController = new PatientSearchController(
-            mMockUi, mFakeCrudEventBus, mFakeGlobalEventBus, mMockAppModel, mSyncManager, LOCALE);
+            mMockUi, mFakeCrudEventBus, mFakeGlobalEventBus, mMockAppModel, mSyncManager);
         mController.attachFragmentUi(mFragmentMockUi);
         mController.init();
     }

--- a/app/src/main/java/org/projectbuendia/client/filter/db/patient/LocationUuidFilter.java
+++ b/app/src/main/java/org/projectbuendia/client/filter/db/patient/LocationUuidFilter.java
@@ -58,7 +58,7 @@ public final class LocationUuidFilter extends SimpleSelectionFilter<Patient> {
 
         mUuid = subroot.uuid;
         String indentedName = subroot.name;
-        for (int i = 1; i < subroot.depth; i++) {
+        for (int i = 0; i < forest.getDepth(subroot); i++) {
             indentedName = "        " + indentedName;
         }
         mDescription = indentedName;

--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -83,7 +83,7 @@ public class AppModel {
         return getForest().getDefaultLocation();
     }
 
-    public @Nonnull LocationForest getForest(String locale) {
+    private @Nonnull LocationForest getForest(String locale) {
         return forestProvider.getForest(locale);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/models/Location.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Location.java
@@ -19,23 +19,19 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /** The app model for a location, including its localized name. */
-public final @Immutable class Location extends Base<String> implements Comparable<Location> {
+public final @Immutable class Location extends Base<String> {
     public final @Nonnull String uuid;  // permanent unique identifier
-    public final @Nonnull String path;  // short IDs from root to this node, separated by slashes
     public final @Nonnull String name;
-    public final int depth;
 
     /** Creates an instance of {@link Location}. */
-    public Location(@Nonnull String uuid, @Nonnull String path, String name) {
+    public Location(@Nonnull String uuid, String name) {
         super(null);
         this.uuid = uuid;
-        this.path = path;
         this.name = Utils.toNonnull(name);
-        this.depth = path.split("/").length;  // split drops trailing empty parts
     }
 
     @Override public String toString() {
-        return Utils.format("<Location %s: %s [%s]>", path, Utils.repr(name), uuid);
+        return Utils.format("<Location %s [%s]>", Utils.repr(name), uuid);
     }
 
     @Override public boolean equals(Object other) {
@@ -44,13 +40,5 @@ public final @Immutable class Location extends Base<String> implements Comparabl
 
     @Override public int hashCode() {
         return Objects.hashCode(uuid);
-    }
-
-    public boolean isInSubtree(Location other) {
-        return path.startsWith(other.path);
-    }
-
-    @Override public int compareTo(Location other) {
-        return path.compareTo(other.path);
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
@@ -46,6 +46,7 @@ public class LocationForest {
     private int totalNumPatients;
 
     private final Object patientCountLock = new Object();
+    private Runnable onPatientCountsUpdatedListener = null;
 
     public LocationForest() {
         locations = new Location[0];
@@ -163,6 +164,13 @@ public class LocationForest {
             }
             LOG.i("Updated existing LocationForest; total patients: %d", totalNumPatients);
         }
+        if (onPatientCountsUpdatedListener != null) {
+            onPatientCountsUpdatedListener.run();
+        }
+    }
+
+    public void setOnPatientCountsUpdatedListener(Runnable listener) {
+        onPatientCountsUpdatedListener = listener;
     }
 
     /** Returns true if the specified location exists in this forest. */

--- a/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
@@ -19,7 +19,6 @@ import org.projectbuendia.client.utils.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -47,12 +46,6 @@ public class LocationForest {
     private int totalNumPatients;
 
     private final Object patientCountLock = new Object();
-
-    private final Comparator<Location> PATH_COMPARATOR = (a, b) -> {
-        String pathA = Utils.toNonnull(pathsByUuid.get(a.uuid));
-        String pathB = Utils.toNonnull(pathsByUuid.get(b.uuid));
-        return pathA.compareTo(pathB);
-    };
 
     public LocationForest() {
         locations = new Location[0];
@@ -128,7 +121,7 @@ public class LocationForest {
 
         // Finally, sort by path, yielding an array of nodes in depth-first
         // order with every subtree in the proper order.
-        Arrays.sort(locations, PATH_COMPARATOR);
+        sort(locations);
 
         // The default location is either set with an asterisk in the name
         // (see above) or defaults to the first leaf node.
@@ -144,6 +137,14 @@ public class LocationForest {
 
         LOG.i("Loaded LocationForest with %d locations; default = %s",
             locations.length, defaultLocation);
+    }
+
+    public void sort(Location[] locations) {
+        Arrays.sort(locations, (a, b) -> {
+            String pathA = Utils.toNonnull(pathsByUuid.get(a.uuid));
+            String pathB = Utils.toNonnull(pathsByUuid.get(b.uuid));
+            return pathA.compareTo(pathB);
+        });
     }
 
     public void updatePatientCounts(Map<String, Integer> patientCountsByLocationUuid) {

--- a/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
@@ -184,6 +184,13 @@ public class LocationForest {
         return get(parentUuidsByUuid.get(location.uuid));
     }
 
+    /** Returns the depth of a node (zero for root nodes, -1 for nonexistent nodes). */
+    public int getDepth(@Nonnull Location location) {
+        String path = Utils.getOrDefault(pathsByUuid, location.uuid, "");
+        // Note: split() omits trailing empty parts; "foo/".split("/").length is 1.
+        return path.split("/").length - 1;
+    }
+
     /** Returns true if the given location is a leaf node. */
     public boolean isLeaf(@Nonnull Location location) {
         return !nonleafUuids.contains(location.uuid);

--- a/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
@@ -125,7 +125,7 @@ public class LocationForest {
 
         // The default location is either set with an asterisk in the name
         // (see above) or defaults to the first leaf node.
-        if (defaultUuid != null) {
+        if (defaultUuid == null) {
             for (Location location : locations) {
                 if (isLeaf(location)) {
                     defaultUuid = location.uuid;

--- a/app/src/main/java/org/projectbuendia/client/models/LocationForestProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForestProvider.java
@@ -4,6 +4,7 @@ import android.content.ContentResolver;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Handler;
 
 import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.utils.Utils;
@@ -21,7 +22,7 @@ public class LocationForestProvider {
     private Runnable onForestReplacedListener = null;
 
     private final ContentResolver resolver;
-    private final ContentObserver locationChangeObserver = new ContentObserver(null) {
+    private final ContentObserver locationChangeObserver = new ContentObserver(new Handler()) {
         public void onChange(boolean selfChange) {
             currentForest = null;
             if (onForestReplacedListener != null) {
@@ -29,7 +30,7 @@ public class LocationForestProvider {
             }
         }
     };
-    private final ContentObserver patientChangeObserver = new ContentObserver(null) {
+    private final ContentObserver patientChangeObserver = new ContentObserver(new Handler()) {
         public void onChange(boolean selfChange) {
             if (currentForest != null) {
                 currentForest.updatePatientCounts(getPatientCountsByLocationUuid());

--- a/app/src/main/java/org/projectbuendia/client/models/LocationForestProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForestProvider.java
@@ -1,0 +1,85 @@
+package org.projectbuendia.client.models;
+
+import android.content.ContentResolver;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.net.Uri;
+
+import org.projectbuendia.client.providers.Contracts;
+import org.projectbuendia.client.utils.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import static org.projectbuendia.client.utils.Utils.eq;
+
+public class LocationForestProvider {
+    private LocationForest currentForest = null;
+    private String currentLocale = null;
+    private Runnable onForestReplacedListener = null;
+
+    private final ContentResolver resolver;
+    private final ContentObserver locationChangeObserver = new ContentObserver(null) {
+        public void onChange(boolean selfChange) {
+            currentForest = null;
+            if (onForestReplacedListener != null) {
+                onForestReplacedListener.run();
+            }
+        }
+    };
+    private final ContentObserver patientChangeObserver = new ContentObserver(null) {
+        public void onChange(boolean selfChange) {
+            if (currentForest != null) {
+                currentForest.updatePatientCounts(getPatientCountsByLocationUuid());
+            }
+        }
+    };
+
+    public LocationForestProvider(ContentResolver resolver) {
+        this.resolver = resolver;
+        resolver.registerContentObserver(
+            Contracts.LocalizedLocations.URI, true, locationChangeObserver);
+        resolver.registerContentObserver(
+            Contracts.Patients.URI, true, patientChangeObserver);
+    }
+
+    public void dispose() {
+        resolver.unregisterContentObserver(locationChangeObserver);
+        resolver.unregisterContentObserver(patientChangeObserver);
+    }
+
+    public @Nonnull LocationForest getForest(String locale) {
+        if (currentForest != null && eq(currentLocale, locale)) {
+            return currentForest;
+        }
+        currentForest = loadForest(locale);
+        currentLocale = locale;
+        return currentForest;
+    }
+
+    public void setOnForestReplacedListener(Runnable listener) {
+        onForestReplacedListener = listener;
+    }
+
+    private LocationForest loadForest(String locale) {
+        Uri uri = Contracts.getLocalizedLocationsUri(locale);
+        try (Cursor cursor = resolver.query(uri, null, null, null, null)) {
+            return new LocationForest(new TypedCursorWithLoader<>(cursor, LocationQueryResult.LOADER));
+        }
+    }
+
+    private Map<String, Integer> getPatientCountsByLocationUuid() {
+        Uri uri = Contracts.PatientCounts.URI;
+        Map<String, Integer> countsByLocationUuid = new HashMap<>();
+        try (Cursor cursor = resolver.query(uri, null, null, null, null)) {
+            while (cursor.moveToNext()) {
+                String locationUuid = Utils.getString(cursor, Contracts.PatientCounts.LOCATION_UUID);
+                Integer count = Utils.getInt(cursor, Contracts.PatientCounts.PATIENT_COUNT);
+                countsByLocationUuid.put(locationUuid, count);
+            }
+        }
+        return countsByLocationUuid;
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/ui/PatientListTypedCursorAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/PatientListTypedCursorAdapter.java
@@ -36,7 +36,6 @@ import org.projectbuendia.client.utils.PatientCountDisplay;
 import org.projectbuendia.client.utils.Utils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -229,7 +228,7 @@ public class PatientListTypedCursorAdapter extends BaseExpandableListAdapter {
         // Produce a sorted list of all the locations that have patients.
         mLocations = new Location[mPatientsByLocation.size()];
         mPatientsByLocation.keySet().toArray(mLocations);
-        Arrays.sort(mLocations);
+        forest.sort(mLocations);
 
         // Sort the patient lists within each location using the default comparator.
         for (List<Patient> patients : mPatientsByLocation.values()) {

--- a/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
@@ -293,7 +293,7 @@ public class SettingsActivity extends PreferenceActivity {
 
     @Override protected void onPause() {
         super.onPause();
-        if (!mAppModel.isFullModelAvailable()) {
+        if (!mAppModel.isReady()) {
             // The database was cleared; go back to the login activity.
             startActivity(new Intent(this, LoginActivity.class).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK));
         }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -549,7 +549,8 @@ final class PatientChartController implements ChartRenderer.JsInterface {
     private final class EventSubscriber {
 
         public void onEventMainThread(SyncSucceededEvent event) {
-            updatePatientObsUi();
+            updatePatientObsUi(); // if the sync fetched observations
+            mAppModel.loadSinglePatient(mCrudEventBus, mPatientUuid); // if the sync touched this patient
         }
 
         public void onEventMainThread(EncounterAddFailedEvent event) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -84,7 +84,6 @@ final class PatientChartController implements ChartRenderer.JsInterface {
     private static final int PATIENT_UPDATE_PERIOD_MILLIS = 10000;
 
     private Patient mPatient = Patient.builder().build();
-    private LocationForest mForest;
     private String mPatientUuid = "";
     private Map<String, Order> mOrdersByUuid;
     private List<Obs> mObservations;
@@ -235,7 +234,6 @@ final class PatientChartController implements ChartRenderer.JsInterface {
         mDefaultEventBus.register(mEventBusSubscriber);
         mCrudEventBus.register(mEventBusSubscriber);
         mAppModel.loadSinglePatient(mCrudEventBus, mPatientUuid);
-        mForest = mAppModel.getForest(mSettings.getLocaleTag());
         updatePatientLocationUi();
     }
 
@@ -321,7 +319,7 @@ final class PatientChartController implements ChartRenderer.JsInterface {
             mUi.showError(R.string.no_user);
             return;
         }
-        if (mForest == null || mForest.getDefaultLocation() == null) {
+        if (mAppModel.getDefaultLocation() == null) {
             mUi.showError(R.string.no_location);
             return;
         }
@@ -331,8 +329,8 @@ final class PatientChartController implements ChartRenderer.JsInterface {
         preset.providerUuid = user.uuid;
         preset.locationUuid = mPatient.locationUuid;
         if (preset.locationUuid == null) {
-            if (mForest != null && mForest.getDefaultLocation() != null) {
-                preset.locationUuid = mForest.getDefaultLocation().uuid;
+            if (mAppModel.getDefaultLocation() != null) {
+                preset.locationUuid = mAppModel.getDefaultLocation().uuid;
             }
         }
         Map<String, Obs> observations = mChartHelper.getLatestObservations(mPatientUuid);
@@ -527,8 +525,8 @@ final class PatientChartController implements ChartRenderer.JsInterface {
     }
 
     private synchronized void updatePatientLocationUi() {
-        if (mForest != null && mPatient != null && mPatient.locationUuid != null) {
-            mUi.updatePatientLocationUi(mForest, mPatient);
+        if (mPatient != null && mPatient.locationUuid != null) {
+            mUi.updatePatientLocationUi(mAppModel.getForest(), mPatient);
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/PatientLocationDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/PatientLocationDialogFragment.java
@@ -76,7 +76,7 @@ public class PatientLocationDialogFragment extends DialogFragment {
         dialog.getWindow().setSoftInputMode(
             WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
 
-        LocationForest forest = mModel.getForest(mSettings.getLocaleTag());
+        LocationForest forest = mModel.getForest();
         mList = new LocationOptionList(c.findView(R.id.list_container), true);
         mList.setLocations(forest, forest.getLeaves());
         mList.setSelectedLocation(forest.get(getArguments().getString("locationUuid")));

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
@@ -119,8 +119,7 @@ public abstract class BaseSearchablePatientListActivity extends BaseLoggedInActi
             mCrudEventBus,
             new EventBusWrapper(mEventBus),
             mAppModel,
-            mSyncManager,
-            mSettings.getLocaleTag());
+            mSyncManager);
 
         mUpdateNotificationController = new UpdateNotificationController(
             new UpdateNotificationUi()

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/BaseSearchablePatientListActivity.java
@@ -147,7 +147,7 @@ public abstract class BaseSearchablePatientListActivity extends BaseLoggedInActi
     }
 
     protected void attemptInit() {
-        if (mAppModel.isFullModelAvailable()) {
+        if (mAppModel.isReady()) {
             mSearchController.init();
             mSearchController.loadSearchResults();
         } else {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/FilteredPatientListActivity.java
@@ -43,8 +43,7 @@ public class FilteredPatientListActivity extends BaseSearchablePatientListActivi
             mSelectedFilter = savedInstanceState.getInt(SELECTED_FILTER_KEY, 0);
         }
 
-        mFilterController = new PatientFilterController(
-            new FilterUi(), mAppModel, mSettings.getLocaleTag());
+        mFilterController = new PatientFilterController(new FilterUi(), mAppModel);
 
         App.getInstance().inject(this);
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -112,7 +112,7 @@ final class LocationListController {
 
     public void loadForest() {
         setReadyState(ReadyState.LOADING);
-        LocationForest forest = mAppModel.getForest(mSettings.getLocaleTag());
+        LocationForest forest = mAppModel.getForest();
         if (forest != null) {
             setForest(forest);
             setReadyState(ReadyState.READY);

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -107,19 +107,18 @@ final class LocationListController {
         mUserCancelRequestPending = false;
         mEventBus.register(mEventBusSubscriber);
         mCrudEventBus.register(mEventBusSubscriber);
-        loadForest();
+        if (mAppModel.isReady()) {
+            loadForest();
+        } else {
+            LOG.w("Model has not been synced successfully yet; initiating full sync.");
+            startInitialSync();
+        }
     }
 
     public void loadForest() {
         setReadyState(ReadyState.LOADING);
-        LocationForest forest = mAppModel.getForest();
-        if (forest != null) {
-            setForest(forest);
-            setReadyState(ReadyState.READY);
-        } else {
-            LOG.w("Forest not available; retrying initial sync.");
-            startInitialSync();
-        }
+        setForest(mAppModel.getForest());
+        setReadyState(ReadyState.READY);
     }
 
     public void startInitialSync() {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -27,7 +27,6 @@ import org.projectbuendia.client.ui.ProgressFragment;
 import org.projectbuendia.client.ui.ReadyState;
 import org.projectbuendia.client.utils.ContextUtils;
 import org.projectbuendia.client.utils.Logger;
-import org.projectbuendia.client.widgets.SubtitledButtonView;
 
 import javax.inject.Inject;
 
@@ -98,12 +97,6 @@ public final class LocationListFragment extends ProgressFragment {
             mController.detachFragmentUi(mUi);
         }
         super.onDestroyView();
-    }
-
-    public void setPatientCount(SubtitledButtonView button, long count) {
-        button.setSubtitle("" + count);
-        button.setTextColor(0xff000000);
-        button.setSubtitleColor(count == 0 ? 0x40000000 : 0xff000000);
     }
 
     private final class Ui implements LocationListController.LocationListFragmentUi {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -61,8 +61,8 @@ public final class LocationListFragment extends ProgressFragment {
 
         mScroll = view.findViewById(R.id.scroll_container);
         mList = new LocationOptionList(view.findViewById(R.id.list_container), false);
-        LocationForest forest = mModel.getForest(mSettings.getLocaleTag());
-        if (forest != null) mList.setLocations(forest, forest.allNodes());
+        LocationForest forest = mModel.getForest();
+        mList.setLocations(forest, forest.allNodes());
         return view;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/PatientFilterController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/PatientFilterController.java
@@ -28,13 +28,10 @@ public class PatientFilterController {
     /**
      * Creates a {@link PatientFilterController} with the specified UI implementation, event
      * bus, model, and locale.  @param ui           a {@link Ui} that will receive UI events
-     * @param appModel     an {@link AppModel} used to retrieve patients
-     * @param locale       a language code/locale for presenting localized information (e.g. en)
+     * @param model     an {@link AppModel} used to retrieve patients
      */
-    public PatientFilterController(Ui ui, AppModel appModel, String locale) {
+    public PatientFilterController(Ui ui, AppModel model) {
         mUi = ui;
-        mUi.populateActionBar(PatientDbFilters.getFiltersForDisplay(
-            appModel.getForest(locale)
-        ));
+        mUi.populateActionBar(PatientDbFilters.getFiltersForDisplay(model.getForest()));
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/PatientFilterController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/PatientFilterController.java
@@ -33,5 +33,8 @@ public class PatientFilterController {
     public PatientFilterController(Ui ui, AppModel model) {
         mUi = ui;
         mUi.populateActionBar(PatientDbFilters.getFiltersForDisplay(model.getForest()));
+        model.setOnForestReplacedListener(() -> {
+            mUi.populateActionBar(PatientDbFilters.getFiltersForDisplay(model.getForest()));
+        });
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/PatientSearchController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/PatientSearchController.java
@@ -114,7 +114,7 @@ public class PatientSearchController {
         mGlobalEventBus.register(mSyncSubscriber);
         mCrudEventBus.register(mCreationSubscriber);
         mForest = mModel.getForest(mLocale);
-        mModel.setForestRebuiltListener(this::onForestRebuilt);
+        mModel.setForestReplacedListener(this::onForestRebuilt);
     }
 
     /** Releases resources required by this controller. */
@@ -125,7 +125,7 @@ public class PatientSearchController {
         if (mPatientsCursor != null) {
             mPatientsCursor.close();
         }
-        mModel.setForestRebuiltListener(null);
+        mModel.setForestReplacedListener(null);
     }
 
     /** Registers a {@link FragmentUi} with this controller. */

--- a/app/src/main/res/layout/location_list_item.xml
+++ b/app/src/main/res/layout/location_list_item.xml
@@ -40,7 +40,7 @@
                 android:background="?android:attr/selectableItemBackground">
 
                 <TextView
-                    android:id="@+id/title"
+                    android:id="@+id/location_name"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12sp"
@@ -52,7 +52,7 @@
                     tools:text="Triage" />
 
                 <TextView
-                    android:id="@+id/content"
+                    android:id="@+id/patient_count"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="0sp"


### PR DESCRIPTION
#### Internal changes <!-- optional -->

The `Location` object now only contains information about the current location; all information about the relationships between locations now resides in the `LocationForest`.  This fixes the semantics of comparing `Location` objects and creates a clear division of responsibility.

The logic for reloading and updating the `LocationForest` is factored into a new `LocationProvider` class.  Listeners for these two events are now at different levels, where they belong.  Reloading is considered a replacement of the entire forest, which is an event on the `LocationProvider`.  Updating patient counts is considered a mutation of the forest, which is an event on the forest.

Handling these events sanely makes it possible for all locations and patient counts in the user interface to pick up changes promptly and coherently.

#### Verification performed

I tried moving patients on one tablet while viewing the locations on another.  Patient counts updated properly.  Even in the location assignment dialog, the locations and their counts are updated dynamically.

I tried adding, renaming, reparenting, and deleting locations in the OpenMRS web portal while the app was open on the tablet.  The location boxes correctly appeared, disappeared, and rearranged themselves quickly and appropriately.