### PR TITLE
Fix the way the locale setting is applied to the base context.

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/App.java
+++ b/app/src/main/java/org/projectbuendia/client/App.java
@@ -79,15 +79,17 @@ public class App extends Application {
         return sInstance.getApplicationContext();
     }
 
-    public static void applyLocaleSetting() {
+    /** This should be called in every Activity's attachBaseContext method. */
+    public static Context applyLocaleSetting(Context base) {
         Locale locale = getSettings().getLocale();
         Locale.setDefault(locale);
-        Resources resources = getContext().getResources();
+        Resources resources = base.getResources();
         Configuration config = resources.getConfiguration();
-        config.locale = locale;
+        config.setLocale(locale);
         config.setLayoutDirection(locale);
-        resources.updateConfiguration(config, resources.getDisplayMetrics());
-        sResources = resources;
+        Context context = base.createConfigurationContext(config);
+        sResources = context.getResources();
+        return context;
     }
 
     public static String str(int id, Object... args) {
@@ -175,7 +177,6 @@ public class App extends Application {
             sConnectionDetails = mOpenMrsConnectionDetails;
             sServer = mServer;
             sConceptService = new ConceptService(getContentResolver());
-            applyLocaleSetting();
             mHealthMonitor.start();
         }
     }

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
@@ -436,8 +436,7 @@ public abstract class BaseActivity extends FragmentActivity {
     }
 
     @Override protected void attachBaseContext(Context base) {
-        App.applyLocaleSetting();
-        super.attachBaseContext(App.getContext());
+        super.attachBaseContext(App.applyLocaleSetting(base));
         u = ContextUtils.from(this);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/SettingsActivity.java
@@ -263,8 +263,7 @@ public class SettingsActivity extends PreferenceActivity {
     }
 
     @Override protected void attachBaseContext(Context base) {
-        App.applyLocaleSetting();
-        super.attachBaseContext(App.getContext());
+        super.attachBaseContext(App.applyLocaleSetting(base));
     }
 
     @Override protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
This fixes an issue that would cause the locale to be applied improperly on Android 8.