### PR TITLE
Fixes to smoke test.

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/FunctionalTestCase.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/FunctionalTestCase.java
@@ -20,13 +20,9 @@ import android.support.test.espresso.NoActivityResumedException;
 import android.support.test.espresso.core.deps.guava.collect.Iterables;
 import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import android.support.test.runner.lifecycle.Stage;
-import android.view.View;
 
 import com.squareup.spoon.Spoon;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -361,23 +357,15 @@ public class FunctionalTestCase extends TestCaseWithMatcherMethods<LoginActivity
         type(id, viewWithId(R.id.patient_id));
         type(given, viewWithId(R.id.patient_given_name));
         type(family, viewWithId(R.id.patient_family_name));
-        type(id.substring(id.length() - 2), viewWithId(R.id.patient_age_years));
-        type(id.substring(id.length() - 2), viewWithId(R.id.patient_age_months));
-        int sex = Integer.parseInt(id) % 2 == 0 ? R.id.patient_sex_female : R.id.patient_sex_male;
+        int i = Integer.parseInt(id);
+        type("" + (i % 100), viewWithId(R.id.patient_age_years));
+        type("" + (i % 10), viewWithId(R.id.patient_age_months));
+        int sex = i % 2 == 0 ? R.id.patient_sex_female : R.id.patient_sex_male;
         click(viewWithId(sex));
         screenshot("After Patient Populated");
     }
 
-    public View getViewThat(Matcher matcher) {
-        final View[] holder = {null};
-        Matcher capturer = new TypeSafeMatcher<View>() {
-            @Override protected boolean matchesSafely(View item) {
-                holder[0] = item;
-                return true;
-            }
-            @Override public void describeTo(Description description) { }
-        };
-        waitUntilVisible(viewThat(matcher, capturer));
-        return holder[0];
+    protected void toast(String message) {
+        getActivity().runOnUiThread(() -> BigToast.show(getActivity(), message));
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/App.java
+++ b/app/src/main/java/org/projectbuendia/client/App.java
@@ -118,6 +118,9 @@ public class App extends Application {
         mObjectGraph.inject(this);
         mObjectGraph.injectStatics();
 
+        // Ensure all unset preferences get initialized with default values.
+        PreferenceManager.setDefaultValues(this, R.xml.pref_general, false);
+
         synchronized (App.class) {
             sModel = mModel;
             sSettings = mSettings;
@@ -128,12 +131,8 @@ public class App extends Application {
             sUserManager = mUserManager; // TODO: Remove when Daggered.
             sConnectionDetails = mOpenMrsConnectionDetails; // TODO: Remove when Daggered.
             sServer = mServer; // TODO: Remove when Daggered.
+            mHealthMonitor.start();
         }
-
-        // Ensure all unset preferences get initialized with default values.
-        PreferenceManager.setDefaultValues(this, R.xml.pref_general, false);
-
-        mHealthMonitor.start();
     }
 
     public <T> T get(Class<T> type) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -78,7 +78,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
     @VisibleForTesting public static String currentPatientLocationUuid;
 
     // Form UUIDs specific to Ebola deployments.
-    static final String EBOLA_LAB_TEST_FORM_UUID = "buendia-form-ebola_lab_test";
+    static final String EBOLA_LAB_TEST_FORM_UUID = "buendia_form_ebola_lab_test";
 
     /**
      * Period between observation syncs while the chart view is active.
@@ -530,6 +530,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
 
     private synchronized void updatePatientLocationUi() {
         if (mPatient != null && mPatient.locationUuid != null) {
+            currentPatientLocationUuid = mPatient.locationUuid;
             mUi.updatePatientLocationUi(mAppModel.getForest(), mPatient);
         }
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -75,7 +75,6 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
     private static final boolean DEBUG = true;
 
     @VisibleForTesting public static String currentPatientUuid;
-    @VisibleForTesting public static String currentPatientLocationUuid;
 
     // Form UUIDs specific to Ebola deployments.
     static final String EBOLA_LAB_TEST_FORM_UUID = "buendia_form_ebola_lab_test";
@@ -530,7 +529,6 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
 
     private synchronized void updatePatientLocationUi() {
         if (mPatient != null && mPatient.locationUuid != null) {
-            currentPatientLocationUuid = mPatient.locationUuid;
             mUi.updatePatientLocationUi(mAppModel.getForest(), mPatient);
         }
     }


### PR DESCRIPTION
This makes some fixes and improvements to the smoke test:
  - Incremental sync is now properly exercised, by changing a patient's location on the server without changing it locally, and then waiting for the sync to pull down the change.
  - The test now looks for changes in patient counts based on previously seen patient counts, so the test is robust to existing patients.
  - The test no longer relies on the PatientChartController to expose the current patient's location UUID.
  - There is better logging for web click operations.
  - The scroll buttons in the chart are exercised; the view is scrolled down to the bottom so the operations on orders are visible.
  - There is a toast at the end indicating success.