### PR TITLE
Fix top-level layout in the ProgressFragment; add a "No locations" message

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
+++ b/app/src/main/java/org/projectbuendia/client/models/LocationForest.java
@@ -18,6 +18,7 @@ import org.projectbuendia.client.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -227,7 +228,7 @@ public class LocationForest {
     }
 
     /** Iterate over all the nodes in depth-first order. */
-    public @Nonnull Iterable<Location> allNodes() {
+    public @Nonnull Collection<Location> allNodes() {
         return Arrays.asList(locations);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/ProgressFragment.java
@@ -41,6 +41,7 @@ import java.util.List;
 public abstract class ProgressFragment extends Fragment implements Response.ErrorListener {
 
     private static final Logger LOG = Logger.create();
+    protected int mContentLayout;
     protected View mContent;
     protected RelativeLayout mFrame;
     protected TextView mErrorTextView;
@@ -110,16 +111,16 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
             RelativeLayout.LayoutParams.MATCH_PARENT);
         mFrame.setLayoutParams(layoutParams);
 
-        RelativeLayout.LayoutParams relativeLayout = new RelativeLayout.LayoutParams(
+        RelativeLayout.LayoutParams centeredLayout = new RelativeLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT,
             LinearLayout.LayoutParams.WRAP_CONTENT);
-        relativeLayout.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+        centeredLayout.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
         mIndeterminateProgressBar = new ProgressBar(getActivity());
-        mIndeterminateProgressBar.setLayoutParams(relativeLayout);
+        mIndeterminateProgressBar.setLayoutParams(centeredLayout);
 
         mProgressBarLayout =
             inflater.inflate(R.layout.progress_fragment_measured_progress_view, null);
-        mProgressBarLayout.setLayoutParams(relativeLayout);
+        mProgressBarLayout.setLayoutParams(centeredLayout);
         mProgressBar =
             mProgressBarLayout.findViewById(R.id.progress_fragment_progress_bar);
         mProgressBarLabel = mProgressBarLayout.findViewById(R.id.progress_fragment_label);
@@ -135,7 +136,9 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
 
         mFrame.setLayoutParams(fullLayout);
 
+        mContent = LayoutInflater.from(getActivity()).inflate(mContentLayout, mFrame, false);
         mContent.setVisibility(View.GONE);
+
         mIndeterminateProgressBar.setVisibility(View.VISIBLE);
         mProgressBarLayout.setVisibility(View.GONE);
         mErrorTextView.setVisibility(View.GONE);
@@ -166,8 +169,8 @@ public abstract class ProgressFragment extends Fragment implements Response.Erro
         return mState;
     }
 
-    protected void setContentView(int layout) {
-        mContent = LayoutInflater.from(getActivity()).inflate(layout, null, false);
+    protected void setContentLayout(int layout) {
+        mContentLayout = layout;
     }
 
     protected void setProgress(int numerator, int denominator) {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListController.java
@@ -27,6 +27,7 @@ import org.projectbuendia.client.utils.EventBusRegistrationInterface;
 import org.projectbuendia.client.utils.Logger;
 import org.projectbuendia.client.utils.Utils;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -77,7 +78,7 @@ final class LocationListController {
 
     public interface LocationListFragmentUi {
 
-        void setLocations(LocationForest forest, Iterable<Location> locations);
+        void setLocations(LocationForest forest, Collection<Location> locations);
 
         void setReadyState(ReadyState state);
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -28,6 +28,8 @@ import org.projectbuendia.client.ui.ReadyState;
 import org.projectbuendia.client.utils.ContextUtils;
 import org.projectbuendia.client.utils.Logger;
 
+import java.util.Collection;
+
 import javax.inject.Inject;
 
 /** Displays a list of all locations. */
@@ -42,6 +44,7 @@ public final class LocationListFragment extends ProgressFragment {
     private final Ui mUi = new Ui();
     private LocationOptionList mList;
     private ScrollView mScroll;
+    private View mEmpty;
 
     public LocationListFragment() {
         // Required empty public constructor
@@ -59,9 +62,10 @@ public final class LocationListFragment extends ProgressFragment {
         View view = super.onCreateView(inflater, container, savedInstanceState);
 
         mScroll = view.findViewById(R.id.scroll_container);
+        mEmpty = view.findViewById(R.id.empty);
         mList = new LocationOptionList(view.findViewById(R.id.list_container), false);
         LocationForest forest = mModel.getForest();
-        mList.setLocations(forest, forest.allNodes());
+        mUi.setLocations(forest, forest.allNodes());
         return view;
     }
 
@@ -100,7 +104,9 @@ public final class LocationListFragment extends ProgressFragment {
     }
 
     private final class Ui implements LocationListController.LocationListFragmentUi {
-        @Override public void setLocations(LocationForest forest, Iterable<Location> locations) {
+        @Override public void setLocations(LocationForest forest, Collection<Location> locations) {
+            mEmpty.setVisibility(locations.isEmpty() ? View.VISIBLE : View.INVISIBLE);
+            mScroll.setVisibility(locations.isEmpty() ? View.INVISIBLE : View.VISIBLE);
             mList.setLocations(forest, locations);
         }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/LocationListFragment.java
@@ -54,7 +54,7 @@ public final class LocationListFragment extends ProgressFragment {
         super.onCreate(savedInstanceState);
         App.getInstance().inject(this);
         c = ContextUtils.from(getActivity());
-        setContentView(R.layout.fragment_location_selection);
+        setContentLayout(R.layout.fragment_location_selection);
     }
 
     @Override public View onCreateView(

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/PatientListFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/PatientListFragment.java
@@ -79,7 +79,7 @@ public class PatientListFragment extends ProgressFragment implements
         App.getInstance().inject(this);
         mListController = new PatientListController(
             mListUi, mSyncManager, new EventBusWrapper(EventBus.getDefault()));
-        setContentView(R.layout.fragment_patient_list);
+        setContentLayout(R.layout.fragment_patient_list);
     }
 
     @Override public void onResume() {

--- a/app/src/main/java/org/projectbuendia/client/ui/login/LoginFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/login/LoginFragment.java
@@ -47,7 +47,7 @@ public class LoginFragment extends ProgressFragment {
         super.onCreate(savedInstanceState);
         App.getInstance().inject(this);
 
-        setContentView(R.layout.login_fragment);
+        setContentLayout(R.layout.login_fragment);
 
         mUserListAdapter = new UserListAdapter(getActivity(), mUserColorizer);
     }

--- a/app/src/main/res/layout/fragment_location_selection.xml
+++ b/app/src/main/res/layout/fragment_location_selection.xml
@@ -9,22 +9,35 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<ScrollView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/scroll_container"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.flexbox.FlexboxLayout
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/list_container"
+    <ScrollView
+        android:id="@+id/scroll_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12sp"
-        app:flexWrap="wrap"
-        app:alignItems="stretch"
-        app:alignContent="stretch" />
+        android:layout_height="match_parent">
 
-</ScrollView>
+        <com.google.android.flexbox.FlexboxLayout
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:id="@+id/list_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="12sp"
+            app:flexWrap="wrap"
+            app:alignItems="stretch"
+            app:alignContent="stretch" />
+
+    </ScrollView>
+
+    <TextView android:id="@+id/empty"
+          style="@style/text.huge"
+          android:visibility="invisible"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          android:text="@string/no_locations"
+          android:gravity="center_vertical|center_horizontal"/>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_patient_list.xml
+++ b/app/src/main/res/layout/fragment_patient_list.xml
@@ -14,10 +14,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:showDividers="middle"
-    android:divider="?android:dividerHorizontal"
-    android:dividerPadding="0dp">
+    android:layout_height="match_parent">
 
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/fragment_patient_list_swipe_to_refresh"
@@ -33,6 +30,7 @@
 
     <TextView android:id="@+id/empty"
               style="@style/text.huge"
+              android:visibility="invisible"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:text="@string/no_patients"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -54,6 +54,7 @@
   <string name="add_user_connection_error">Erreur de connexion au serveur</string>
   <string name="title_single_location">Les patients dans ce lieu</string>
 
+  <string name="no_locations">Aucun lieu</string>
   <string name="no_patients">Aucun patient</string>
   <string name="one_patient">1 patient</string>
   <string name="n_patients">%d patients</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
   <string name="add_user_connection_error">Error connecting to server</string>
   <string name="title_single_location">Patients at this location</string>
 
+  <string name="no_locations">No locations</string>
   <string name="no_patients">No patients</string>
   <string name="one_patient">1 patient</string>
   <string name="n_patients">%d patients</string>


### PR DESCRIPTION

#### User-visible changes

When there are no locations, the app shows a "No locations" message instead of a blank screen.

The layout of the location list (and any other items that don't fill the entire screen) is properly expanded to fill the screen.


<!-- What is different about the user experience?  Or "None" if this PR is intended not to change anything for users. -->

#### Internal changes <!-- optional -->

Previously, the layout of the top-level content was not being inflated properly in ProgressFragment (there was no reference to the parent view, so layout information could not be propagated).  This is now fixed.
