### PR TITLE
Fix the validation logic for the user, patient, and order dialogs

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -194,7 +194,7 @@ public class EditPatientDialogFragment extends DialogFragment {
         // Set focus.
         EditText[] fields = {mIdPrefix, mId, mGivenName, mFamilyName, mAgeYears, mAgeMonths};
         for (EditText field : fields) {
-            if (field.isShown() && field.getText().toString().isEmpty()) {
+            if (field.isEnabled() && field.getText().toString().isEmpty()) {
                 field.requestFocus();
                 return;
             }

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/NewUserDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/NewUserDialogFragment.java
@@ -71,37 +71,42 @@ public class NewUserDialogFragment extends DialogFragment {
             .setView(fragment);
 
         final AlertDialog dialog = dialogBuilder.create();
-        dialog.setOnShowListener(dialogInterface -> dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(
-            view -> {
-                // Validate the user.
-                String givenName = Utils.toNonnullString(mGivenName.getText()).trim();
-                String familyName = Utils.toNonnullString(mFamilyName.getText()).trim();
-                boolean valid = true;
-                if (givenName.isEmpty()) {
-                    setError(mGivenName, R.string.given_name_cannot_be_null);
-                    valid = false;
-                }
-                if (familyName.isEmpty()) {
-                    setError(mFamilyName, R.string.family_name_cannot_be_null);
-                    valid = false;
-                }
-                Utils.logUserAction("add_user_submitted",
-                    "valid", "" + valid,
-                    "given_name", givenName,
-                    "family_name", familyName);
-                if (!valid) return;
+        dialog.setOnShowListener(di ->
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+                .setOnClickListener(view -> onSubmit(dialog))
+        );
 
-                App.getUserManager().addUser(new JsonNewUser(
-                    givenName, familyName
-                ));
-                if (mActivityUi != null) {
-                    mActivityUi.showSpinner(true);
-                }
-                dialog.dismiss();
-            }));
         // Open the keyboard, ready to type into the given name field.
         dialog.getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         return dialog;
+    }
+
+    private void onSubmit(DialogInterface dialog) {
+        // Validate the user.
+        String givenName = Utils.toNonnullString(mGivenName.getText()).trim();
+        String familyName = Utils.toNonnullString(mFamilyName.getText()).trim();
+        boolean valid = true;
+        if (givenName.isEmpty()) {
+            setError(mGivenName, R.string.given_name_cannot_be_null);
+            valid = false;
+        }
+        if (familyName.isEmpty()) {
+            setError(mFamilyName, R.string.family_name_cannot_be_null);
+            valid = false;
+        }
+        Utils.logUserAction("add_user_submitted",
+            "valid", "" + valid,
+            "given_name", givenName,
+            "family_name", familyName);
+        if (!valid) return;
+
+        App.getUserManager().addUser(new JsonNewUser(
+            givenName, familyName
+        ));
+        if (mActivityUi != null) {
+            mActivityUi.showSpinner(true);
+        }
+        dialog.dismiss();
     }
 
     private void setError(EditText field, int resourceId) {

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
@@ -314,10 +314,17 @@ public class OrderDialogFragment extends DialogFragment {
         final AlertDialog dialog = new AlertDialog.Builder(getActivity())
             .setCancelable(false)
             .setTitle(title)
-            .setPositiveButton(R.string.ok, (dialog1, which) -> onSubmit(dialog1))
+            .setPositiveButton(R.string.ok, null)
             .setNegativeButton(R.string.cancel, null)
             .setView(fragment)
             .create();
+
+        // To prevent the dialog from being automatically dismissed, we have to
+        // override the listener instead of passing it in to setPositiveButton.
+        dialog.setOnShowListener(di ->
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+                .setOnClickListener(view -> onSubmit(dialog))
+        );
 
         // Hide or show the "Stop" and "Delete" buttons appropriately.
         Long stopMillis = Utils.getLong(args, "stop_millis");

--- a/app/src/main/res/layout/patient_dialog_fragment.xml
+++ b/app/src/main/res/layout/patient_dialog_fragment.xml
@@ -29,6 +29,7 @@
           android:text="@string/id_prefix" />
       <EditText
           android:id="@+id/patient_id_prefix"
+          android:enabled="false"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
           android:inputType="textCapCharacters"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -124,7 +124,10 @@
   <string name="female">Feminin</string>
   <string name="unknown">Inconnu</string>
   <string name="title_updating_patient">Mise à jour du patient</string>
+  <string name="title_adding_new_patient">Ajout d\'un nouveau patient</string>
   <string name="please_wait">Attendez SVP</string>
+  <string name="updating_patient_please_wait">Mise à jour du patient, veuillez patienter...</string>
+  <string name="adding_new_patient_please_wait">Ajout d\'un nouveau patient, veuillez patienter...</string>
 
   <string name="title_zoom">Sélectionnez le niveau de zoom</string>
   <string name="zoom_day">1 colonne par jour</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,7 +126,10 @@
   <string name="female">Female</string>
   <string name="unknown">Unknown</string>
   <string name="title_updating_patient">Updating patient</string>
+  <string name="title_adding_new_patient">Adding new patient</string>
   <string name="please_wait">Please wait&#8230;</string>
+  <string name="updating_patient_please_wait">Updating patient; please wait...</string>
+  <string name="adding_new_patient_please_wait">Adding new patient; please wait...</string>
 
   <string name="title_zoom">Set zoom level</string>
   <string name="zoom_day">1 column per day</string>
@@ -326,14 +329,11 @@
   <string name="patient_validation_missing_given_name">Enter the given name</string>
   <string name="patient_validation_missing_id">Enter the patient ID</string>
   <string name="patient_validation_missing_admission_date">Enter the admission date</string>
+  <string name="patient_validation_age_limit">Age cannot be greater than 120 years</string>
   <string name="patient_missing_sex">Please select Male or Female.</string>
-  <string name="patient_validation_future_admission_date">Admission date cannot be in the future.</string>
-  <string name="patient_validation_future_onset_date">Symptom onset date cannot be in the future.</string>
+  <string name="patient_validation_future_admission_date">Admission date cannot be in the future</string>
+  <string name="patient_validation_future_onset_date">Symptom onset date cannot be in the future</string>
   <string name="patient_creation_clear_symptom_onset_date">Clear</string>
-  <!-- Use en dashes for unknown names. These names will be searchable using any form of dash. -->
-  <string name="family_name_hint_unknown">–</string>
-  <string name="given_name_hint_unknown">–</string>
-  <string name="unknown_name">–</string>
 
   <!-- UI strings related to settings -->
   <string name="title_activity_settings">Settings</string>


### PR DESCRIPTION
Scope: New User dialog, New Patient dialog, Edit Patient dialog, Order dialog

#### User-visible changes

Validation was not working properly for these dialogs; entering invalid data would cause the dialog to disappear with no indication that invalid data was entered.

With this change, all the dialogs stay visible with an error message attached to the invalid field indicating what was wrong.

This includes validating that an ID is entered when adding a new patient.

As a crude fix for the problem of no visible feedback while a patient is being saved or updated, we pop a toast indicating that work is happening.  The duration of the toast is fixed, though, and does not actually indicate when processing is finished.