### PR TITLE
Remove support for order instructions in the older storage format

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/models/Order.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Order.java
@@ -29,7 +29,6 @@ import org.projectbuendia.client.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.Immutable;
@@ -305,38 +304,26 @@ public final @Immutable class Order extends Base<String> {
             //   - Record 1: dosage, unit, concentration, unit
             //   - Record 2: frequency, unit
             //   - Record 3: notes
-            if (instructionsText.contains(RS)) {
-                String[] records = Utils.splitFields(instructionsText, RS, 4);
+            String[] records = Utils.splitFields(instructionsText, RS, 4);
 
-                // Medication
-                String[] fields = Utils.splitFields(records[0], US, 2);
-                medication = fields[0].trim();
-                route = fields[1].trim();
+            // Medication
+            String[] fields = Utils.splitFields(records[0], US, 2);
+            medication = fields[0].trim();
+            route = fields[1].trim();
 
-                // Dosage
-                fields = Utils.splitFields(records[1], US, 2);
-                dosage = fields[0].trim();
-                // TODO(ping): Support dosage units and concentration.
+            // Dosage
+            fields = Utils.splitFields(records[1], US, 2);
+            dosage = fields[0].trim();
+            // TODO(ping): Support dosage units and concentration.
 
-                // Frequency
-                fields = Utils.splitFields(records[2], US, 2);
-                frequency = Utils.toIntOrDefault(fields[0].trim(), 0);
-                // TODO(ping): Support frequency units (currently "per day" is assumed).
+            // Frequency
+            fields = Utils.splitFields(records[2], US, 2);
+            frequency = Utils.toIntOrDefault(fields[0].trim(), 0);
+            // TODO(ping): Support frequency units (currently "per day" is assumed).
 
-                // Notes
-                fields = Utils.splitFields(records[3], US, 2);
-                notes = fields[0].trim();
-            } else {
-                Matcher matcher = OLD_PATTERN.matcher(Utils.toNonnull(instructionsText));
-                if (!matcher.matches()) {
-                    throw new IllegalArgumentException("Invalid order instructions: " + Utils.repr(instructionsText));
-                }
-                medication = Utils.orDefault(matcher.group(1), matcher.group(4)).replace(NON_BREAKING_SPACE, ' ');
-                route = "";
-                dosage = Utils.orDefault(matcher.group(2), matcher.group(5));
-                frequency = matcher.group(3) != null ? Integer.valueOf(matcher.group(3)) : 0;
-                notes = "";
-            }
+            // Notes
+            fields = Utils.splitFields(records[3], US, 2);
+            notes = fields[0].trim();
         }
 
         /** Packs medication, dosage, and frequency into a single instruction string. */
