### PR TITLE
Simplify the bookmark format

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/json/IncrementalSyncResponse.java
+++ b/app/src/main/java/org/projectbuendia/client/json/IncrementalSyncResponse.java
@@ -14,23 +14,17 @@
 package org.projectbuendia.client.json;
 
 /**
- * Represents an incremental sync response of type {@code T}. This object is deserialized from JSON,
- * so {@code T} should be a type that can be populated from the JSON response.
+ * An incremental sync response containing items of type T.  This object is
+ * deserialized from JSON, so T should be a type that can be deserialized
+ * from the JSON response.
  */
 public class IncrementalSyncResponse<T> {
     /** A list of objects returned by the incremental sync operation. */
     public T[] results;
 
-    /**
-     * Can be sent to the server with the next request to ensure that only new data will be
-     * returned.
-     */
-    public String syncToken;
+    /** Can be sent with the next request to cause only new data to be returned. */
+    public String bookmark;
 
-    /**
-     * {@code true} if there is more data that remains unfetched. In this case, a subsequent request
-     * to the same endpoint that supplies {@link #syncToken} from this response will return more
-     * data that the client hasn't previously fetched.
-     */
+    /** True if there is more data available to be fetched. */
     public boolean more;
 }

--- a/app/src/main/java/org/projectbuendia/client/json/JsonOrdersResponse.java
+++ b/app/src/main/java/org/projectbuendia/client/json/JsonOrdersResponse.java
@@ -1,9 +1,0 @@
-package org.projectbuendia.client.json;
-
-/** JSON format of a response to GET /orders?v=full */
-public class JsonOrdersResponse {
-    public JsonOrder[] results;
-    // TODO(capnfabs): Rename this to syncToken.
-    /** In ISO 8601 date format. */
-    public String snapshotTime;
-}

--- a/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/BuendiaProvider.java
@@ -20,7 +20,7 @@ import org.projectbuendia.client.providers.Contracts.Misc;
 import org.projectbuendia.client.providers.Contracts.Observations;
 import org.projectbuendia.client.providers.Contracts.Orders;
 import org.projectbuendia.client.providers.Contracts.Patients;
-import org.projectbuendia.client.providers.Contracts.SyncTokens;
+import org.projectbuendia.client.providers.Contracts.Bookmarks;
 import org.projectbuendia.client.providers.Contracts.Table;
 import org.projectbuendia.client.providers.Contracts.Users;
 import org.projectbuendia.client.sync.Database;
@@ -84,11 +84,11 @@ public class BuendiaProvider extends DelegatingProvider<Database> {
         registry.registerDelegate(Misc.URI.getPath(),
             new InsertableItemProviderDelegate(Misc.ITEM_TYPE, Table.MISC, "rowid"));
 
-        // Custom provider for our sync token table.
-        registry.registerDelegate(SyncTokens.URI.getPath(),
-            new GroupProviderDelegate(SyncTokens.ITEM_TYPE, Table.SYNC_TOKENS));
-        registry.registerDelegate(SyncTokens.URI.getPath() + "/*",
-                new ItemProviderDelegate(SyncTokens.ITEM_TYPE, Table.SYNC_TOKENS, SyncTokens.TABLE_NAME));
+        // Custom provider for our bookmark table.
+        registry.registerDelegate(Bookmarks.URI.getPath(),
+            new GroupProviderDelegate(Bookmarks.ITEM_TYPE, Table.BOOKMARKS));
+        registry.registerDelegate(Bookmarks.URI.getPath() + "/*",
+                new ItemProviderDelegate(Bookmarks.ITEM_TYPE, Table.BOOKMARKS, Bookmarks.TABLE_NAME));
 
         return registry;
     }

