### PR TITLE
Reopen the ODK instance db; send a 0000-00-00 syncToken.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/sync/controllers/IncrementalSyncWorker.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/controllers/IncrementalSyncWorker.java
@@ -108,9 +108,10 @@ public abstract class IncrementalSyncWorker<T> implements SyncWorker {
         OpenMrsConnectionDetails connectionDetails = App.getConnectionDetails();
         Uri.Builder url = Uri.parse(connectionDetails.getBuendiaApiUrl()).buildUpon();
         url.appendPath(resourceType);
-        if (lastSyncToken != null) {
-            url.appendQueryParameter("since", lastSyncToken);
+        if (lastSyncToken == null) {
+            lastSyncToken = "{\"t\":\"0000-00-00T00:00:00.000Z\"}";
         }
+        url.appendQueryParameter("since", lastSyncToken);
         GsonRequest<IncrementalSyncResponse<T>> request = new GsonRequest<>(
                 url.build().toString(),
                 new IncrementalSyncResponseType(clazz),

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -115,7 +115,13 @@ public class InstanceProvider extends ContentProvider {
         }
 
         if (mDbHelper != null) {
-        	return mDbHelper;
+            if (new File(mDbHelper.getWritableDatabase().getPath()).exists()) {
+                return mDbHelper;
+            }
+            // If the file has been moved or deleted, we have to close this
+            // database and open a new one.  Otherwise, the invalid database
+            // will be reused indefinitely and all operations will fail.
+            mDbHelper.close();
         }
         mDbHelper = new DatabaseHelper(DATABASE_NAME);
         return mDbHelper;


### PR DESCRIPTION
Form submission would previously sometimes crash if the ODK directory had been removed (by "Apply and clear data"), because the ODK instance database would get stuck in read-only mode.  Reopening the database causes a new one to be created in read-write mode.  This is the same fix as in https://github.com/projectbuendia/client/commit/a648686bd53880b570050b45c9d447f25266f899  which fixed the form database; this fixes the instance database.

Due to changes in the server API, a syncToken is now required for every sync request.  So, if we don't have a stored syncToken, we send a 0000-00-00 token as the starting point for the sync.