### PR TITLE
Improvements to the Edit Patient dialog.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/json/JsonPatient.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonPatient.java
@@ -14,6 +14,7 @@ package org.projectbuendia.client.json;
 import com.google.common.base.MoreObjects;
 
 import org.joda.time.LocalDate;
+import org.projectbuendia.client.models.Sex;
 
 import java.io.Serializable;
 
@@ -24,7 +25,7 @@ public class JsonPatient implements Serializable {
     public String id;  // user-specified patient ID
     public String given_name;
     public String family_name;
-    public String sex; // "U", "M", "F", or "O"
+    public Sex sex;
     public LocalDate birthdate;
 
     public JsonPatient() {

--- a/app/src/main/java/org/projectbuendia/client/models/Patient.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Patient.java
@@ -26,7 +26,7 @@ public final @Immutable class Patient extends Model implements Comparable<Patien
         Utils.getString(cursor, Patients.ID),
         Utils.getString(cursor, Patients.GIVEN_NAME),
         Utils.getString(cursor, Patients.FAMILY_NAME),
-        Sex.forCode(Utils.getString(cursor, Patients.SEX)),
+        Sex.nullableValueOf(Utils.getString(cursor, Patients.SEX)),
         Utils.getLocalDate(cursor, Patients.BIRTHDATE),
         Utils.getBoolean(cursor, Patients.PREGNANCY, false),
         Utils.getString(cursor, Patients.LOCATION_UUID),
@@ -46,7 +46,8 @@ public final @Immutable class Patient extends Model implements Comparable<Patien
     public static Patient fromJson(JsonPatient patient) {
         return new Patient(
             patient.uuid, patient.id, patient.given_name, patient.family_name,
-            Sex.forCode(patient.sex), patient.birthdate, false, "", "");
+            patient.sex, patient.birthdate, false /* pregnancy */,
+            "" /* locationUuid */, "" /* bedNumber */);
     }
 
     @Override public int compareTo(Patient other) {
@@ -60,7 +61,7 @@ public final @Immutable class Patient extends Model implements Comparable<Patien
         cv.put(Patients.ID, id);
         cv.put(Patients.GIVEN_NAME, givenName);
         cv.put(Patients.FAMILY_NAME, familyName);
-        cv.put(Patients.SEX, sex.code);
+        cv.put(Patients.SEX, Sex.nullableNameOf(sex));
         cv.put(Patients.BIRTHDATE, Utils.formatDate(birthdate));
         // PREGNANCY is a denormalized column and is never written directly.
         // LOCATION_UUID is a denormalized column and is never written directly.

--- a/app/src/main/java/org/projectbuendia/client/models/PatientDelta.java
+++ b/app/src/main/java/org/projectbuendia/client/models/PatientDelta.java
@@ -46,7 +46,7 @@ public class PatientDelta {
             cv.put(Contracts.Patients.FAMILY_NAME, familyName.get());
         }
         if (sex.isPresent()) {
-            cv.put(Contracts.Patients.SEX, sex.get().code);
+            cv.put(Contracts.Patients.SEX, Sex.nullableNameOf(sex.get()));
         }
         if (birthdate.isPresent()) {
             cv.put(Contracts.Patients.BIRTHDATE, birthdate.get().toString());
@@ -79,7 +79,7 @@ public class PatientDelta {
                 json.put(Server.PATIENT_FAMILY_NAME_KEY, familyName.get());
             }
             if (sex.isPresent()) {
-                json.put(Server.PATIENT_SEX_KEY, sex.get().code);
+                json.put(Server.PATIENT_SEX_KEY, Sex.serialize(sex.get()));
             }
             if (birthdate.isPresent()) {
                 json.put(

--- a/app/src/main/java/org/projectbuendia/client/models/Sex.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Sex.java
@@ -1,23 +1,47 @@
 package org.projectbuendia.client.models;
 
+import com.google.gson.annotations.SerializedName;
+
+import org.projectbuendia.client.App;
+import org.projectbuendia.client.R;
+
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public enum Sex {
-    UNKNOWN("U"),
-    MALE("M"),
-    FEMALE("F"),
-    OTHER("O");
+    @SerializedName("F") FEMALE,
+    @SerializedName("M") MALE,
+    @SerializedName("O") OTHER;
 
-    public final String code;
-
-    Sex(String code) {
-        this.code = code;
+    public static @Nullable Sex nullableValueOf(@Nullable String name) {
+        return name != null ? Enum.valueOf(Sex.class, name) : null;
     }
 
-    public static @Nonnull Sex forCode(String code) {
-        for (Sex sex : values()) {
-            if (sex.code.equals(code)) return sex;
+    public static @Nullable String nullableNameOf(@Nullable Sex sex) {
+        return sex != null ? sex.name() : null;
+    }
+
+    /** Converts a Sex value to a code for JSON communication with the server. */
+    public static @Nullable String serialize(@Nullable Sex sex) {
+        if (sex == null) return null;
+        try {
+            return Sex.class.getField(sex.name()).getAnnotation(SerializedName.class).value();
+        } catch (NoSuchFieldException e) {
+            return null;
         }
-        return UNKNOWN;
+    }
+
+    /** Gets the localized abbreviation for a Sex value. */
+    public static @Nonnull String getAbbreviation(@Nullable Sex sex) {
+        switch (sex) {
+            case FEMALE:
+                return App.str(R.string.sex_female_abbreviation);
+            case MALE:
+                return App.str(R.string.sex_male_abbreviation);
+            case OTHER:
+                return App.str(R.string.sex_other_abbreviation);
+            default:
+                return "";
+        }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
+++ b/app/src/main/java/org/projectbuendia/client/net/OpenMrsServer.java
@@ -130,13 +130,7 @@ public class OpenMrsServer implements Server {
     }
 
     private JsonPatient patientFromJson(JSONObject object) throws JSONException {
-        JsonPatient patient = mGson.fromJson(object.toString(), JsonPatient.class);
-
-        if (!patient.sex.matches("^[MFOU]$")) {
-            LOG.e("Invalid sex from server: " + patient.sex);
-            patient.sex = "U";
-        }
-        return patient;
+        return mGson.fromJson(object.toString(), JsonPatient.class);
     }
 
     /**

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -502,8 +502,8 @@ public final class PatientChartActivity extends BaseLoggedInActivity {
                 Utils.orDefault(patient.familyName, EN_DASH);
 
             List<String> labels = new ArrayList<>();
-            if (patient.sex != Sex.UNKNOWN) {
-                labels.add(patient.sex.code);
+            if (patient.sex != null) {
+                labels.add(Sex.getAbbreviation(patient.sex));
             }
             if (patient.pregnancy) {
                 labels.add(getString(R.string.pregnant).toLowerCase());

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -17,7 +17,6 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -51,6 +50,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
 import butterknife.ButterKnife;
@@ -68,13 +68,15 @@ public class EditPatientDialogFragment extends DialogFragment {
     @InjectView(R.id.patient_family_name) EditText mFamilyName;
     @InjectView(R.id.patient_age_years) EditText mAgeYears;
     @InjectView(R.id.patient_age_months) EditText mAgeMonths;
-    @InjectView(R.id.patient_sex) RadioGroup mSex;
+    @InjectView(R.id.patient_sex) RadioGroup mSexRadioGroup;
     @InjectView(R.id.patient_sex_female) RadioButton mSexFemale;
     @InjectView(R.id.patient_sex_male) RadioButton mSexMale;
+    @InjectView(R.id.patient_sex_other) RadioButton mSexOther;
 
     private static final Pattern ID_PATTERN = Pattern.compile("([a-zA-Z]+)/?([0-9]+)*");
 
     private LayoutInflater mInflater;
+    private ToggleRadioGroup<Sex> mSex;
     private boolean mAgeChanged;
 
     /** Creates a new instance and registers the given UI, if specified. */
@@ -88,7 +90,7 @@ public class EditPatientDialogFragment extends DialogFragment {
             args.putString("givenName", patient.givenName);
             args.putString("familyName", patient.familyName);
             args.putString("birthdate", Utils.formatDate(patient.birthdate));
-            args.putString("sex", patient.sex.code);
+            args.putString("sex", Sex.nullableNameOf(patient.sex));
         }
         fragment.setArguments(args);
         return fragment;
@@ -98,6 +100,35 @@ public class EditPatientDialogFragment extends DialogFragment {
         super.onCreate(savedInstanceState);
         App.inject(this);
         mInflater = LayoutInflater.from(getActivity());
+    }
+
+    @Override public @Nonnull Dialog onCreateDialog(Bundle savedInstanceState) {
+        View fragment = mInflater.inflate(R.layout.patient_dialog_fragment, null);
+        ButterKnife.inject(this, fragment);
+
+        Bundle args = getArguments();
+        String title = args.getBoolean("new") ?
+            getString(R.string.title_activity_patient_add) :
+            getString(R.string.action_edit_patient);
+        populateFields(args);
+
+        AlertDialog dialog = new AlertDialog.Builder(getActivity())
+            .setCancelable(false) // Disable auto-cancel.
+            .setTitle(title)
+            .setPositiveButton(getString(R.string.ok), null)
+            .setNegativeButton(getString(R.string.cancel), null)
+            .setView(fragment)
+            .create();
+
+        // To prevent the dialog from being automatically dismissed, we have to
+        // override the listener instead of passing it in to setPositiveButton.
+        dialog.setOnShowListener(di ->
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+                .setOnClickListener(view -> onSubmit(dialog))
+        );
+
+        focusFirstEmptyField(dialog);
+        return dialog;
     }
 
     private void populateFields(Bundle args) {
@@ -122,17 +153,15 @@ public class EditPatientDialogFragment extends DialogFragment {
             mAgeYears.setText(String.valueOf(age.getYears()));
             mAgeMonths.setText(String.valueOf(age.getMonths()));
         }
-        switch (Sex.forCode(args.getString("sex", Sex.UNKNOWN.code))) {
-            case FEMALE:
-                mSexFemale.setChecked(true);
-                break;
-            case MALE:
-                mSexMale.setChecked(true);
-                break;
-        }
+
+        Sex sex = Sex.nullableValueOf(args.getString("sex"));
+        mSexFemale.setTag(Sex.FEMALE);
+        mSexMale.setTag(Sex.MALE);
+        mSexOther.setTag(Sex.OTHER);
+        mSex = new ToggleRadioGroup<>(mSexRadioGroup);
+        mSex.setSelection(sex);
 
         mAgeChanged = false;
-
         TextWatcher ageEditedWatcher = new AgeEditedWatcher();
         mAgeYears.addTextChangedListener(ageEditedWatcher);
         mAgeMonths.addTextChangedListener(ageEditedWatcher);
@@ -143,6 +172,7 @@ public class EditPatientDialogFragment extends DialogFragment {
         String id = Utils.toNonemptyOrNull(mId.getText().toString().trim());
         String givenName = Utils.toNonemptyOrNull(mGivenName.getText().toString().trim());
         String familyName = Utils.toNonemptyOrNull(mFamilyName.getText().toString().trim());
+        Sex sex = mSex.getSelection();
         String ageYears = mAgeYears.getText().toString().trim();
         String ageMonths = mAgeMonths.getText().toString().trim();
         LocalDate birthdate = null;
@@ -178,19 +208,6 @@ public class EditPatientDialogFragment extends DialogFragment {
             valid = false;
         }
         if (!valid) return;
-
-        Sex sex = null;
-        // TODO: This should start out as "Sex sex = null" and then get set to female, male,
-        // other, or unknown if any button is selected (there should be four buttons) -- so
-        // that we can distinguish "no change to sex" (null) from "change sex to unknown" ("U").
-        switch (mSex.getCheckedRadioButtonId()) {
-            case R.id.patient_sex_female:
-                sex = Sex.FEMALE;
-                break;
-            case R.id.patient_sex_male:
-                sex = Sex.MALE;
-                break;
-        }
 
         if (!idPrefix.isEmpty()) {
             id = idPrefix + "/" + id;
@@ -259,33 +276,6 @@ public class EditPatientDialogFragment extends DialogFragment {
         // If all fields are populated, default to the end of the given name field.
         mGivenName.requestFocus();
         mGivenName.setSelection(mGivenName.getText().length());
-    }
-
-    @Override public @NonNull Dialog onCreateDialog(Bundle savedInstanceState) {
-        View fragment = mInflater.inflate(R.layout.patient_dialog_fragment, null);
-        ButterKnife.inject(this, fragment);
-
-        Bundle args = getArguments();
-        String title = args.getBoolean("new") ? getString(R.string.title_activity_patient_add) : getString(R.string.action_edit_patient);
-        populateFields(args);
-
-        AlertDialog dialog = new AlertDialog.Builder(getActivity())
-            .setCancelable(false) // Disable auto-cancel.
-            .setTitle(title)
-            .setPositiveButton(getString(R.string.ok), null)
-            .setNegativeButton(getString(R.string.cancel), null)
-            .setView(fragment)
-            .create();
-
-        // To prevent the dialog from being automatically dismissed, we have to
-        // override the listener instead of passing it in to setPositiveButton.
-        dialog.setOnShowListener(di ->
-            dialog.getButton(DialogInterface.BUTTON_POSITIVE)
-                .setOnClickListener(view -> onSubmit(dialog))
-        );
-
-        focusFirstEmptyField(dialog);
-        return dialog;
     }
 
     private class AgeEditedWatcher implements TextWatcher {

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/ToggleRadioGroup.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/ToggleRadioGroup.java
@@ -1,0 +1,48 @@
+package org.projectbuendia.client.ui.dialogs;
+
+import android.view.View;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.projectbuendia.client.utils.Utils.eq;
+
+public class ToggleRadioGroup<T> {
+    private final RadioGroup group;
+    private Map<T, RadioButton> buttons = new HashMap<>();
+    private T selection = null;
+
+    public ToggleRadioGroup(RadioGroup group) {
+        this.group = group;
+        for (int i = 0; i < group.getChildCount(); i++) {
+            View child = group.getChildAt(i);
+            T value;
+            try {
+                value = (T) child.getTag();
+            } catch (ClassCastException e) {
+                continue;
+            }
+            if (child instanceof RadioButton && value != null) {
+                buttons.put(value, (RadioButton) child);
+                child.setOnClickListener(view -> setSelection(
+                    eq(selection, value) ? null : value));
+            }
+        }
+    }
+
+    public void setSelection(T value) {
+        if (value == null) {
+            group.clearCheck();
+        } else {
+            RadioButton button = buttons.get(value);
+            if (button != null) button.setChecked(true);
+        }
+        selection = value;
+    }
+
+    public T getSelection() {
+        return selection;
+    }
+}

--- a/app/src/main/res/layout/patient_dialog_fragment.xml
+++ b/app/src/main/res/layout/patient_dialog_fragment.xml
@@ -144,19 +144,13 @@
             android:id="@+id/patient_sex_male"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="8sp"
             android:text="@string/male" />
-        <!--
         <RadioButton
-            android:id="@+id/sex_other"
+            android:id="@+id/patient_sex_other"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/other" />
-        <RadioButton
-            android:id="@+id/sex_unknown"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/unknown" />
-        -->
       </RadioGroup>
     </TableRow>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -122,8 +122,12 @@
   <string name="chart_last_updated">"Graphique dernière mise à jour: "</string>
   <string name="last_observation_none">Aucune observation</string>
   <string name="male">Masculin</string>
-  <string name="female">Feminin</string>
+  <string name="female">Féminin</string>
+  <string name="other">Autre</string>
   <string name="unknown">Inconnu</string>
+  <string name="sex_male_abbreviation">M</string>
+  <string name="sex_female_abbreviation">F</string>
+  <string name="sex_other_abbreviation">A</string>
   <string name="title_updating_patient">Mise à jour du patient</string>
   <string name="title_adding_new_patient">Ajout d\'un nouveau patient</string>
   <string name="please_wait">Attendez SVP</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,7 +125,11 @@
   <string name="last_observation_none">No observations</string>
   <string name="male">Male</string>
   <string name="female">Female</string>
+  <string name="other">Other</string>
   <string name="unknown">Unknown</string>
+  <string name="sex_male_abbreviation">M</string>
+  <string name="sex_female_abbreviation">F</string>
+  <string name="sex_other_abbreviation">O</string>
   <string name="title_updating_patient">Updating patient</string>
   <string name="title_adding_new_patient">Adding new patient</string>
   <string name="please_wait">Please wait&#8230;</string>


### PR DESCRIPTION
This fixes two problems:
  - The age of the patient used to be overwritten even if the user didn't edit it, causing the birthdate to drift.
  - We weren't consistent about how we handled the sex field; now there are exactly four states: female, male, other, and unknown (null).