--- a/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
+++ b/app/src/main/java/org/projectbuendia/client/providers/Contracts.java
@@ -25,6 +25,7 @@ public interface Contracts {
 
     /** Names of tables in the local datastore. */
     enum Table {
+        BOOKMARKS("bookmarks"),
         CHART_ITEMS("chart_items"),
         CONCEPT_NAMES("concept_names"),
         CONCEPTS("concepts"),
@@ -34,8 +35,7 @@ public interface Contracts {
         OBSERVATIONS("observations"),
         ORDERS("orders"),
         PATIENTS("patients"),
-        USERS("users"),
-        SYNC_TOKENS("sync_tokens");
+        USERS("users");
 
         public String name;
 
@@ -50,6 +50,13 @@ public interface Contracts {
 
     // Each interface below corresponds to one SQLite table in the local datastore.  The column
     // names defined in the constants should exactly match the schemas defined in Database.java.
+
+    interface Bookmarks {
+        Uri URI = buildContentUri("bookmarks");
+        String ITEM_TYPE = buildItemType("bookmark");
+        String TABLE_NAME = "table_name";
+        String BOOKMARK = "bookmark";
+    }
 
     interface ChartItems {
         Uri URI = buildContentUri("chart-items");
@@ -139,13 +146,6 @@ public interface Contracts {
          */
         String FULL_SYNC_END_MILLIS = "full_sync_end_millis";
 
-    }
-
-    interface SyncTokens {
-        Uri URI = buildContentUri("sync-tokens");
-        String ITEM_TYPE = buildItemType("sync-token");
-        String TABLE_NAME = "table_name";
-        String SYNC_TOKEN = "sync_token";
     }
 
     interface Observations {

--- a/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
@@ -32,9 +32,9 @@ import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.projectbuendia.client.R;
 import org.projectbuendia.client.providers.BuendiaProvider;
-import org.projectbuendia.client.providers.Contracts;
 import org.projectbuendia.client.providers.Contracts.Misc;
 import org.projectbuendia.client.providers.Contracts.SyncTokens;
+import org.projectbuendia.client.providers.Contracts.Table;
 import org.projectbuendia.client.providers.DatabaseTransaction;
 import org.projectbuendia.client.sync.SyncManager.SyncStatus;
 import org.projectbuendia.client.sync.controllers.ChartsSyncWorker;
@@ -242,11 +242,12 @@ public class BuendiaSyncEngine implements SyncEngine {
 
     /** Returns the server timestamp corresponding to the last observation sync. */
     @Nullable
-    public static String getLastSyncToken(ContentProviderClient provider, Contracts.Table table)
+    public static String getBookmark(ContentProviderClient provider, Table table)
             throws RemoteException {
-        try(Cursor c = provider.query(
+        try (Cursor c = provider.query(
                 SyncTokens.URI.buildUpon().appendPath(table.name).build(),
-                new String[] {SyncTokens.SYNC_TOKEN}, null, null, null)) {
+                new String[] {SyncTokens.SYNC_TOKEN}, null, null, null)
+        ) {
             // Make the linter happy, there's no way that the cursor can be null without throwing
             // an exception.
             assert c != null;
@@ -263,8 +264,7 @@ public class BuendiaSyncEngine implements SyncEngine {
         }
     }
 
-    public static void storeSyncToken(
-            ContentProviderClient provider, Contracts.Table table, String syncToken)
+    public static void setBookmark(ContentProviderClient provider, Table table, String syncToken)
             throws RemoteException {
         ContentValues cv = new ContentValues();
         cv.put(SyncTokens.TABLE_NAME, table.name);

--- a/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/BuendiaSyncEngine.java
@@ -33,7 +33,7 @@ import org.joda.time.Instant;
 import org.projectbuendia.client.R;
 import org.projectbuendia.client.providers.BuendiaProvider;
 import org.projectbuendia.client.providers.Contracts.Misc;
-import org.projectbuendia.client.providers.Contracts.SyncTokens;
+import org.projectbuendia.client.providers.Contracts.Bookmarks;
 import org.projectbuendia.client.providers.Contracts.Table;
 import org.projectbuendia.client.providers.DatabaseTransaction;
 import org.projectbuendia.client.sync.SyncManager.SyncStatus;
@@ -245,8 +245,8 @@ public class BuendiaSyncEngine implements SyncEngine {
     public static String getBookmark(ContentProviderClient provider, Table table)
             throws RemoteException {
         try (Cursor c = provider.query(
-                SyncTokens.URI.buildUpon().appendPath(table.name).build(),
-                new String[] {SyncTokens.SYNC_TOKEN}, null, null, null)
+                Bookmarks.URI.buildUpon().appendPath(table.name).build(),
+                new String[] {Bookmarks.BOOKMARK}, null, null, null)
         ) {
             // Make the linter happy, there's no way that the cursor can be null without throwing
             // an exception.
@@ -264,11 +264,11 @@ public class BuendiaSyncEngine implements SyncEngine {
         }
     }
 
-    public static void setBookmark(ContentProviderClient provider, Table table, String syncToken)
+    public static void setBookmark(ContentProviderClient provider, Table table, String bookmark)
             throws RemoteException {
         ContentValues cv = new ContentValues();
-        cv.put(SyncTokens.TABLE_NAME, table.name);
-        cv.put(SyncTokens.SYNC_TOKEN, syncToken);
-        provider.insert(SyncTokens.URI, cv);
+        cv.put(Bookmarks.TABLE_NAME, table.name);
+        cv.put(Bookmarks.BOOKMARK, bookmark);
+        provider.insert(Bookmarks.URI, cv);
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/sync/Database.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/Database.java
@@ -31,7 +31,7 @@ public class Database extends SQLiteOpenHelper {
     private static final Logger LOG = Logger.create();
 
     /** Schema version. */
-    public static final int DATABASE_VERSION = 35;
+    public static final int DATABASE_VERSION = 36;
 
     /** Filename for SQLite file. */
     public static final String DATABASE_FILENAME = "buendia.db";
@@ -129,9 +129,9 @@ public class Database extends SQLiteOpenHelper {
             + "full_sync_start_millis INTEGER,"
             + "full_sync_end_millis INTEGER");
 
-        SCHEMAS.put(Table.SYNC_TOKENS, ""
+        SCHEMAS.put(Table.BOOKMARKS, ""
             + "table_name TEXT PRIMARY KEY NOT NULL,"
-            + "sync_token TEXT NOT NULL");
+            + "bookmark TEXT NOT NULL");
     }
 
     public Database(Context context) {


### PR DESCRIPTION
This changes the bookmark format from the previously unwieldy SyncToken JSON to a simple string.  This is a wire protocol change and must be deployed with the corresponding change in the server.