### PR TITLE
Recognize the Guest User by its UUID instead of its name.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/json/JsonUser.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonUser.java
@@ -13,6 +13,8 @@ package org.projectbuendia.client.json;
 
 import com.google.common.base.Preconditions;
 
+import org.projectbuendia.client.utils.Utils;
+
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
@@ -20,23 +22,15 @@ import java.util.Objects;
 import static org.projectbuendia.client.utils.Utils.eq;
 
 /** JSON reprsentation of a user (an OpenMRS Provider). */
-public class JsonUser implements Serializable, Comparable<JsonUser> {
+public class JsonUser implements Serializable {
     public String uuid;
     public String fullName;
 
-    // GUEST_ACCOUNT_NAME must match the name defined in UserResource on the server side.
-    // The only special handling for this user is that (a) the server automatically
-    // creates this user and (b) the client always sorts it first when showing a list.
-
-    // TODO/i18n: This will be tricky to internationalize as it's stored on the server.
-    // Perhaps create the guest account with a special name like "*" on the server, and replace
-    // "*" with the localized string for "Guest User" on the client when displaying the user?
-    private static final String GUEST_ACCOUNT_NAME = "Guest User";
-
-    public static final Comparator<JsonUser> COMPARATOR_BY_UUID = (a, b) -> a.uuid.compareTo(b.uuid);
+    /** This must match the same constant on the server. */
+    public static final String PROVIDER_GUEST_UUID = "buendia_provider_guest";
 
     public static final Comparator<JsonUser> COMPARATOR_BY_NAME = (a, b) -> {
-        // Special case: the guest account should always appear first if present.
+        // The guest account always sorts first.
         int aSection = a.isGuestUser() ? 1 : 2;
         int bSection = b.isGuestUser() ? 1 : 2;
         if (aSection != bSection) {
@@ -46,9 +40,7 @@ public class JsonUser implements Serializable, Comparable<JsonUser> {
     };
 
     /** Default constructor for serialization. */
-    public JsonUser() {
-        // Intentionally blank.
-    }
+    public JsonUser() { }
 
     /** Creates a user with the given unique id and full name. */
     public JsonUser(String uuid, String fullName) {
@@ -61,6 +53,10 @@ public class JsonUser implements Serializable, Comparable<JsonUser> {
     public static JsonUser fromNewUser(JsonNewUser newUser) {
         String fullName = newUser.givenName + " " + newUser.familyName;
         return new JsonUser(newUser.username, fullName);
+    }
+
+    public String toString() {
+        return Utils.format("<User %s [%s]>", Utils.repr(fullName), uuid);
     }
 
     /** Returns the user's initials, using the first letter of each word of the user's full name. */
@@ -76,10 +72,6 @@ public class JsonUser implements Serializable, Comparable<JsonUser> {
         }
     }
 
-    @Override public int compareTo(JsonUser other) {
-        return COMPARATOR_BY_UUID.compare(this, other);
-    }
-
     @Override public int hashCode() {
         return Objects.hash(uuid);
     }
@@ -89,6 +81,6 @@ public class JsonUser implements Serializable, Comparable<JsonUser> {
     }
 
     public final boolean isGuestUser() {
-        return GUEST_ACCOUNT_NAME.equals(fullName);
+        return eq(uuid, PROVIDER_GUEST_UUID);
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/models/User.java
+++ b/app/src/main/java/org/projectbuendia/client/models/User.java
@@ -11,50 +11,14 @@
 
 package org.projectbuendia.client.models;
 
-import com.google.common.base.Preconditions;
-
 /** A user in the app model. */
-public final class User extends Base<Integer> {
-
+public final class User extends Base<String> {
     public final String uuid;
     public final String fullName;
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static final class Builder {
-
-        private int mId = 0;
-        private String mUuid = "";
-        private String mFullName = "";
-
-        public Builder setId(int id) {
-            this.mId = id;
-            return this;
-        }
-
-        public Builder setUuid(String uuid) {
-            this.mUuid = Preconditions.checkNotNull(uuid);
-            return this;
-        }
-
-        public Builder setFullName(String fullName) {
-            this.mFullName = Preconditions.checkNotNull(fullName);
-            return this;
-        }
-
-        public User build() {
-            return new User(this);
-        }
-
-        private Builder() {
-        }
-    }
-
-    private User(Builder builder) {
-        super(builder.mId);
-        this.uuid = builder.mUuid;
-        this.fullName = builder.mFullName;
+    private User(String uuid, String id, String fullName) {
+        super(id);
+        this.uuid = uuid;
+        this.fullName = fullName;
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseLoggedInActivity.java
@@ -44,6 +44,8 @@ import butterknife.ButterKnife;
 import butterknife.InjectView;
 import butterknife.OnClick;
 
+import static org.projectbuendia.client.utils.Utils.eq;
+
 /** A {@link BaseActivity} that requires that there currently be a logged-in user. */
 public abstract class BaseLoggedInActivity extends BaseActivity {
 
@@ -139,9 +141,8 @@ public abstract class BaseLoggedInActivity extends BaseActivity {
     private void updateActiveUser() {
         JsonUser user = App.getUserManager().getActiveUser();
 
-        if (mLastActiveUser == null || mLastActiveUser.compareTo(user) != 0) {
-            LOG.w("The user has switched. I don't know how to deal with that right now");
-            // TODO: Handle.
+        if (!eq(mLastActiveUser, user)) {
+            LOG.w("User has switched from %s to %s", mLastActiveUser, user);
         }
         mLastActiveUser = user;
 

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -75,7 +75,6 @@ public class ODKView extends LinearLayout {
     private final static int VIEW_ID = 12345;
 
     private final static String t = "ODKView";
-    private static final Object GUEST_USER_NAME = "Guest User";
 
     private LinearLayout mView;
     private LinearLayout.LayoutParams mLayout;


### PR DESCRIPTION
#### User-visible changes

None; though enables the possibility of translating the "Guest User" label.

#### Internal changes <!-- optional -->

The app now identifies the special Guest User according to a canonical pseudo-UUID, `buendia_provider_guest`, rather than a string match on the name.  The only special treatment that this user gets is to be sorted first in the list.