@@ -344,7 +331,8 @@ public final @Immutable class Order extends Base<String> {
             return (medication + US + route)
                 + RS + (dosage)
                 + RS + (frequency > 0 ? (frequency + US + "x daily") : "")
-                + RS + (notes);
+                + RS + (notes)
+                + RS + US + US + ".";
         }
 
         public boolean equals(Object other) {

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/AddEncounterTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/AddEncounterTask.java
@@ -169,9 +169,11 @@ public class AddEncounterTask extends AsyncTask<Void, Void, EncounterAddFailedEv
     // report success/failure.
     @SuppressWarnings("unused") // Called by reflection from EventBus.
     private final class CreationEventSubscriber {
-        public void onEventMainThread(ItemLoadedEvent<Encounter> event) {
-            mBus.post(new ItemCreatedEvent<>(event.item));
-            mBus.unregister(this);
+        public void onEventMainThread(ItemLoadedEvent<?> event) {
+            if (event.item instanceof Encounter) {
+                mBus.post(new ItemCreatedEvent<>((Encounter) event.item));
+                mBus.unregister(this);
+            }
         }
 
         public void onEventMainThread(ItemLoadFailedEvent event) {

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/AddPatientTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/AddPatientTask.java
@@ -153,9 +153,11 @@ public class AddPatientTask extends AsyncTask<Void, Void, PatientAddFailedEvent>
     // success/failure.
     @SuppressWarnings("unused") // Called by reflection from EventBus.
     private final class CreationEventSubscriber {
-        public void onEventMainThread(ItemLoadedEvent<Patient> event) {
-            mBus.post(new ItemCreatedEvent<>(event.item));
-            mBus.unregister(this);
+        public void onEventMainThread(ItemLoadedEvent<?> event) {
+            if (event.item instanceof Patient) {
+                mBus.post(new ItemCreatedEvent<>((Patient) event.item));
+                mBus.unregister(this);
+            }
         }
 
         public void onEventMainThread(ItemLoadFailedEvent event) {

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/SaveOrderTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/SaveOrderTask.java
@@ -66,10 +66,15 @@ public class SaveOrderTask extends AsyncTask<Void, Void, OrderSaveFailedEvent> {
     }
 
     @SuppressWarnings("unused") // called by reflection from EventBus
-    public void onEventMainThread(ItemLoadedEvent<Order> event) {
-        mBus.post(mOrder.uuid != null ? new ItemUpdatedEvent<>(mOrder.uuid, event.item)
-            : new ItemCreatedEvent<>(event.item));
-        mBus.unregister(this);
+    public void onEventMainThread(ItemLoadedEvent<?> event) {
+        if (event.item instanceof Order) {
+            Order item = (Order) event.item;
+            mBus.post(mOrder.uuid != null
+                ? new ItemUpdatedEvent<>(mOrder.uuid, item)
+                : new ItemCreatedEvent<>(item)
+            );
+            mBus.unregister(this);
+        }
     }
 
     @SuppressWarnings("unused") // called by reflection from EventBus

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/UpdatePatientTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/UpdatePatientTask.java
@@ -120,9 +120,11 @@ public class UpdatePatientTask extends AsyncTask<Void, Void, PatientUpdateFailed
     // success/failure.
     @SuppressWarnings("unused") // Called by reflection from EventBus.
     private final class UpdateEventSubscriber {
-        public void onEventMainThread(ItemLoadedEvent<Patient> event) {
-            mBus.post(new ItemUpdatedEvent<>(mUuid, event.item));
-            mBus.unregister(this);
+        public void onEventMainThread(ItemLoadedEvent<?> event) {
+            if (event.item instanceof Patient) {
+                mBus.post(new ItemUpdatedEvent<>(mUuid, (Patient) event.item));
+                mBus.unregister(this);
+            }
         }
 
         public void onEventMainThread(ItemLoadFailedEvent event) {

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/GoToPatientDialogFragment.java
@@ -100,14 +100,16 @@ public class GoToPatientDialogFragment extends DialogFragment {
         }
     }
 
-    public void onEventMainThread(ItemLoadedEvent<Patient> event) {
-        String id = mPatientId.getText().toString().trim();
-        Patient patient = event.item;
-        if (id.equals(patient.id)) {  // server returned the patient we were looking for
-            mPatientUuid = patient.uuid;
-            mPatientSearchResult.setText(patient.givenName + " " + patient.familyName +
-                " (" + patient.sex + ", " + Utils.birthdateToAge(
-                patient.birthdate, App.getInstance().getResources()) + ")");
+    public void onEventMainThread(ItemLoadedEvent<?> event) {
+        if (event.item instanceof Patient) {
+            String id = mPatientId.getText().toString().trim();
+            Patient patient = (Patient) event.item;
+            if (id.equals(patient.id)) {  // server returned the patient we were looking for
+                mPatientUuid = patient.uuid;
+                mPatientSearchResult.setText(patient.givenName + " " + patient.familyName +
+                    " (" + patient.sex + ", " + Utils.birthdateToAge(
+                    patient.birthdate, App.getInstance().getResources()) + ")");
+            }
         }
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/PatientSearchController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/PatientSearchController.java
@@ -14,8 +14,8 @@ package org.projectbuendia.client.ui.lists;
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.events.CrudEventBus;
 import org.projectbuendia.client.events.actions.PatientChartRequestedEvent;
+import org.projectbuendia.client.events.data.AppPatientsLoadedEvent;
 import org.projectbuendia.client.events.data.ItemCreatedEvent;
-import org.projectbuendia.client.events.data.TypedCursorLoadedEvent;
 import org.projectbuendia.client.events.sync.SyncSucceededEvent;
 import org.projectbuendia.client.filter.db.SimpleSelectionFilter;
 import org.projectbuendia.client.filter.db.SimpleSelectionFilterGroup;
@@ -238,9 +238,11 @@ public class PatientSearchController {
     }
 
     private class CreationSubscriber {
-        public void onEventMainThread(ItemCreatedEvent<Patient> event) {
-            Utils.logEvent("add_patient_succeeded");
-            mUi.goToPatientChart(event.item.uuid);
+        public void onEventMainThread(ItemCreatedEvent<?> event) {
+            if (event.item instanceof Patient) {
+                Utils.logEvent("add_patient_succeeded");
+                mUi.goToPatientChart(((Patient) event.item).uuid);
+            }
         }
     }
 
@@ -253,7 +255,7 @@ public class PatientSearchController {
     }
 
     private final class FilterSubscriber {
-        public void onEventMainThread(TypedCursorLoadedEvent<Patient> event) {
+        public void onEventMainThread(AppPatientsLoadedEvent event) {
             mCrudEventBus.unregister(this);
 
             // If a patient cursor was already open, close it.


### PR DESCRIPTION
Ever since we added the route of administration, we don't use this storage format anymore.  It's been a while, and we don't need to maintain compatibility.