### PR TITLE
Fetch all available charts in one request from the server

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
@@ -77,7 +77,7 @@ public final class PatientChartControllerTest {
     private FakeEventBus mFakeCrudEventBus;
     private FakeEventBus mFakeGlobalEventBus;
     private FakeHandler mFakeHandler;
-    private Chart mFakeChart = new Chart(PATIENT_UUID_1, "Test Chart");
+    private Chart mFakeChart = new Chart("Test Chart");
 
 
     /** Tests that suspend() unregisters from the event bus. */
@@ -273,8 +273,7 @@ public final class PatientChartControllerTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         List<Chart> charts = ImmutableList.of(mFakeChart);
-        when(mMockChartHelper.getCharts(AppModel.CHART_UUID))
-                .thenReturn(charts);
+        when(mMockChartHelper.getCharts()).thenReturn(charts);
 
         mFakeCrudEventBus = new FakeEventBus();
         mFakeGlobalEventBus = new FakeEventBus();

--- a/app/src/main/java/org/projectbuendia/client/json/JsonChart.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonChart.java
@@ -16,7 +16,7 @@ package org.projectbuendia.client.json;
  * displayed, giving the grouping and ordering of fields.
  */
 public class JsonChart {
-    public String version;  // dot-separated decimal integers, e.g. "0.6", "0.7.1"
     public String uuid;  // UUID of the OpenMRS Form
+    public String version;  // dot-separated decimal integers, e.g. "0.6", "0.7.1"
     public JsonChartSection[] sections;  // sections in display order
 }

--- a/app/src/main/java/org/projectbuendia/client/json/JsonChartsResponse.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonChartsResponse.java
@@ -1,0 +1,7 @@
+package org.projectbuendia.client.json;
+
+/** JSON format of a response to GET /charts?v=full */
+public class JsonChartsResponse {
+    public JsonChart[] results;
+    public String snapshotTime;
+}

--- a/app/src/main/java/org/projectbuendia/client/json/JsonConceptsResponse.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonConceptsResponse.java
@@ -12,6 +12,6 @@
 package org.projectbuendia.client.json;
 
 /** A list of concept results returned by the server. */
-public class JsonConceptResponse {
+public class JsonConceptsResponse {
     public JsonConcept[] results;
 }

--- a/app/src/main/java/org/projectbuendia/client/json/JsonOrdersResponse.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonOrdersResponse.java
@@ -1,10 +1,6 @@
 package org.projectbuendia.client.json;
 
-/**
- * JSON representation of a set of patients returned by the server.
- * <p>
- * TODO: Generify this class into e.g. an IncrementalFetchResponse<JsonEncounter>
- */
+/** JSON format of a response to GET /orders?v=full */
 public class JsonOrdersResponse {
     public JsonOrder[] results;
     // TODO(capnfabs): Rename this to syncToken.

--- a/app/src/main/java/org/projectbuendia/client/models/AppModel.java
+++ b/app/src/main/java/org/projectbuendia/client/models/AppModel.java
@@ -49,14 +49,6 @@ import javax.annotation.Nullable;
  * not need to worry about the implementation details of this.
  */
 public class AppModel {
-    // The UUID of the single OpenMRS form that defines all our charts.
-    public static final String CHART_UUID = "buendia_chart";
-
-    // This is a custom Buendia-specific concept to indicate that a treatment order
-    // has been carried out (e.g. a prescribed medication has been administered).
-    // The timestamp of an observation for this concept should be the time the order
-    // was executed, and the value of the observation should be the UUID of the order.
-    public static final String ORDER_EXECUTED_CONCEPT_UUID = "buendia_concept_order_executed";
 
     private static final Logger LOG = Logger.create();
     private final ContentResolver mContentResolver;

--- a/app/src/main/java/org/projectbuendia/client/models/Chart.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Chart.java
@@ -16,13 +16,13 @@ import java.util.List;
 
 /** A chart definition. */
 public class Chart {
-    public final String uuid;  // UUID of the OpenMRS Form containing this chart definition
+    // TODO(ping): Support multiple charts stored in multiple forms.  Right now,
+    // there is no UUID field because there is only ever a single chart form.
     public final List<ChartSection> tileGroups;
     public final List<ChartSection> rowGroups;
     public final String name;
 
-    public Chart(String uuid, String name) {
-        this.uuid = uuid;
+    public Chart(String name) {
         this.name = name;
         this.tileGroups = new ArrayList<>();
         this.rowGroups = new ArrayList<>();

--- a/app/src/main/java/org/projectbuendia/client/models/ConceptUuids.java
+++ b/app/src/main/java/org/projectbuendia/client/models/ConceptUuids.java
@@ -70,6 +70,15 @@ public class ConceptUuids {
     };
 
 
+    // ==== Concept UUIDs for observation-like events stored as observations.
+
+    // This is a custom Buendia-specific concept to indicate that a treatment order
+    // has been carried out (e.g. a prescribed medication has been administered).
+    // The timestamp of an observation for this concept should be the time the order
+    // was executed, and the value of the observation should be the UUID of the order.
+    public static final String ORDER_EXECUTED_CONCEPT_UUID = "buendia_concept_order_executed";
+
+
     // ==== Pulse; used only for health checks and logging messages to the server.
 
     public static final String PULSE_UUID = toUuid(5087);

--- a/app/src/main/java/org/projectbuendia/client/models/Encounter.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Encounter.java
@@ -140,7 +140,7 @@ public class Encounter extends Base<String> {
         }
         for (int i = 0; i < orderUuids.length; i++) {
             ContentValues cv = new ContentValues();
-            cv.put(Observations.CONCEPT_UUID, AppModel.ORDER_EXECUTED_CONCEPT_UUID);
+            cv.put(Observations.CONCEPT_UUID, ConceptUuids.ORDER_EXECUTED_CONCEPT_UUID);
             cv.put(Observations.ENCOUNTER_MILLIS, timestamp.getMillis());
             cv.put(Observations.ENCOUNTER_UUID, encounterUuid);
             cv.put(Observations.PATIENT_UUID, patientUuid);

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsChartServer.java
@@ -14,8 +14,8 @@ package org.projectbuendia.client.net;
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Response;
 
-import org.projectbuendia.client.json.JsonChart;
-import org.projectbuendia.client.json.JsonConceptResponse;
+import org.projectbuendia.client.json.JsonChartsResponse;
+import org.projectbuendia.client.json.JsonConceptsResponse;
 
 import java.util.HashMap;
 
@@ -46,14 +46,13 @@ public class OpenMrsChartServer {
      * @param successListener a {@link Response.Listener} that handles successful concept retrieval
      * @param errorListener   a {@link Response.ErrorListener} that handles failed concept retrieval
      */
-    public void getConcepts(Response.Listener<JsonConceptResponse> successListener,
+    public void getConcepts(Response.Listener<JsonConceptsResponse> successListener,
                             Response.ErrorListener errorListener) {
-        GsonRequest<JsonConceptResponse> request = new GsonRequest<JsonConceptResponse>(
+        GsonRequest<JsonConceptsResponse> request = new GsonRequest<>(
             mConnectionDetails.getBuendiaApiUrl() + "/concepts",
-            JsonConceptResponse.class,
+            JsonConceptsResponse.class,
             mConnectionDetails.addAuthHeader(new HashMap<>()),
-            successListener, errorListener) {
-        };
+            successListener, errorListener);
         request.setRetryPolicy(new DefaultRetryPolicy(Common.REQUEST_TIMEOUT_MS_LONG, 1, 1f));
         mConnectionDetails.getVolley().addToRequestQueue(request);
     }
@@ -64,15 +63,13 @@ public class OpenMrsChartServer {
      * @param successListener a {@link Response.Listener} that handles successful structure retrieval
      * @param errorListener   a {@link Response.ErrorListener} that handles failed structure retrieval
      */
-    public void getChartStructure(
-        String uuid, Response.Listener<JsonChart> successListener,
-        Response.ErrorListener errorListener) {
-        GsonRequest<JsonChart> request = new GsonRequest<JsonChart>(
-            mConnectionDetails.getBuendiaApiUrl() + "/charts/" + uuid + "?v=full",
-            JsonChart.class,
+    public void getChartStructures(Response.Listener<JsonChartsResponse> successListener,
+                                   Response.ErrorListener errorListener) {
+        GsonRequest<JsonChartsResponse> request = new GsonRequest<>(
+            mConnectionDetails.getBuendiaApiUrl() + "/charts/?v=full",
+            JsonChartsResponse.class,
             mConnectionDetails.addAuthHeader(new HashMap<>()),
-            successListener, errorListener) {
-        };
+            successListener, errorListener);
         request.setRetryPolicy(new DefaultRetryPolicy(Common.REQUEST_TIMEOUT_MS_LONG, 1, 1f));
         mConnectionDetails.getVolley().addToRequestQueue(request);
     }

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -103,6 +103,8 @@ public class Database extends SQLiteOpenHelper {
             + "start_millis INTEGER,"
             + "stop_millis INTEGER");
 
+        // TODO(ping): Store multiple charts, sourced from multiple forms,
+        // using a CHARTS table (uuid, name), where order is determined by name.
         SCHEMAS.put(Table.CHART_ITEMS, ""
             + "rowid INTEGER PRIMARY KEY NOT NULL,"
             + "chart_uuid TEXT,"

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/ConceptsSyncWorker.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/ConceptsSyncWorker.java
@@ -9,7 +9,7 @@ import com.android.volley.toolbox.RequestFuture;
 
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.json.JsonConcept;
-import org.projectbuendia.client.json.JsonConceptResponse;
+import org.projectbuendia.client.json.JsonConceptsResponse;
 import org.projectbuendia.client.net.OpenMrsChartServer;
 import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.sync.ChartDataHelper;
@@ -29,7 +29,7 @@ public class ConceptsSyncWorker implements SyncWorker {
         ContentResolver resolver, SyncResult result, ContentProviderClient client
     ) throws Throwable {
         OpenMrsChartServer chartServer = new OpenMrsChartServer(App.getConnectionDetails());
-        RequestFuture<JsonConceptResponse> future = RequestFuture.newFuture();
+        RequestFuture<JsonConceptsResponse> future = RequestFuture.newFuture();
         chartServer.getConcepts(future, future); // errors handled by caller
         ArrayList<ContentValues> conceptInserts = new ArrayList<>();
         ArrayList<ContentValues> conceptNameInserts = new ArrayList<>();

--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/SyncWorker.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/SyncWorker.java
@@ -15,14 +15,17 @@ import android.content.SyncResult;
 public interface SyncWorker {
     // TODO: Replace Throwable with something more specific.
 
+    /** Performs any initial tasks before sync() is called. */
     default void initialize(
         ContentResolver resolver, SyncResult result, ContentProviderClient client
     ) throws Throwable { }
 
+    /** Performs a transactional chunk of sync work, returning true if all done. */
     boolean sync(
         ContentResolver resolver, SyncResult result, ContentProviderClient client
     ) throws Throwable;
 
+    /** Performs any final tasks after all calls to sync() are done. */
     default void finalize(
         ContentResolver resolver, SyncResult result, ContentProviderClient client
     ) throws Throwable { }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -22,10 +22,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.R;
-import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.models.Chart;
 import org.projectbuendia.client.models.ChartItem;
 import org.projectbuendia.client.models.ChartSection;
+import org.projectbuendia.client.models.ConceptUuids;
 import org.projectbuendia.client.models.Obs;
 import org.projectbuendia.client.models.ObsPoint;
 import org.projectbuendia.client.models.Order;
@@ -227,7 +227,7 @@ public class ChartRenderer {
             for (Obs obs : observations) {
                 if (obs == null) continue;
 
-                if (obs.conceptUuid.equals(AppModel.ORDER_EXECUTED_CONCEPT_UUID)) {
+                if (obs.conceptUuid.equals(ConceptUuids.ORDER_EXECUTED_CONCEPT_UUID)) {
                     Order order = orders.get(obs.value);
                     if (order != null) {
                         if (!mExecutionHistories.containsKey(order.uuid)) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -215,7 +215,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
         mSyncManager = syncManager;
         mMainThreadHandler = mainThreadHandler;
         mLastScrollPosition = new Point(Integer.MAX_VALUE, 0);
-        mCharts = mChartHelper.getCharts(AppModel.CHART_UUID);
+        mCharts = mChartHelper.getCharts();
     }
 
     public void setPatient(String uuid) {
@@ -392,7 +392,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
         Interval interval = new Interval(start, start.plusDays(1));
         List<DateTime> executionTimes = new ArrayList<>();
         for (Obs obs : mObservations) {
-            if (AppModel.ORDER_EXECUTED_CONCEPT_UUID.equals(obs.conceptUuid) &&
+            if (ConceptUuids.ORDER_EXECUTED_CONCEPT_UUID.equals(obs.conceptUuid) &&
                 order.uuid.equals(obs.value)) {
                 executionTimes.add(obs.time);
             }


### PR DESCRIPTION
#### User-visible changes

None.

#### Internal changes <!-- optional -->

The dependence on the hardcoded chart UUID is eliminated; the client now requests the charts by asking for the entire list rather than a single chart by its UUID.  This paves the way for multiple charts to be stored in separate forms.