### PR TITLE
Show pregnancy status in action bar subtitle.

### DIFF
--- a/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
+++ b/app/src/androidTest/java/org/projectbuendia/client/ui/chart/PatientChartControllerTest.java
@@ -139,7 +139,7 @@ public final class PatientChartControllerTest {
         // WHEN that patient's details are loaded
         mFakeCrudEventBus.post(new ItemLoadedEvent<>(PATIENT));
         // THEN the controller updates the UI
-        verify(mMockUi).updatePatientDetailsUi(PATIENT);
+        verify(mMockUi).updatePatientDetailsUi(PATIENT, false);
     }
 
     /** Tests that selecting a new general condition results in adding a new encounter. */

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -497,7 +497,7 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             mPatientLocationView.setIcon(createIcon(FontAwesomeIcons.fa_map_marker, R.color.chart_tile_icon));
         }
 
-        @Override public void updatePatientDetailsUi(Patient patient) {
+        @Override public void updatePatientDetailsUi(Patient patient, boolean pregnant) {
             // TODO: Localize everything below.
             String id = Utils.orDefault(patient.id, EN_DASH);
             String fullName = Utils.orDefault(patient.givenName, EN_DASH) + " " +
@@ -506,6 +506,9 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
             List<String> labels = new ArrayList<>();
             if (patient.sex != Sex.UNKNOWN) {
                 labels.add(patient.sex.code);
+            }
+            if (pregnant) {
+                labels.add(getString(R.string.pregnant).toLowerCase());
             }
             labels.add(patient.birthdate == null ? "age unknown"
                 : Utils.birthdateToAge(patient.birthdate, getResources())); // TODO/i18n

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -90,6 +90,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
     private String mPatientUuid = "";
     private Map<String, Order> mOrdersByUuid;
     private List<Obs> mObservations;
+    private boolean mPregnant;
 
     private final EventBusRegistrationInterface mDefaultEventBus;
     private final CrudEventBus mCrudEventBus;
@@ -151,7 +152,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
             LocalDate firstSymptomsDate);
 
         /** Updates the UI with the patient's personal details (name, sex, etc.) */
-        void updatePatientDetailsUi(Patient patient);
+        void updatePatientDetailsUi(Patient patient, boolean pregnant);
 
         /** Shows a progress dialog with an indeterminate spinner in it. */
         void showWaitDialog(int titleId);
@@ -488,9 +489,13 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
             latestObservations, ConceptUuids.ADMISSION_DATE_UUID);
         LocalDate firstSymptomsDate = getObservedDate(
             latestObservations, ConceptUuids.FIRST_SYMPTOM_DATE_UUID);
+        mPregnant = ConceptUuids.isYes(
+            latestObservations.get(ConceptUuids.PREGNANCY_UUID));
+
         mUi.updateAdmissionDateAndFirstSymptomsDateUi(admissionDate, firstSymptomsDate);
         mUi.updateEbolaPcrTestResultUi(latestObservations);
         mUi.updatePregnancyAndIvStatusUi(latestObservations);
+        mUi.updatePatientDetailsUi(mPatient, mPregnant);
         if (!mCharts.isEmpty()) {
             mUi.updateTilesAndGrid(
                 mCharts.get(mChartIndex),
@@ -574,7 +579,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
                 Patient patient = (Patient) event.item;
                 if (patient.uuid.equals(mPatientUuid)) {
                     mPatient = patient;
-                    mUi.updatePatientDetailsUi(mPatient);
+                    mUi.updatePatientDetailsUi(mPatient, mPregnant);
                     updatePatientLocationUi();
                 }
             } else if (event.item instanceof Encounter) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -171,7 +171,7 @@
   <string name="latest_pcr_label_with_date">Essai d\'Ebola test (%s)</string>
   <string name="action_add_test_result">Ajouter le résultat du test</string>
   <string name="pregnant">Enceinte</string>
-  <string name="iv_fitted">cathéter intraveineux en place</string>
+  <string name="iv_fitted">Cathéter intraveineux en place</string>
   <string name="cannot_eat">Ne peut pas manger</string>
   <string name="oxygen">Oxygène</string>
   <string name="status_short_desc_unknown">-</string>


### PR DESCRIPTION
#### User-visible changes

The pregnancy status of the patient is now shown in the action bar, e.g. "F, pregnant, 30 y".

This duplicates the information currently shown in red labels to the right; that area has yet to be reworked.