### PR TITLE
Define fixed tiles in the profile

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -42,7 +42,7 @@ button#up { bottom: 12rem; }
 button#down { bottom: 6rem; }
 
 /* Apply borders to all cells so their sizes are uniform. */
-.top th { border-top: 1px solid transparent; }
+.top th { border-top: 1px solid transparent; border-bottom: none; }
 th, td { border: 1px solid transparent; border-width: 0 1px 1px 0; }
 
 /* Grid lines */
@@ -170,7 +170,7 @@ th.command { /* should match @style/ActionButton */
 #grid-left .frozen { background: #fff; z-index: 1; }
 
 /* Tiles */
-#fixed { background: #ddd; }
+#fixed { background: #eee; }
 #tiles { width: 100%; }
 .row { display: flex; flex-direction: row; }
 .tile { flex-basis: 0; flex-grow: 1; padding: 1rem 0 1rem 16px; }

--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -170,7 +170,7 @@ th.command { /* should match @style/ActionButton */
 #grid-left .frozen { background: #fff; z-index: 1; }
 
 /* Tiles */
-#fixed { background: #eee; }
+#fixed { background: #eee; min-height: 1px; }
 #tiles { width: 100%; }
 .row { display: flex; flex-direction: row; }
 .tile { flex-basis: 0; flex-grow: 1; padding: 1rem 0 1rem 16px; }

--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -7,12 +7,14 @@ body { margin: 0; }
 div, th, td { text-overflow: ellipsis; }
 th, td, table div { overflow: hidden; }
 th, td { font-weight: normal; text-align: left; vertical-align: baseline; }
+#grid-table { visibility: hidden; }
 
 /* Scrolling */
-#scroller { display: flex; flex-direction: row; width: 100%; }
-#grid { visibility: hidden; }
-#grid-left { flex-basis: 0; flex-grow: 0; }
-#grid-body { flex-basis: 0; flex-grow: 1; overflow: scroll; position: relative; }
+body { position: absolute; top: 0; bottom: 0; left: 0; right: 0; display: flex; flex-direction: column; }
+#scrolling { flex: 1; overflow: scroll; }
+#grid { display: flex; flex-direction: row; width: 100%; overflow: scroll; }
+#grid-left { flex-grow: 0; }
+#grid-body { flex-grow: 1; overflow: scroll; position: relative; }
 
 #buttons button {
   font-size: 3.2rem;
@@ -163,11 +165,12 @@ th.command { /* should match @style/ActionButton */
 .order .notes + .medication { max-width: 60%; }
 
 /* Frozen headings */
-.frozen { position: fixed; top: 0; background: #fff; }
+.frozen { position: fixed; background: #fff; }
 .floating { position: absolute; background: #fff; }
 #grid-left .frozen { background: #fff; z-index: 1; }
 
 /* Tiles */
+#fixed { background: #ddd; }
 #tiles { width: 100%; }
 .row { display: flex; flex-direction: row; }
 .tile { flex-basis: 0; flex-grow: 1; padding: 1rem 0 1rem 16px; }

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -22,7 +22,7 @@
           <th class="gap" scope="col" rowspan=2>&nbsp;</th>
         {% endif %}
         {% if column.start == column.dayStart %}
-          <th class="day {{column.date == today ? 'now' : ''}} {{column.date.dayOfWeek > 5 ? 'weekend' : ''}}" colspan={{numColumnsPerDay}} onclick="c.showObsDetails({{column.dayStart.millis}}, {{column.dayStop.millis}});">
+          <th class="day {{column.date == today ? 'now' : ''}} {{column.date.dayOfWeek > 5 ? 'weekend' : ''}}" colspan={{numColumnsPerDay}} onclick="c.showObsDialog({{column.dayStart.millis}}, {{column.dayStop.millis}});">
             {% if numColumnsPerDay == 1 %}
               {% if column.dayLabel is empty %}&nbsp;{% else %}{{column.dayLabel}}{% endif %}
             {% elseif column.dayLabel is not empty %}
@@ -38,7 +38,7 @@
     <tr>
       <th class="corner">&nbsp;</th>
       {% for column in columns %}
-        <th class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}}" scope="col" onclick="c.showObsDetails({{column.start.millis}}, {{column.stop.millis}});">
+        <th class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}}" scope="col" onclick="c.showObsDialog({{column.start.millis}}, {{column.stop.millis}});">
           {% if numColumnsPerDay == 1 %}
             {{column.shortDate}}
           {% else %}
@@ -70,7 +70,7 @@
       {% for row in group.rows %}
         {% set id = row.item.conceptIds | first %}
         <tr class="obs {{row.item.label | to_css_identifier}}">
-          <th scope="row" onclick="c.showObsDetails('{{row.item.conceptUuidsList}}');">
+          <th scope="row" onclick="c.showObsDialog('{{row.item.conceptUuidsList}}');">
             {{row.item.label}}
           </th>
           {% set prevStop = columns[0].start %}
@@ -91,7 +91,7 @@
             <td class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}} {{class}}"
               style="{{style}}"
               onclick="{% if points is not empty and row.item.type.string != 'text_icon' %}
-                         c.showObsDetails('{{row.item.conceptUuidsList}}', {{column.start.millis}}, {{column.stop.millis}});
+                         c.showObsDialog('{{row.item.conceptUuidsList}}', {{column.start.millis}}, {{column.stop.millis}});
                        {% endif %}">
               {% if points is empty %}
                 &nbsp;
@@ -237,7 +237,7 @@
         {% set values = tile.points | values %}
         {% set class = values | format_values(tile.item.cssClass) %}
         {% set style = values | format_values(tile.item.cssStyle) %}
-      <div class="tile {{class}}" onclick="c.showObsDetails('{{tile.item.conceptUuidsList}}');" style="{{style}}">
+      <div class="tile {{class}}" onclick="c.showObsDialog('{{tile.item.conceptUuidsList}}');" style="{{style}}">
           <div class="heading">{{tile.item.label}}</div>
           <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
           <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>
@@ -256,7 +256,7 @@
           {% set values = tile.points | values %}
           {% set class = values | format_values(tile.item.cssClass) %}
           {% set style = values | format_values(tile.item.cssStyle) %}
-          <div class="tile {{class}}" onclick="c.showObsDetails('{{tile.item.conceptUuidsList}}');" style="{{style}}">
+          <div class="tile {{class}}" onclick="c.showObsDialog('{{tile.item.conceptUuidsList}}');" style="{{style}}">
             <div class="heading">{{tile.item.label}}</div>
             <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
             <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -237,7 +237,7 @@
         {% set values = tile.points | values %}
         {% set class = values | format_values(tile.item.cssClass) %}
         {% set style = values | format_values(tile.item.cssStyle) %}
-        <div class="tile {{class}}" onclick="c.showObsDetails('{{tile.item.conceptUuidsList}}');" style="{{style}}">
+      <div class="tile {{class}}" onclick="c.showObsDetails('{{tile.item.conceptUuidsList}}');" style="{{style}}">
           <div class="heading">{{tile.item.label}}</div>
           <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
           <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -11,25 +11,8 @@
 
 <!-- Use double-quotes for HTML attributes; single-quotes for JS/Pebble strings. -->
 <body>
-<div id="tiles" cellspacing="0" cellpadding="0">
-  {% for tileRow in tileRows %}
-    <div class="row">
-      {% for tile in tileRow %}
-        {% set id = tile.item.conceptIds | first %}
-        {% set values = tile.points | values %}
-        {% set class = values | format_values(tile.item.cssClass) %}
-        {% set style = values | format_values(tile.item.cssStyle) %}
-        <div class="tile {{class}}" onclick="od('{{tile.item.conceptUuids[0]}}','','');" style="{{style}}">
-          <div class="heading">{{tile.item.label}}</div>
-          <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
-          <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>
-        </div>
-      {% endfor %}
-    </div>
-  {% endfor %}
-</div>
 
-<table id="grid" cellspacing=0 cellpadding=0>
+<table id="grid-table" cellspacing=0 cellpadding=0>
   <thead>
     <tr class="top">
       <th class="corner">&nbsp;</th>
@@ -246,22 +229,68 @@
   </tbody>
 </table>
 
-<div id="scroller" ontouchstart="seeking = false">
-  <div id="grid-left"></div>
-  <div id="grid-body"></div>
-  <div id="buttons">
-    <button id="up" ontouchstart="moveTarget(event, 0, -jumpY)"></button>
-    <button id="down" ontouchstart="moveTarget(event, 0, jumpY)"></button>
-    <button id="left" ontouchstart="moveTarget(event, -jumpX, 0)"></button>
-    <button id="home" ontouchstart="moveTarget(event, 0, 0, true)"></button>
-    <button id="right" ontouchstart="moveTarget(event, jumpX, 0)"></button>
+<div id="fixed" cellspacing="0" cellpadding="0">
+  {% for fixedRow in fixedRows %}
+    <div class="row">
+      {% for tile in fixedRow %}
+        {% set id = tile.item.conceptIds | first %}
+        {% set values = tile.points | values %}
+        {% set class = values | format_values(tile.item.cssClass) %}
+        {% set style = values | format_values(tile.item.cssStyle) %}
+        <div class="tile {{class}}" onclick="od('{{tile.item.conceptUuids[0]}}','','');" style="{{style}}">
+          <div class="heading">{{tile.item.label}}</div>
+          <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
+          <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endfor %}
+</div>
+
+<div id="scrolling" ontouchstart="seeking = false">
+  <div id="tiles" cellspacing="0" cellpadding="0">
+    {% for tileRow in tileRows %}
+      <div class="row">
+        {% for tile in tileRow %}
+          {% set id = tile.item.conceptIds | first %}
+          {% set values = tile.points | values %}
+          {% set class = values | format_values(tile.item.cssClass) %}
+          {% set style = values | format_values(tile.item.cssStyle) %}
+          <div class="tile {{class}}" onclick="od('{{tile.item.conceptUuids[0]}}','','');" style="{{style}}">
+            <div class="heading">{{tile.item.label}}</div>
+            <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
+            <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endfor %}
   </div>
+  <div id="grid">
+    <div id="grid-left"></div>
+    <div id="grid-body"></div>
+  </div>
+</div>
+
+<div id="buttons">
+  <button id="up" ontouchstart="moveTarget(event, 0, -jumpY)"></button>
+  <button id="down" ontouchstart="moveTarget(event, 0, jumpY)"></button>
+  <button id="left" ontouchstart="moveTarget(event, -jumpX, 0)"></button>
+  <button id="home" ontouchstart="moveTarget(event, 0, 0, true)"></button>
+  <button id="right" ontouchstart="moveTarget(event, jumpX, 0)"></button>
 </div>
 
 <script>
   controller.log('Start running script');
 
   var data = {{dataCellsByConceptId | raw}};
+
+  {% for fixedRow in fixedRows %}
+    {% for tile in fixedRow %}
+      {% if tile.item.script is not empty %}
+        runTileScript(data, {{tile.item.conceptIds | join(',') | js | raw}}, {{tile.item.script | js | raw}});
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
 
   {% for tileRow in tileRows %}
     {% for tile in tileRow %}
@@ -279,16 +308,17 @@
 
   controller.log('Start constructing grid-left and grid-body');
 
-  var win = $(window);
-  var grid = $('#grid');
+  var scrolling = $('#scrolling');
+  var tiles = $('#tiles');
+  var gridTable = $('#grid-table');
   var gridLeft = $('#grid-left');
   var gridBody = $('#grid-body');
 
-  var left = grid.clone();
-  var body = grid.clone();
+  var left = gridTable.clone();
+  var body = gridTable.clone();
   left.find('th').add(left.find('td')).not(':first-child').remove();
   body.find('th:first-child').add(body.find('td:first-child')).remove();
-  grid.remove();
+  gridTable.remove();
   gridLeft.append(left.attr('id', null));
   gridBody.append(body.attr('id', null));
 
@@ -296,17 +326,23 @@
   var frozenCorner = corner.clone().addClass('frozen').hide();
   gridLeft.append(frozenCorner);
 
+  // We use two copies of the column headings.  The "frozen headings" are for
+  // vertical scrolling and are fixed at the top of the window.  The "floating
+  // headings" scroll horizontally with #grid-body.
   var headings = $('#grid-body thead');
   var frozenHeadings = headings.clone().addClass('frozen').hide();
   gridBody.append(frozenHeadings);
-
   var floatingHeadings = headings.clone().addClass('floating').hide();
   gridBody.append(floatingHeadings);
+
+  // The frozen parts are fixed at the top of the vertical scrolling region.
+  frozenCorner.css({top: scrolling.offset().top + 'px'});
+  frozenHeadings.css({top: scrolling.offset().top + 'px'});
 
   var yOffset = 0;
 
   function updateY() {
-    yOffset = win.scrollTop() - headings.offset().top;
+    yOffset = scrolling.scrollTop() - tiles.height();
     frozenCorner.toggle(yOffset > 0);
     frozenHeadings.toggle(yOffset > 0);
     floatingHeadings.hide();
@@ -325,7 +361,7 @@
     }
   }
 
-  win.scroll(updateY);
+  scrolling.scroll(updateY);
   gridBody.scroll(updateX);
 
   $(window).unload(function() {
@@ -340,14 +376,14 @@
   var nowCenter = nowColumn.offset().left + nowColumn.width()/2;
   var bodyCenter = gridBody.offset().left + gridBody.width()/2;
   var jumpX = gridBody.width()/2;
-  var jumpY = (window.innerHeight - $('#scroller').offset().top)/2;
+  var jumpY = (window.innerHeight - $('#grid').offset().top)/2;
   var homeX = nowCenter - bodyCenter;
   var targetX = 0;
   var targetY = 0;
 
   function scrollJump(dx, dy, home) {
     var x = gridBody.scrollLeft();
-    var y = win.scrollTop();
+    var y = scrolling.scrollTop();
     if (home) {
       gridBody.scrollLeft(homeX);
       updateX();
@@ -357,7 +393,7 @@
       updateX();
     }
     if (dy != 0) {
-      win.scrollTop(y + dy);
+      scrolling.scrollTop(y + dy);
       updateY();
     }
   }
@@ -369,7 +405,7 @@
     event.stopPropagation();
     if (!seeking) {
       targetX = gridBody.scrollLeft();
-      targetY = win.scrollTop();
+      targetY = scrolling.scrollTop();
     }
     if (home) targetX = homeX;
     targetX += dx;
@@ -381,15 +417,15 @@
   function scrollStep() {
     if (!seeking) return;
     var x = gridBody.scrollLeft();
-    var y = win.scrollTop();
+    var y = scrolling.scrollTop();
     gridBody.scrollLeft(x * 0.6 + targetX * 0.4);
-    win.scrollTop(y * 0.6 + targetY * 0.4);
+    scrolling.scrollTop(y * 0.6 + targetY * 0.4);
     if (abs(gridBody.scrollLeft() - x) > 0.5) {
       updateX();
     } else {
       targetX = x;
     }
-    if (abs(win.scrollTop() - y) > 0.5) {
+    if (abs(scrolling.scrollTop() - y) > 0.5) {
       updateY();
     } else {
       targetY = y;

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -4,10 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <link rel="stylesheet" href="chart.css">
-<script>controller.log('Start loading scripts');</script>
+<script>c.log('Start loading scripts');</script>
 <script src="jquery-1.5.1.min.js"></script>
 <script src="chart.js"></script>
-<script>controller.log('Start HTML');</script>
+<script>c.log('Start HTML');</script>
 
 <!-- Use double-quotes for HTML attributes; single-quotes for JS/Pebble strings. -->
 <body>
@@ -22,7 +22,7 @@
           <th class="gap" scope="col" rowspan=2>&nbsp;</th>
         {% endif %}
         {% if column.start == column.dayStart %}
-          <th class="day {{column.date == today ? 'now' : ''}} {{column.date.dayOfWeek > 5 ? 'weekend' : ''}}" colspan={{numColumnsPerDay}} onclick="od('','{{column.dayStart.millis}}','{{column.dayStop.millis}}');">
+          <th class="day {{column.date == today ? 'now' : ''}} {{column.date.dayOfWeek > 5 ? 'weekend' : ''}}" colspan={{numColumnsPerDay}} onclick="c.showObsDetails({{column.dayStart.millis}}, {{column.dayStop.millis}});">
             {% if numColumnsPerDay == 1 %}
               {% if column.dayLabel is empty %}&nbsp;{% else %}{{column.dayLabel}}{% endif %}
             {% elseif column.dayLabel is not empty %}
@@ -38,7 +38,7 @@
     <tr>
       <th class="corner">&nbsp;</th>
       {% for column in columns %}
-        <th class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}}" scope="col" onclick="od('','{{column.start.millis}}','{{column.stop.millis}}');">
+        <th class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}}" scope="col" onclick="c.showObsDetails({{column.start.millis}}, {{column.stop.millis}});">
           {% if numColumnsPerDay == 1 %}
             {{column.shortDate}}
           {% else %}
@@ -70,7 +70,7 @@
       {% for row in group.rows %}
         {% set id = row.item.conceptIds | first %}
         <tr class="obs {{row.item.label | to_css_identifier}}">
-          <th scope="row" onclick="od('{{row.item.conceptUuids[0]}}','','');">
+          <th scope="row" onclick="c.showObsDetails('{{row.item.conceptUuidsList}}');">
             {{row.item.label}}
           </th>
           {% set prevStop = columns[0].start %}
@@ -91,7 +91,7 @@
             <td class="{{column.stop == column.dayStop ? 'day-last' : ''}} {{column.start == nowColumn.start ? 'now' : ''}} {{class}}"
               style="{{style}}"
               onclick="{% if points is not empty and row.item.type.string != 'text_icon' %}
-                         od('{{row.item.conceptUuids[0]}}','{{column.start.millis}}','{{column.stop.millis}}');
+                         c.showObsDetails('{{row.item.conceptUuidsList}}', {{column.start.millis}}, {{column.stop.millis}});
                        {% endif %}">
               {% if points is empty %}
                 &nbsp;
@@ -134,7 +134,7 @@
       {% set ins = order.instructions %}
       {% set id = ins.medication | to_css_identifier %}
       <tr class="order route-{{ins.route}}">
-        <th scope="row" id="{{id}}_row" onclick="controller.onOrderHeadingPressed('{{order.uuid}}')">
+        <th scope="row" id="{{id}}_row" onclick="c.onOrderHeadingPressed('{{order.uuid}}')">
           {% if ins.notes is not empty %}
             <div class="notes" id="{{id}}_notes">{{ins.notes | slice(0, min(30, ins.notes|length))}}</div>
           {% endif %}
@@ -165,7 +165,7 @@
               {% set started = true %}
             {% endif %}
             <td class="day" colspan={{numColumnsPerDay}}
-                onclick="controller.onOrderCellPressed('{{order.uuid}}', {{column.start.millis}})">
+                onclick="c.onOrderCellPressed('{{order.uuid}}', {{column.start.millis}})">
               &nbsp; {# ensure uniform height #}
               {% set totalScheduled = 0 %}
               {% set totalGiven = 0 %}
@@ -222,7 +222,7 @@
     {% endfor %}
 
     <tr>
-      <th scope="row" class="command" id="new_treatment" onclick="controller.onNewOrderPressed()">
+      <th scope="row" class="command" id="new_treatment" onclick="c.onNewOrderPressed()">
         {{get_string("add_new_treatment")}}
       </th>
     </tr>
@@ -237,7 +237,7 @@
         {% set values = tile.points | values %}
         {% set class = values | format_values(tile.item.cssClass) %}
         {% set style = values | format_values(tile.item.cssStyle) %}
-        <div class="tile {{class}}" onclick="od('{{tile.item.conceptUuids[0]}}','','');" style="{{style}}">
+        <div class="tile {{class}}" onclick="c.showObsDetails('{{tile.item.conceptUuidsList}}');" style="{{style}}">
           <div class="heading">{{tile.item.label}}</div>
           <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
           <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>
@@ -256,7 +256,7 @@
           {% set values = tile.points | values %}
           {% set class = values | format_values(tile.item.cssClass) %}
           {% set style = values | format_values(tile.item.cssStyle) %}
-          <div class="tile {{class}}" onclick="od('{{tile.item.conceptUuids[0]}}','','');" style="{{style}}">
+          <div class="tile {{class}}" onclick="c.showObsDetails('{{tile.item.conceptUuidsList}}');" style="{{style}}">
             <div class="heading">{{tile.item.label}}</div>
             <div class="value">{{values | format_values(tile.item.format) | line_break_html | raw}}</div>
             <div class="caption">{{values | format_values(tile.item.captionFormat) | line_break_html | raw}}</div>
@@ -280,7 +280,7 @@
 </div>
 
 <script>
-  controller.log('Start running script');
+  c.log('Start running script');
 
   var data = {{dataCellsByConceptId | raw}};
 
@@ -306,7 +306,7 @@
     {% endif %}
   {% endfor %}
 
-  controller.log('Start constructing grid-left and grid-body');
+  c.log('Start constructing grid-left and grid-body');
 
   var scrolling = $('#scrolling');
   var tiles = $('#tiles');
@@ -365,12 +365,8 @@
   gridBody.scroll(updateX);
 
   $(window).unload(function() {
-    controller.onPageUnload($('#grid-body').scrollLeft(), $(window).scrollTop());
+    c.onPageUnload($('#grid-body').scrollLeft(), $(window).scrollTop());
   });
-
-  function od(conceptUuid, startMillis, stopMillis) {
-    controller.onObsDialog(conceptUuid, startMillis, stopMillis);
-  }
 
   var nowColumn = $('.now[scope="col"]');
   var nowCenter = nowColumn.offset().left + nowColumn.width()/2;
@@ -436,7 +432,7 @@
 
   gridBody.scrollLeft(homeX);
 
-  controller.finish();
+  c.finish();
 </script>
 </body>
 </html>

--- a/app/src/main/java/org/projectbuendia/client/AppSettings.java
+++ b/app/src/main/java/org/projectbuendia/client/AppSettings.java
@@ -24,7 +24,13 @@ import java.util.Locale;
 
 /** Type-safe access to application settings. */
 public class AppSettings {
+    // The locale in which this app guarantees a definition for every string.
+    public static final Locale APP_DEFAULT_LOCALE = new Locale("en");
+
+    // The system default locale at app startup time.
     public static final Locale ORIGINAL_DEFAULT_LOCALE = Locale.getDefault();
+
+    // Locales to offer as options to the user.
     public static final Locale[] AVAILABLE_LOCALES = new Locale[] {
         new Locale("en"), new Locale("fr")
     };
@@ -152,11 +158,6 @@ public class AppSettings {
     public int getLocaleIndex() {
         String languageTag = Utils.toNonnull(prefs.getString("locale", ""));
         return Arrays.asList(getLocaleOptionValues()).indexOf(languageTag);
-    }
-
-    /** Gets the app's hardcoded default locale. */
-    public static Locale getDefaultLocale() {
-        return new Locale("en");
     }
 
     /** Gets the values for a menu of available locales. */

--- a/app/src/main/java/org/projectbuendia/client/models/Chart.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Chart.java
@@ -18,12 +18,15 @@ import java.util.List;
 public class Chart {
     // TODO(ping): Support multiple charts stored in multiple forms.  Right now,
     // there is no UUID field because there is only ever a single chart form.
+
+    public final String name;
+    public final List<ChartSection> fixedGroups;
     public final List<ChartSection> tileGroups;
     public final List<ChartSection> rowGroups;
-    public final String name;
 
     public Chart(String name) {
         this.name = name;
+        this.fixedGroups = new ArrayList<>();
         this.tileGroups = new ArrayList<>();
         this.rowGroups = new ArrayList<>();
     }

--- a/app/src/main/java/org/projectbuendia/client/models/ChartItem.java
+++ b/app/src/main/java/org/projectbuendia/client/models/ChartItem.java
@@ -11,12 +11,12 @@
 
 package org.projectbuendia.client.models;
 
+import com.google.common.base.Joiner;
+
 import org.projectbuendia.client.ui.chart.ObsFormat;
 import org.projectbuendia.client.utils.Utils;
 
 import java.text.Format;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -27,7 +27,7 @@ public class ChartItem {
     public final @Nonnull String type;
     public final boolean required;
     public final @Nonnull String[] conceptUuids;
-    public final @Nonnull List<Object> conceptIds;
+    public final @Nonnull String conceptUuidsList;
     public final @Nullable Format format;
     public final @Nullable Format captionFormat;
     public final @Nullable Format cssClass;
@@ -56,11 +56,7 @@ public class ChartItem {
         this.cssClass = cssClass;
         this.cssStyle = cssStyle;
         this.script = Utils.toNonnull(script);
-
-        this.conceptIds = new ArrayList<>();
-        for (String uuid : this.conceptUuids) {
-            this.conceptIds.add(Utils.compressUuid(uuid));
-        }
+        conceptUuidsList = Joiner.on(",").join(this.conceptUuids);
     }
 
     public ChartItem withDefaults(@Nullable ChartItem defaults) {

--- a/app/src/main/java/org/projectbuendia/client/models/ChartSectionType.java
+++ b/app/src/main/java/org/projectbuendia/client/models/ChartSectionType.java
@@ -14,6 +14,7 @@ package org.projectbuendia.client.models;
 /** Chart section type identifiers, used in the ChartItems.SECTION_TYPE column. */
 public enum ChartSectionType {
     CHART_DIVIDER,
+    FIXED_ROW,
     TILE_ROW,
     GRID_SECTION
 }

--- a/app/src/main/java/org/projectbuendia/client/models/Patient.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Patient.java
@@ -50,7 +50,7 @@ public final @Immutable class Patient extends Model {
         cv.put(Patients.GIVEN_NAME, givenName);
         cv.put(Patients.FAMILY_NAME, familyName);
         cv.put(Patients.SEX, Sex.nullableNameOf(sex));
-        cv.put(Patients.BIRTHDATE, Utils.formatDate(birthdate));
+        cv.put(Patients.BIRTHDATE, Utils.format(birthdate));
         // PREGNANCY is a denormalized column and is never written directly.
         // LOCATION_UUID is a denormalized column and is never written directly.
         // BED_NUMBER is a denormalized column and is never written directly.

--- a/app/src/main/java/org/projectbuendia/client/models/PatientDelta.java
+++ b/app/src/main/java/org/projectbuendia/client/models/PatientDelta.java
@@ -84,7 +84,7 @@ public class PatientDelta {
             if (birthdate.isPresent()) {
                 json.put(
                     Server.PATIENT_BIRTHDATE_KEY,
-                    Utils.formatDate(birthdate.get()));
+                    Utils.format(birthdate.get()));
             }
             return true;
         } catch (JSONException e) {

--- a/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
@@ -247,6 +247,10 @@ public class ChartDataHelper {
                         if (chart.tileGroups.size() + chart.rowGroups.size() > 0) {
                             charts.add(chart);
                         }
+                    } else if (eq(sectionType, "FIXED_ROW") && chart != null) {
+                        ChartSection fixedGroup = new ChartSection(label);
+                        chart.fixedGroups.add(fixedGroup);
+                        tileGroupsById.put(rowid, fixedGroup);
                     } else if (eq(sectionType, "TILE_ROW") && chart != null) {
                         ChartSection tileGroup = new ChartSection(label);
                         chart.tileGroups.add(tileGroup);

--- a/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ChartDataHelper.java
@@ -21,6 +21,7 @@ import org.projectbuendia.client.json.ConceptType;
 import org.projectbuendia.client.models.Chart;
 import org.projectbuendia.client.models.ChartItem;
 import org.projectbuendia.client.models.ChartSection;
+import org.projectbuendia.client.models.ConceptUuids;
 import org.projectbuendia.client.models.Form;
 import org.projectbuendia.client.models.Obs;
 import org.projectbuendia.client.models.ObsRow;
@@ -49,6 +50,10 @@ import static org.projectbuendia.client.utils.Utils.eq;
 /** A helper class for retrieving and localizing data to show in patient charts. */
 public class ChartDataHelper {
     private static final Logger LOG = Logger.create();
+    private static final String[] UUIDS_TO_OMIT = {
+        ConceptUuids.ORDER_EXECUTED_UUID,
+        ConceptUuids.PLACEMENT_UUID
+    };
 
     private final ContentResolver mContentResolver;
 
@@ -92,7 +97,6 @@ public class ChartDataHelper {
         Obs obs = loadObs(c, locale, concepts);
         String uuid = Utils.getString(c, Observations.UUID);
         String conceptName = concepts.getName(obs.conceptUuid, locale);
-        if (conceptName == null) return null;
         return new ObsRow(uuid, obs.time.getMillis(),
             conceptName, obs.conceptUuid, obs.value, obs.valueName);
     }
@@ -119,73 +123,50 @@ public class ChartDataHelper {
         return results;
     }
 
-    public ArrayList<ObsRow> getPatientObservationsByConcept(String patientUuid, String... conceptUuids) {
+    /** Gets observations filtered by optional concept and optional time bounds. */
+    public ArrayList<ObsRow> getPatientObservations(String patientUuid, String[] conceptUuids, Long startMillis, Long stopMillis) {
         ConceptService concepts = App.getConceptService();
         Locale locale = App.getSettings().getLocale();
-        String[] placeholders = new String[conceptUuids.length];
+        List<String> args = new ArrayList<>();
+
+        String query = Observations.VOIDED + " IS NOT 1";
+
+        query += " AND " + Observations.PATIENT_UUID + " = ?";
+        args.add(patientUuid);
+
+        if (Utils.hasItems(conceptUuids)) {
+            query += " AND " + Observations.CONCEPT_UUID + " IN " + makeSqlPlaceholderSet(conceptUuids);
+            args.addAll(Arrays.asList(conceptUuids));
+        } else {
+            query += " AND " + Observations.CONCEPT_UUID + " NOT IN " + makeSqlPlaceholderSet(UUIDS_TO_OMIT);
+            args.addAll(Arrays.asList(UUIDS_TO_OMIT));
+        }
+        if (startMillis != null) {
+            query += " AND " + Observations.ENCOUNTER_MILLIS + " >= ?";
+            args.add("" + startMillis);
+        }
+        if (stopMillis != null) {
+            query += " AND " + Observations.ENCOUNTER_MILLIS + " < ?";
+            args.add("" + stopMillis);
+        }
+        String[] argArray = args.toArray(new String[0]);
+
+        String order = Observations.ENCOUNTER_MILLIS + " ASC";
+
+        ArrayList<ObsRow> results = new ArrayList<>();
+        try (Cursor c = mContentResolver.query(Observations.URI, null, query, argArray, order)) {
+            while (c.moveToNext()) {
+                ObsRow row = loadObsRow(c, locale, concepts);
+                if (row != null) results.add(row);
+            }
+        }
+        return results;
+    }
+
+    private String makeSqlPlaceholderSet(String[] items) {
+        String[] placeholders = new String[items.length];
         Arrays.fill(placeholders, "?");
-
-        ArrayList<ObsRow> results = new ArrayList<>();
-        try (Cursor c = mContentResolver.query(
-            Observations.URI,
-            null,
-            Observations.CONCEPT_UUID + " in (" + Joiner.on(", ").join(placeholders) + ")"
-                + " AND " + Observations.PATIENT_UUID + " = ?"
-                + " AND " + Observations.VOIDED + " IS NOT 1",
-            conceptUuids,
-            Observations.ENCOUNTER_MILLIS + " ASC"
-        )) {
-            while (c.moveToNext()) {
-                ObsRow row = loadObsRow(c, locale, concepts);
-                if (row != null) results.add(row);
-            }
-        }
-        return results;
-    }
-
-    public ArrayList<ObsRow> getPatientObservationsByMillis(String patientUuid, String startMillis,String stopMillis) {
-        ConceptService concepts = App.getConceptService();
-        Locale locale = App.getSettings().getLocale();
-        ArrayList<ObsRow> results = new ArrayList<>();
-
-        try (Cursor c = mContentResolver.query(
-            Observations.URI, null,
-            Observations.VOIDED + " IS NOT 1 AND "
-                + Observations.PATIENT_UUID + " = ? AND "
-                + Observations.ENCOUNTER_MILLIS + " >= ? AND "
-                + Observations.ENCOUNTER_MILLIS + " <= ?",
-            new String[] {patientUuid, startMillis, stopMillis},
-            Observations.ENCOUNTER_MILLIS + " ASC"
-        )) {
-            while (c.moveToNext()) {
-                ObsRow row = loadObsRow(c, locale, concepts);
-                if (row != null) results.add(row);
-            }
-        }
-        return results;
-    }
-
-    public ArrayList<ObsRow> getPatientObservationsByConceptMillis(String patientUuid, String conceptUuid, String startMillis, String stopMillis) {
-        ConceptService concepts = App.getConceptService();
-        Locale locale = App.getSettings().getLocale();
-        ArrayList<ObsRow> results = new ArrayList<>();
-
-        try (Cursor c = mContentResolver.query(
-            Observations.URI, null,
-            Observations.VOIDED + " IS NOT 1 AND "
-                + Observations.PATIENT_UUID + " = ? AND "
-                + Observations.CONCEPT_UUID + " = ? AND "
-                + Observations.ENCOUNTER_MILLIS + " >= ? AND "
-                + Observations.ENCOUNTER_MILLIS + " <= ?",
-            new String[] {patientUuid, conceptUuid, startMillis, stopMillis},
-            Observations.ENCOUNTER_MILLIS + " ASC"
-        )) {
-            while (c.moveToNext()) {
-                ObsRow row = loadObsRow(c, locale, concepts);
-                if (row != null) results.add(row);
-            }
-        }
-        return results;
+        return "(" + Joiner.on(", ").join(placeholders) + ")";
     }
 
     /** Gets the latest observation of each concept for a given patient from the app db. */

--- a/app/src/main/java/org/projectbuendia/client/sync/ConceptService.java
+++ b/app/src/main/java/org/projectbuendia/client/sync/ConceptService.java
@@ -3,6 +3,7 @@ package org.projectbuendia.client.sync;
 import android.content.ContentResolver;
 import android.database.Cursor;
 
+import org.projectbuendia.client.AppSettings;
 import org.projectbuendia.client.json.ConceptType;
 import org.projectbuendia.client.models.ConceptUuids;
 import org.projectbuendia.client.providers.Contracts.ConceptNames;
@@ -35,11 +36,16 @@ public class ConceptService {
     }
 
     public String getName(String uuid, Locale locale) {
+        // TODO(ping): Internationalize concept names in a way that doesn't require
+        // reloading all concepts just to get the default locale for one concept.
+        locale = AppSettings.APP_DEFAULT_LOCALE;
         if (names == null || !eq(locale, loadedLocale)) {
             names = loadNames(resolver, locale);
             loadedLocale = locale;
         }
-        return names.get(uuid);
+        String name = names.get(uuid);
+        if (name == null) name = Utils.compressUuid(uuid) + "?";
+        return name;
     }
 
     public void invalidate() {

--- a/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/BaseActivity.java
@@ -146,6 +146,7 @@ public abstract class BaseActivity extends FragmentActivity {
      * @see "SnackBar Documentation." {@link SnackBar#message(int)}
      */
     public void snackBar(@StringRes int message) {
+        initializeSnackBar();
         snackBar.message(message);
     }
 
@@ -154,6 +155,7 @@ public abstract class BaseActivity extends FragmentActivity {
      * @see "SnackBar Documentation." {@link SnackBar#message(int, int)}
      */
     public void snackBar(@StringRes int message, int priority) {
+        initializeSnackBar();
         snackBar.message(message, priority);
     }
 
@@ -161,8 +163,8 @@ public abstract class BaseActivity extends FragmentActivity {
      * Adds a message to the SnackBar. Priority defaults to 999.
      * @see "SnackBar Documentation." {@link SnackBar#message(int, int, View.OnClickListener, int)}
      */
-    public void snackBar(@StringRes int message, @StringRes int actionMessage, View
-        .OnClickListener listener) {
+    public void snackBar(@StringRes int message, @StringRes int actionMessage, View.OnClickListener listener) {
+        initializeSnackBar();
         snackBar.message(message, actionMessage, listener, 999);
     }
 
@@ -170,8 +172,9 @@ public abstract class BaseActivity extends FragmentActivity {
      * Adds a message to the SnackBar with informed priority.
      * @see "SnackBar Documentation." {@link SnackBar#message(int, int, View.OnClickListener, int)}
      */
-    public void snackBar(@StringRes int message, @StringRes int actionMessage, View
-        .OnClickListener listener, int priority) {
+    public void snackBar(@StringRes int message, @StringRes int actionMessage,
+                         View.OnClickListener listener, int priority) {
+        initializeSnackBar();
         snackBar.message(message, actionMessage, listener, priority);
     }
 
@@ -180,8 +183,9 @@ public abstract class BaseActivity extends FragmentActivity {
      * @see "SnackBar Documentation."
      * {@link SnackBar#message(int, int, View.OnClickListener, int, boolean, int)}
      */
-    public void snackBar(@StringRes int message, @StringRes int actionMessage, View
-        .OnClickListener actionOnClick, int priority, boolean isDismissible) {
+    public void snackBar(@StringRes int message, @StringRes int actionMessage,
+                         View.OnClickListener actionOnClick, int priority, boolean isDismissible) {
+        initializeSnackBar();
         snackBar.message(message, actionMessage, actionOnClick, priority, isDismissible, 0);
     }
 
@@ -190,8 +194,10 @@ public abstract class BaseActivity extends FragmentActivity {
      * @see "SnackBar Documentation."
      * {@link SnackBar#message(int, int, View.OnClickListener, int, boolean, int)}
      */
-    public void snackBar(@StringRes int message, @StringRes int actionMessage, View
-        .OnClickListener actionOnClick, int priority, boolean isDismissible, int secondsToTimeOut) {
+    public void snackBar(@StringRes int message, @StringRes int actionMessage,
+                         View.OnClickListener actionOnClick, int priority,
+                         boolean isDismissible, int secondsToTimeOut) {
+        initializeSnackBar();
         snackBar.message(message, actionMessage, actionOnClick, priority, isDismissible,
             secondsToTimeOut);
     }
@@ -201,15 +207,15 @@ public abstract class BaseActivity extends FragmentActivity {
      * @param id The @StringRes for the message.
      */
     public void snackBarDismiss(@StringRes int id) {
-        snackBar.dismiss(id);
+        if (snackBar != null) snackBar.dismiss(id);
     }
 
     /**
      * Programmatically dismiss multiple messages at once
      * @param id a @StringRes message Array
      */
-    public void snackBarDismiss(@StringRes int[] id) {
-        snackBar.dismiss(id);
+    public void snackBarDismiss(@StringRes int[] ids) {
+        if (snackBar != null) snackBar.dismiss(ids);
     }
 
     @Override public void setContentView(View view) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -186,11 +186,14 @@ public class ChartRenderer {
 
         GridHtmlGenerator(Chart chart, Map<String, Obs> latestObservations,
                           List<Obs> observations, List<Order> orders) {
+            LOG.start("GridHtmlGenerator");
+
             mOrders = orders;
             mNow = DateTime.now();
+            Obs obs = latestObservations.get(ConceptUuids.ADMISSION_DATE_UUID);
+            mAdmissionDate = obs != null ? Utils.toLocalDate(obs.value) : null;
             mNowColumn = getColumnContainingTime(mNow); // ensure there's a column for today
 
-            LOG.start("GridHtmlGenerator");
             for (ChartSection section : chart.fixedGroups) {
                 mFixedRows.add(createTiles(section, latestObservations));
             }
@@ -208,9 +211,6 @@ public class ChartRenderer {
             addObservations(observations, ordersByUuid);
             addOrders(orders);
             insertEmptyColumns();
-
-            Obs obs = latestObservations.get(ConceptUuids.ADMISSION_DATE_UUID);
-            mAdmissionDate = obs != null ? Utils.toLocalDate(obs.value) : null;
 
             LOG.elapsed("GridHtmlGenerator", "Data prepared");
         }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -92,9 +92,9 @@ public class ChartRenderer {
         @JavascriptInterface void onNewOrderPressed();
         @JavascriptInterface void onOrderHeadingPressed(String orderUuid);
         @JavascriptInterface void onOrderCellPressed(String orderUuid, long startMillis);
-        @JavascriptInterface void showObsDetails(String conceptUuids);
-        @JavascriptInterface void showObsDetails(long startMillis, long stopMillis);
-        @JavascriptInterface void showObsDetails(String conceptUuids, long startMillis, long stopMillis);
+        @JavascriptInterface void showObsDialog(String conceptUuids);
+        @JavascriptInterface void showObsDialog(long startMillis, long stopMillis);
+        @JavascriptInterface void showObsDialog(String conceptUuids, long startMillis, long stopMillis);
         @JavascriptInterface void onPageUnload(int scrollX, int scrollY);
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -111,7 +111,6 @@ public class ChartRenderer {
     // TODO/cleanup: Have this take the types that getObservations and getLatestObservations return.
     public void render(Chart chart, Map<String, Obs> latestObservations,
                        List<Obs> observations, List<Order> orders,
-                       LocalDate admissionDate, LocalDate firstSymptomsDate,
                        JsInterface controllerInterface) {
         if (chart == null) {
             mView.loadUrl("file:///android_asset/no_chart.html");
@@ -138,8 +137,7 @@ public class ChartRenderer {
         mView.addJavascriptInterface(controllerInterface, "c");
         mView.setWebChromeClient(new WebChromeClient());
         String html = new GridHtmlGenerator(
-            chart, latestObservations, observations, orders,
-            admissionDate, firstSymptomsDate).getHtml();
+            chart, latestObservations, observations, orders).getHtml();
 
         LOG.elapsed("render", "HTML generated");
 
@@ -173,7 +171,6 @@ public class ChartRenderer {
         DateTime mNow;
         Column mNowColumn;
         LocalDate mAdmissionDate;
-        LocalDate mFirstSymptomsDate;
 
         Map<String, ExecutionHistory> mExecutionHistories = new HashMap<String, ExecutionHistory>() {
             @Override public @NonNull ExecutionHistory get(Object key) {
@@ -188,10 +185,7 @@ public class ChartRenderer {
         Set<String> mConceptsToDump = new HashSet<>();  // concepts whose data to dump in JSON
 
         GridHtmlGenerator(Chart chart, Map<String, Obs> latestObservations,
-                          List<Obs> observations, List<Order> orders,
-                          LocalDate admissionDate, LocalDate firstSymptomsDate) {
-            mAdmissionDate = admissionDate;
-            mFirstSymptomsDate = firstSymptomsDate;
+                          List<Obs> observations, List<Order> orders) {
             mOrders = orders;
             mNow = DateTime.now();
             mNowColumn = getColumnContainingTime(mNow); // ensure there's a column for today
@@ -214,6 +208,9 @@ public class ChartRenderer {
             addObservations(observations, ordersByUuid);
             addOrders(orders);
             insertEmptyColumns();
+
+            Obs obs = latestObservations.get(ConceptUuids.ADMISSION_DATE_UUID);
+            mAdmissionDate = obs != null ? Utils.toLocalDate(obs.value) : null;
 
             LOG.elapsed("GridHtmlGenerator", "Data prepared");
         }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ChartRenderer.java
@@ -76,15 +76,23 @@ public class ChartRenderer {
     private int mLastRenderedZoomIndex;  // last zoom level index rendered
     private String mLastChartName = "";
 
+    // WARNING(kpy): The WebView only knows how to pass boolean, numeric, or
+    // String arguments to these methods from JavaScript, and does not always
+    // perform the obvious conversions.  Every parameter must be declared here
+    // as boolean, int, long, float, double, or String.  Methods must be called
+    // with exactly the declared number of arguments, or the call will cause
+    // a JavaScript "Method not found" exception.  Boolean parameters convert
+    // all non-boolean values to false.  Numeric parameters convert incoming
+    // numbers to the declared type and all non-numeric values to 0.  String
+    // parameters pass through nulls, convert all booleans and numbers to
+    // strings, and convert anything else to the string "undefined".
     public interface JsInterface {
         @JavascriptInterface void onNewOrderPressed();
-
         @JavascriptInterface void onOrderHeadingPressed(String orderUuid);
-
         @JavascriptInterface void onOrderCellPressed(String orderUuid, long startMillis);
-
-        @JavascriptInterface void onObsDialog(String conceptUuid, String startMillis, String stopMillis);
-
+        @JavascriptInterface void showObsDetails(String conceptUuids);
+        @JavascriptInterface void showObsDetails(long startMillis, long stopMillis);
+        @JavascriptInterface void showObsDetails(String conceptUuids, long startMillis, long stopMillis);
         @JavascriptInterface void onPageUnload(int scrollX, int scrollY);
     }
 
@@ -125,7 +133,7 @@ public class ChartRenderer {
         mView.getSettings().setDefaultFontSize((int) defaultFontSize);
 
         mView.getSettings().setJavaScriptEnabled(true);
-        mView.addJavascriptInterface(controllerInterface, "controller");
+        mView.addJavascriptInterface(controllerInterface, "c");
         mView.setWebChromeClient(new WebChromeClient());
         String html = new GridHtmlGenerator(
             chart, latestObservations, observations, orders,

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
@@ -143,7 +143,7 @@ public class ObsFormat extends Format {
                                          @Nonnull FieldPosition pos) {
         if (obj instanceof ObsValue[]) {
             mCurrentArgs = (ObsValue[]) obj;
-            mCurrentArgs[0] = mCurrentArgs[1];
+            if (mCurrentArgs.length > 1) mCurrentArgs[0] = mCurrentArgs[1];
             return mFormat.format(obj, buf, pos);
         } else {
             buf.append(TYPE_ERROR);
@@ -193,7 +193,7 @@ public class ObsFormat extends Format {
         @Override public StringBuffer format(Object obj, @Nonnull StringBuffer buf,
                                              @Nonnull FieldPosition pos) {
             // UNOBSERVED is compared by identity (not using equals()) because it is a sentinel.
-            mCurrentArgs[0] = obj;
+            if (mCurrentArgs.length > 0) mCurrentArgs[0] = obj;
             if (obj == UNOBSERVED) {
                 buf.append(formatObsValue(null));
             } else if (obj instanceof ObsValue) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/ObsFormat.java
@@ -1,11 +1,12 @@
 package org.projectbuendia.client.ui.chart;
 
-import com.google.common.base.Objects;
-
 import org.apache.commons.text.ExtendedMessageFormat;
 import org.apache.commons.text.FormatFactory;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+import org.projectbuendia.client.App;
+import org.projectbuendia.client.R;
+import org.projectbuendia.client.models.Location;
 import org.projectbuendia.client.models.ObsPoint;
 import org.projectbuendia.client.models.ObsValue;
 import org.projectbuendia.client.utils.Utils;
@@ -54,11 +55,13 @@ public class ObsFormat extends Format {
         FORMAT_CLASSES.put("yes_no", ObsYesNoFormat.class);
         FORMAT_CLASSES.put("abbr", ObsAbbrFormat.class);
         FORMAT_CLASSES.put("name", ObsNameFormat.class);
-        FORMAT_CLASSES.put("number", ObsDecimalFormat.class);
+        FORMAT_CLASSES.put("number", ObsNumberFormat.class);
         FORMAT_CLASSES.put("text", ObsTextFormat.class);
         FORMAT_CLASSES.put("date", ObsDateFormat.class);
         FORMAT_CLASSES.put("time", ObsTimeFormat.class);
         FORMAT_CLASSES.put("select", ObsSelectFormat.class);
+        FORMAT_CLASSES.put("day_number", ObsDayNumberFormat.class);
+        FORMAT_CLASSES.put("location", ObsLocationFormat.class);
     }
 
     public static final String ELLIPSIS = "\u2026";  // used when truncating excessively long text
@@ -73,9 +76,10 @@ public class ObsFormat extends Format {
      * pattern, ObsNumberFormat will get instantiated and invoked with the first argument.
      * In some cases, most notably ObsSelectFormat, the sub-format invokes other formats.
      * We'd like those sub-formats to have access to all the arguments, not just the single
-     * argument that they're being asked to format.  So, we keep a reference to the root
-     * ObsFormat from which all others descended, which holds onto the original array of all
-     * the arguments.  The sub-format classes are all inner classes, so they can see mRootObsFormat.
+     * argument passed to ObsSelectFormat.  So, we keep a reference to the root ObsFormat
+     * from which all others descended, which holds the original array of all the arguments.
+     * The sub-format classes are all inner classes, so they can see mRootObsFormat.
+     * For convenience, we also make the parent format's first argument available as {0}.
      */
     private ObsFormat mRootObsFormat;  // root ObsFormat from which this ObsFormat descended
     private Object[] mCurrentArgs;  // args currently being formatted by this ObsFormat
@@ -85,12 +89,15 @@ public class ObsFormat extends Format {
             pattern = "";
         }
         mPattern = pattern;
-        // Allow plain numeric formats like "#0.00" as a shorthand for "{1,number,#0.00}".
+        // Allow plain numeric formats like "#0.00" as a shorthand for "{0,number,#0.00}".
         if (!pattern.contains("{") && (pattern.contains("#") || pattern.contains("0"))) {
             try {
                 new DecimalFormat(pattern);  // check if it's a valid numeric format
-                pattern = "{1,number," + pattern + "}";
+                pattern = "{0,number," + pattern + "}";
             } catch (IllegalArgumentException e) { }
+        } else if (!pattern.contains("{") && pattern.contains("$")) {
+            // Allow "$" as a shorthand for "{0,text}".
+            pattern = pattern.replaceFirst("$", "{0,text}");
         }
         mRootObsFormat = Utils.orDefault(rootObsFormat, this);
         try {
@@ -136,6 +143,7 @@ public class ObsFormat extends Format {
                                          @Nonnull FieldPosition pos) {
         if (obj instanceof ObsValue[]) {
             mCurrentArgs = (ObsValue[]) obj;
+            mCurrentArgs[0] = mCurrentArgs[1];
             return mFormat.format(obj, buf, pos);
         } else {
             buf.append(TYPE_ERROR);
@@ -185,6 +193,7 @@ public class ObsFormat extends Format {
         @Override public StringBuffer format(Object obj, @Nonnull StringBuffer buf,
                                              @Nonnull FieldPosition pos) {
             // UNOBSERVED is compared by identity (not using equals()) because it is a sentinel.
+            mCurrentArgs[0] = obj;
             if (obj == UNOBSERVED) {
                 buf.append(formatObsValue(null));
             } else if (obj instanceof ObsValue) {
@@ -271,17 +280,21 @@ public class ObsFormat extends Format {
     }
 
     /** "number" format for numeric values.  Typical use: {1,number,##.# kg} */
-    class ObsDecimalFormat extends ObsOutputFormat {
+    class ObsNumberFormat extends ObsOutputFormat {
         DecimalFormat mFormat;
 
-        public ObsDecimalFormat(String pattern) {
-            mFormat = new DecimalFormat(pattern);
+        public ObsNumberFormat(String pattern) {
+            mFormat = new DecimalFormat(Utils.toNonnull(pattern));
+        }
+
+        protected String formatNumber(Double number) {
+            return mFormat.format(number).replace('-', '\u2212');  // use a real minus sign
         }
 
         @Override public String formatObsValue(@Nullable ObsValue value) {
             if (value == null) return EN_DASH;
             if (value.number == null) return TYPE_ERROR;
-            return mFormat.format(value.number).replace('-', '\u2212');  // use a real minus sign
+            return formatNumber(value.number);
         }
     }
 
@@ -300,7 +313,10 @@ public class ObsFormat extends Format {
         @Override public String formatObsValue(@Nullable ObsValue value) {
             if (value == null) return EN_DASH;
             if (value.text == null) return TYPE_ERROR;
-            String text = value.text;
+            return formatText(value.text);
+        }
+
+        protected String formatText(String text) {
             return maxLength < text.length() ? text.substring(0, maxLength) + ELLIPSIS : text;
         }
     }
@@ -335,6 +351,33 @@ public class ObsFormat extends Format {
         }
     }
 
+    /** "day_number" format that describes today, counting the observed date as day 1.  Typical use: {1,day_number,Day #} */
+    class ObsDayNumberFormat extends ObsNumberFormat {
+        public ObsDayNumberFormat(String pattern) {
+            super(pattern);
+        }
+
+        @Override public String formatObsValue(@Nullable ObsValue value) {
+            if (value == null) return EN_DASH;
+            if (value.date == null) return TYPE_ERROR;
+            return formatNumber((double) Utils.dayNumberSince(value.date, LocalDate.now()));
+        }
+    }
+
+    /** "day_number" format that describes today, counting the observed date as day 1.  Typical use: {1,day_number,Day #} */
+    class ObsLocationFormat extends ObsTextFormat {
+        public ObsLocationFormat(String pattern) {
+            super(pattern);
+        }
+
+        @Override public String formatObsValue(@Nullable ObsValue value) {
+            if (value == null) return EN_DASH;
+            if (value.text == null) return TYPE_ERROR;
+            Location location = App.getModel().getForest().get(value.text);
+            return formatText(location != null ? location.name : App.str(R.string.unknown));
+        }
+    }
+
     private static final Pattern CONDITION_PATTERN = Pattern.compile("([<>=]*)(.*)");
 
     /**
@@ -344,7 +387,7 @@ public class ObsFormat extends Format {
      */
     class ObsSelectFormat extends ObsOutputFormat {
         class Option {
-            public @Nonnull String operator = "";
+            public @Nullable String operator = null;
             public @Nonnull String operand = "";
             public @Nonnull ObsFormat format;
         }
@@ -442,8 +485,13 @@ public class ObsFormat extends Format {
             } else if (value.text != null) {
                 operand = ObsValue.newText(operandStr);
             } else if (value.date != null) {
+                Integer days = Utils.toIntOrNull(operandStr);
                 try {
-                    operand = ObsValue.newDate(LocalDate.parse(operandStr));
+                    if (days != null) {
+                        operand = ObsValue.newDate(LocalDate.now().plusDays(days));
+                    } else {
+                        operand = ObsValue.newDate(LocalDate.parse(operandStr));
+                    }
                 } catch (IllegalArgumentException e) {
                     operand = ObsValue.MIN_DATE;
                 }
@@ -459,7 +507,7 @@ public class ObsFormat extends Format {
                 case "":
                 case "=":
                 case "==":
-                    return Objects.equal(value.uuid, operand.uuid);
+                    return value.compareTo(operand) == 0;
                 case "<":
                     return value.compareTo(operand) < 0;
                 case "<=":
@@ -474,7 +522,7 @@ public class ObsFormat extends Format {
 
         @Override public String formatObsValue(@Nullable ObsValue value) {
             for (Option option : mOptions) {
-                if (matches(value, option.operator, option.operand)) {
+                if (option.operator == null || matches(value, option.operator, option.operand)) {
                     return option.format.format(getRootArgs());
                 }
             }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -271,12 +271,12 @@ public final class PatientChartActivity extends LoggedInActivity {
     class DateObsDialog extends DatePickerDialog {
         private String mTitle;
 
-        public DateObsDialog(String title, final String conceptUuid, final LocalDate date) {
+        public DateObsDialog(String title, final String conceptUuid, LocalDate date) {
             super(
                 PatientChartActivity.this,
                 (picker, year, zeroBasedMonth, day) -> {
                     int month = zeroBasedMonth + 1;
-                    mController.setDate(conceptUuid, new LocalDate(year, month, day));
+                    mController.submitDateObservation(conceptUuid, new LocalDate(year, month, day));
                 },
                 date.getYear(),
                 date.getMonthOfYear() - 1,
@@ -364,6 +364,13 @@ public final class PatientChartActivity extends LoggedInActivity {
     public final class Ui implements PatientChartController.Ui {
         @Override public void setTitle(String title) {
             PatientChartActivity.this.setTitle(title);
+        }
+
+        @Override public void showDateObsDialog(String title, String uuid, LocalDate date) {
+            if (date == null) date = LocalDate.now();
+            DatePickerDialog dialog = new DateObsDialog(title, uuid, date);
+            dialog.updateDate(date.getYear(), date.getMonthOfYear() - 1, date.getDayOfMonth());
+            dialog.show();
         }
 
         // TODO/cleanup: As soon as we implement an ObsFormat formatter that displays

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -24,12 +24,9 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.widget.TextView;
 
-import com.google.common.base.Joiner;
 import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.joda.time.DateTime;
@@ -45,8 +42,6 @@ import org.projectbuendia.client.models.AppModel;
 import org.projectbuendia.client.models.Chart;
 import org.projectbuendia.client.models.ConceptUuids;
 import org.projectbuendia.client.models.Form;
-import org.projectbuendia.client.models.Location;
-import org.projectbuendia.client.models.LocationForest;
 import org.projectbuendia.client.models.Obs;
 import org.projectbuendia.client.models.ObsRow;
 import org.projectbuendia.client.models.Order;
@@ -65,11 +60,8 @@ import org.projectbuendia.client.ui.dialogs.OrderExecutionDialogFragment;
 import org.projectbuendia.client.ui.dialogs.PatientLocationDialogFragment;
 import org.projectbuendia.client.utils.EventBusWrapper;
 import org.projectbuendia.client.utils.Logger;
-import org.projectbuendia.client.utils.RelativeDateTimeFormatter;
 import org.projectbuendia.client.utils.Utils;
-import org.projectbuendia.client.widgets.PatientAttributeView;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -110,13 +102,7 @@ public final class PatientChartActivity extends LoggedInActivity {
     @Inject SyncManager mSyncManager;
     @Inject ChartDataHelper mChartDataHelper;
     @Inject AppSettings mSettings;
-    @InjectView(R.id.patient_chart_root) ViewGroup mRootView;
-    @InjectView(R.id.patient_placement) PatientAttributeView mPatientPlacement;
-    @InjectView(R.id.admission_day_number) PatientAttributeView mAdmissionDayNumber;
-    @InjectView(R.id.symptom_day_number) PatientAttributeView mSymptomDayNumber;
-    @InjectView(R.id.ebola_test_results) PatientAttributeView mEbolaTestResults;
-    @InjectView(R.id.special_labels) TextView mSpecialLabelsView;
-    @InjectView(R.id.chart_webview) WebView mGridWebView;
+    @InjectView(R.id.chart_webview) WebView mWebView;
 
     private static final String EN_DASH = "\u2013";
 
@@ -152,7 +138,6 @@ public final class PatientChartActivity extends LoggedInActivity {
                 return true;
             });
 
-        boolean ebolaLabTestFormEnabled = false;
         for (final Form form : mChartDataHelper.getForms()) {
             MenuItem item = editSubmenu.add(form.name);
             item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM | MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
@@ -162,11 +147,7 @@ public final class PatientChartActivity extends LoggedInActivity {
                     return true;
                 }
             );
-            if (form.uuid.equals(PatientChartController.EBOLA_LAB_TEST_FORM_UUID)) {
-                ebolaLabTestFormEnabled = true;
-            }
         }
-        Utils.showIf(mEbolaTestResults, ebolaLabTestFormEnabled);
     }
 
     @Override protected void onCreateImpl(Bundle savedInstanceState) {
@@ -201,7 +182,7 @@ public final class PatientChartActivity extends LoggedInActivity {
             R.string.symptoms_onset_date_picker_title, ConceptUuids.FIRST_SYMPTOM_DATE_UUID);
 
         // Remembering scroll position and applying it after the chart finished loading.
-        mGridWebView.setWebViewClient(new WebViewClient() {
+        mWebView.setWebViewClient(new WebViewClient() {
             public void onPageFinished(WebView view, String url) {
                 Point scrollPosition = mController.getLastScrollPosition();
                 if (scrollPosition != null) {
@@ -210,7 +191,7 @@ public final class PatientChartActivity extends LoggedInActivity {
                 }
             }
         });
-        mChartRenderer = new ChartRenderer(mGridWebView, getResources(), mSettings);
+        mChartRenderer = new ChartRenderer(mWebView, getResources(), mSettings);
 
         final OdkResultSender odkResultSender = (patientUuid, resultCode, data) ->
             OdkActivityLauncher.sendOdkResultToServer(
@@ -237,20 +218,6 @@ public final class PatientChartActivity extends LoggedInActivity {
             mSyncManager,
             minimalHandler);
 
-        mAdmissionDayNumber.setOnClickListener(view -> {
-            Utils.logUserAction("admission_day_pressed");
-            mAdmissionDateDialog.show();
-        });
-        mSymptomDayNumber.setOnClickListener(view -> {
-            Utils.logUserAction("symptom_day_pressed");
-            mSymptomOnsetDateDialog.show();
-        });
-        mPatientPlacement.setOnClickListener(view -> {
-            Utils.logUserAction("placement_pressed");
-            mController.showAssignLocationDialog(PatientChartActivity.this);
-        });
-        mEbolaTestResults.setOnClickListener(view -> mController.onEbolaTestResultsPressed());
-
         initChartTabs();
     }
 
@@ -263,7 +230,7 @@ public final class PatientChartActivity extends LoggedInActivity {
         if (uuid != null) {
             // Immediately hide the current patient chart, to avoid giving the
             // misleading impression that it applies to the new patient.
-            mGridWebView.setVisibility(View.INVISIBLE);
+            mWebView.setVisibility(View.INVISIBLE);
             mController.setPatient(uuid);
         }
     }
@@ -373,134 +340,10 @@ public final class PatientChartActivity extends LoggedInActivity {
             dialog.show();
         }
 
-        // TODO/cleanup: As soon as we implement an ObsFormat formatter that displays
-        // a date as a count of days (Utils.dayNumberSince), we can replace this logic
-        // with a format defined in the profile, decide how to arrange the tiles for
-        // admission date, first symptoms date, IV status, oxygen status, and Ebola
-        // PCR test results, and delete this method.
-        @Override public void updateAdmissionDateAndFirstSymptomsDateUi(
-            LocalDate admissionDate, LocalDate firstSymptomsDate) {
-            // TODO: Localize strings in this function.
-            int day = Utils.dayNumberSince(admissionDate, LocalDate.now());
-            mAdmissionDayNumber.setValue(
-                day >= 1 ? getString(R.string.day_n, day) : "–");
-            day = Utils.dayNumberSince(firstSymptomsDate, LocalDate.now());
-            mSymptomDayNumber.setValue(
-                day >= 1 ? getString(R.string.day_n, day) : "–");
-            if (admissionDate != null) {
-                mAdmissionDateDialog.updateDate(
-                    admissionDate.getYear(),
-                    admissionDate.getMonthOfYear() - 1,
-                    admissionDate.getDayOfMonth()
-                );
-            }
-            if (firstSymptomsDate != null) {
-                mSymptomOnsetDateDialog.updateDate(
-                    firstSymptomsDate.getYear(),
-                    firstSymptomsDate.getMonthOfYear() - 1,
-                    firstSymptomsDate.getDayOfMonth()
-                );
-            }
-        }
-
-        // TODO/cleanup: We don't need this special logic for the Ebola PCR test results
-        // any more, because the two-number format with a "NEG" displayed for numbers
-        // greater than 39.95 can be implemented using a format configured in the profile
-        // (e.g. the format "{1,select,>39.95:NEG;#} / {2,select,>39.95:NEG;#}" with the
-        // concepts "162826,162827").  The only reason we haven't deleted this code is
-        // that we need to do the other tiles like Admission Date to complete the layout.
-        @Override public void updateEbolaTestResultUi(Map<String, Obs> observations) {
-            // PCR
-            Obs pcrGpObservation = observations.get(ConceptUuids.PCR_GP_UUID);
-            Obs pcrNpObservation = observations.get(ConceptUuids.PCR_NP_UUID);
-
-            mEbolaTestResults.setIcon(createIcon(FontAwesomeIcons.fa_flask, R.color.chart_tile_icon));
-            if ((pcrGpObservation == null || pcrGpObservation.valueName == null)
-                    && (pcrNpObservation == null || pcrNpObservation.valueName == null)) {
-                mEbolaTestResults.setValue("–");
-            } else {
-                String pcrGpString = "–";
-                DateTime pcrObsTime = null;
-                if (pcrGpObservation != null && pcrGpObservation.valueName != null) {
-                    pcrObsTime = pcrGpObservation.time;
-                    try {
-                        double pcrGp = Double.parseDouble(pcrGpObservation.valueName);
-                        pcrGpString = getFormattedPcrString(pcrGp);
-                    } catch (NumberFormatException e) {
-                        LOG.w(
-                            "Retrieved a malformed GP-gene PCR value: '%1$s'.",
-                            pcrGpObservation.valueName);
-                        pcrGpString = pcrGpObservation.valueName;
-                    }
-                }
-                String pcrNpString = "–";
-                if (pcrNpObservation != null && pcrNpObservation.valueName != null) {
-                    pcrObsTime = pcrNpObservation.time;
-                    try {
-                        double pcrNp = Double.parseDouble(pcrNpObservation.valueName);
-                        pcrNpString = getFormattedPcrString(pcrNp);
-                    } catch (NumberFormatException e) {
-                        LOG.w(
-                            "Retrieved a malformed Np-gene PCR value: '%1$s'.",
-                            pcrNpObservation.valueName);
-                        pcrNpString = pcrNpObservation.valueName;
-                    }
-                }
-
-                mEbolaTestResults.setValue(String.format("%1$s / %2$s", pcrGpString, pcrNpString));
-                if (pcrObsTime != null) {
-                    LocalDate today = LocalDate.now();
-                    LocalDate obsDay = pcrObsTime.toLocalDate();
-                    String dateText = new RelativeDateTimeFormatter().format(obsDay, today);
-                    mEbolaTestResults.setName(getString(R.string.latest_pcr_label_with_date, dateText));
-                }
-            }
-        }
-
-        // TODO/cleanup: We don't need this special logic for these IV fields anymore,
-        // because it can be implemented using a format configured in the profile
-        // (e.g. the format "{1,yes_no,Oxygen} / {2,yes_no,IV fitted}" with the concepts
-        // concepts "888162738,f50c9c63-3ff9-4c26-9d18-12bfc58a3d07").  The only reason
-        // we haven't deleted this code is that we need to do the other tiles like
-        // Admission Date to complete the layout.
-        @Override public void updateSpecialLabels(Map<String, Obs> observations) {
-            List<String> specialLabels = new ArrayList<>();
-            if (ConceptUuids.isYes(observations.get(ConceptUuids.IV_UUID))) {
-                specialLabels.add(getString(R.string.iv_fitted));
-            }
-            if (ConceptUuids.isYes(observations.get(ConceptUuids.OXYGEN_UUID))) {
-                specialLabels.add(getString(R.string.oxygen));
-            }
-            if (ConceptUuids.isYes(observations.get(ConceptUuids.DYSPHAGIA_UUID))) {
-                specialLabels.add(getString(R.string.cannot_eat));
-            }
-            mSpecialLabelsView.setText(Joiner.on("\n").join(specialLabels));
-        }
-
-        @Override public void updatePatientConditionUi(String generalConditionUuid) {
-        }
-
-        @Override public void updateTilesAndGrid(
-            Chart chart,
-            Map<String, Obs> latestObservations,
-            List<Obs> observations,
-            List<Order> orders,
-            LocalDate admissionDate,
-            LocalDate firstSymptomsDate) {
-            mChartRenderer.render(chart, latestObservations, observations, orders,
-                                  admissionDate, firstSymptomsDate, mController);
-            mRootView.invalidate();
-        }
-
-        public void updatePatientLocationUi(LocationForest forest, Patient patient) {
-            Location location = forest.get(patient.locationUuid);
-            String locationText = location != null ? location.name : u.str(R.string.unknown);
-            String bedNumberText = Utils.toNonnull(patient.bedNumber).trim();
-
-            mPatientPlacement.setName(bedNumberText.isEmpty()
-                ? u.str(R.string.location) : u.str(R.string.bed_number_n, bedNumberText));
-            mPatientPlacement.setValue(locationText);
-            mPatientPlacement.setIcon(createIcon(FontAwesomeIcons.fa_map_marker, R.color.chart_tile_icon));
+        @Override public void updateTilesAndGrid(Chart chart, Map<String, Obs> latestObservations,
+            List<Obs> observations, List<Order> orders) {
+            mChartRenderer.render(chart, latestObservations, observations, orders, mController);
+            mWebView.invalidate();
         }
 
         @Override public void updatePatientDetailsUi(Patient patient) {

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -548,8 +548,8 @@ public final class PatientChartActivity extends LoggedInActivity {
         }
 
         @Override public void showObsDetailDialog(
-            List<ObsRow> obsRows, List<String> orderedConceptUuids) {
-            ObsDetailDialogFragment.newInstance(obsRows, orderedConceptUuids)
+            Interval interval, String[] conceptUuids, List<ObsRow> obsRows, List<String> conceptOrdering) {
+            ObsDetailDialogFragment.newInstance(interval, conceptUuids, obsRows, conceptOrdering)
                 .show(getSupportFragmentManager(), null);
         }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -69,6 +69,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import static org.projectbuendia.client.utils.Utils.eq;
+
 /** Controller for {@link PatientChartActivity}. */
 public final class PatientChartController implements ChartRenderer.JsInterface {
 
@@ -362,6 +364,10 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
     }
 
     @JavascriptInterface public void showObsDetails(String conceptUuids) {
+        if (eq(conceptUuids, ConceptUuids.PLACEMENT_UUID)) {
+            mUi.showPatientLocationDialog(mPatient);
+            return;
+        }
         mUi.showObsDetailDialog(
             null,
             conceptUuids.split(","),

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartController.java
@@ -365,7 +365,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
         );
     }
 
-    @JavascriptInterface public void showObsDetails(String conceptUuids) {
+    @JavascriptInterface public void showObsDialog(String conceptUuids) {
         if (!conceptUuids.contains(",")) {
             String uuid = conceptUuids;
             if (eq(uuid, ConceptUuids.PLACEMENT_UUID)) {
@@ -388,7 +388,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
         );
     }
 
-    @JavascriptInterface public void showObsDetails(long startMillis, long stopMillis) {
+    @JavascriptInterface public void showObsDialog(long startMillis, long stopMillis) {
         Interval interval = new Interval(startMillis, stopMillis);
         mUi.showObsDetailDialog(
             interval,
@@ -398,7 +398,7 @@ public final class PatientChartController implements ChartRenderer.JsInterface {
         );
     }
 
-    @JavascriptInterface public void showObsDetails(String conceptUuids, long startMillis, long stopMillis) {
+    @JavascriptInterface public void showObsDialog(String conceptUuids, long startMillis, long stopMillis) {
         Interval interval = new Interval(startMillis, stopMillis);
         mUi.showObsDetailDialog(
             interval,

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -89,7 +89,7 @@ public class EditPatientDialogFragment extends DialogFragment {
             args.putString("id", patient.id);
             args.putString("givenName", patient.givenName);
             args.putString("familyName", patient.familyName);
-            args.putString("birthdate", Utils.formatDate(patient.birthdate));
+            args.putString("birthdate", Utils.format(patient.birthdate));
             args.putString("sex", Sex.nullableNameOf(patient.sex));
         }
         fragment.setArguments(args);

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/ObsDetailDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/ObsDetailDialogFragment.java
@@ -36,6 +36,8 @@ import javax.annotation.Nullable;
 
 import butterknife.ButterKnife;
 
+import static org.projectbuendia.client.utils.Utils.DateStyle.SENTENCE_MONTH_DAY_HOUR_MINUTE;
+
 public class ObsDetailDialogFragment extends DialogFragment {
     private ContextUtils u;
     private SortedMap<Section, List<ObsRow>> rowsBySection;
@@ -97,8 +99,8 @@ public class ObsDetailDialogFragment extends DialogFragment {
             conceptNames = u.formatItems(names);
         }
         if (interval != null) {
-            String start = Utils.formatShortDateTime(interval.getStart());
-            String stop = Utils.formatShortDateTime(interval.getEnd());
+            String start = Utils.format(interval.getStart(), SENTENCE_MONTH_DAY_HOUR_MINUTE);
+            String stop = Utils.format(interval.getEnd(), SENTENCE_MONTH_DAY_HOUR_MINUTE);
             if (conceptNames != null) {
                 message.setText(getString(
                     Utils.hasItems(obsRows)

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/ObsDetailDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/ObsDetailDialogFragment.java
@@ -6,22 +6,26 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentManager;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ExpandableListAdapter;
 import android.widget.ExpandableListView;
+import android.widget.TextView;
 
+import org.joda.time.Interval;
 import org.joda.time.LocalDate;
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.R;
 import org.projectbuendia.client.models.ObsRow;
+import org.projectbuendia.client.sync.ConceptService;
 import org.projectbuendia.client.ui.lists.ExpandableObsRowAdapter;
+import org.projectbuendia.client.utils.ContextUtils;
 import org.projectbuendia.client.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
@@ -33,10 +37,7 @@ import javax.annotation.Nullable;
 import butterknife.ButterKnife;
 
 public class ObsDetailDialogFragment extends DialogFragment {
-    private static final String KEY_OBS_ROWS = "obsRows";
-    private static final String KEY_CONCEPT_UUIDS = "conceptUuids";
-
-    private LayoutInflater mInflater;
+    private ContextUtils u;
     private SortedMap<Section, List<ObsRow>> rowsBySection;
 
     private static String EN_DASH = "\u2013";
@@ -44,10 +45,13 @@ public class ObsDetailDialogFragment extends DialogFragment {
     private static String BULLET = "\u2022";
 
     public static ObsDetailDialogFragment newInstance(
-        List<ObsRow> obsRows, List<String> orderedConceptUuids) {
+        Interval interval, String[] conceptUuids,
+        List<ObsRow> obsRows, List<String> conceptOrdering) {
         Bundle args = new Bundle();
-        args.putParcelableArrayList(KEY_OBS_ROWS, new ArrayList<>(obsRows));
-        args.putStringArrayList(KEY_CONCEPT_UUIDS, new ArrayList<>(orderedConceptUuids));
+        args.putString("interval", Utils.toNullableString(interval));
+        args.putStringArray("conceptUuids", conceptUuids);
+        args.putParcelableArrayList("obsRows", new ArrayList<>(obsRows));
+        args.putStringArrayList("conceptOrdering", new ArrayList<>(conceptOrdering));
         ObsDetailDialogFragment fragment = new ObsDetailDialogFragment();
         fragment.setArguments(args);
         return fragment;
@@ -55,17 +59,20 @@ public class ObsDetailDialogFragment extends DialogFragment {
 
     @Override public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mInflater = LayoutInflater.from(getActivity());
+        u = ContextUtils.from(getActivity());
     }
 
     @Override public @NonNull Dialog onCreateDialog(Bundle savedInstanceState) {
-        View fragment = mInflater.inflate(R.layout.obs_detail_dialog_fragment, null);
+        View fragment = u.inflateForDialog(R.layout.obs_detail_dialog_fragment);
         ButterKnife.inject(this, fragment);
 
-        List<String> conceptUuids = getArguments().getStringArrayList(KEY_CONCEPT_UUIDS);
-        List<ObsRow> obsRows = getArguments().getParcelableArrayList(KEY_OBS_ROWS);
+        String arg = getArguments().getString("interval");
+        Interval interval = arg != null ? Interval.parse(arg) : null;
+        String[] conceptUuids = getArguments().getStringArray("conceptUuids");
+        List<ObsRow> obsRows = getArguments().getParcelableArrayList("obsRows");
+        List<String> conceptOrdering = getArguments().getStringArrayList("conceptOrdering");
 
-        rowsBySection = new TreeMap<>(new SectionComparator(conceptUuids));
+        rowsBySection = new TreeMap<>(new SectionComparator(conceptOrdering));
         if (obsRows != null) {
             for (ObsRow row : obsRows) {
                 if (row.valueName != null) {
@@ -78,8 +85,47 @@ public class ObsDetailDialogFragment extends DialogFragment {
             }
         }
 
-        ExpandableListAdapter adapter = new ExpandableObsRowAdapter(
-            App.getContext(), rowsBySection);
+        TextView message = fragment.findViewById(R.id.message);
+        String conceptNames = null;
+        if (Utils.hasItems(conceptUuids)) {
+            ConceptService concepts = App.getConceptService();
+            Locale locale = App.getSettings().getLocale();
+            String[] names = new String[conceptUuids.length];
+            for (int i = 0; i < conceptUuids.length; i++) {
+                names[i] = getString(R.string.quoted_text, concepts.getName(conceptUuids[i], locale));
+            }
+            conceptNames = u.formatItems(names);
+        }
+        if (interval != null) {
+            String start = Utils.formatShortDateTime(interval.getStart());
+            String stop = Utils.formatShortDateTime(interval.getEnd());
+            if (conceptNames != null) {
+                message.setText(getString(
+                    Utils.hasItems(obsRows)
+                        ? R.string.obs_details_concept_interval
+                        : R.string.obs_details_concept_interval_empty,
+                    conceptNames, start, stop
+                ));
+            } else {
+                message.setText(getString(
+                    Utils.hasItems(obsRows)
+                        ? R.string.obs_details_interval
+                        : R.string.obs_details_interval_empty,
+                    start, stop
+                ));
+            }
+        } else if (conceptNames != null) {
+            message.setText(getString(
+                Utils.hasItems(obsRows)
+                    ? R.string.obs_details_concept
+                    : R.string.obs_details_concept_empty,
+                conceptNames
+            ));
+        } else {
+            // Should never get here (no concepts and no interval).
+            message.setText("");
+        }
+        ExpandableListAdapter adapter = new ExpandableObsRowAdapter(u, rowsBySection);
         ExpandableListView listView = fragment.findViewById(R.id.obs_list);
         listView.setAdapter(adapter);
         for (int i = 0; i < adapter.getGroupCount(); i++) {
@@ -92,6 +138,7 @@ public class ObsDetailDialogFragment extends DialogFragment {
         // listView.addFooterView(listFooterView);
 
         return new AlertDialog.Builder(getActivity())
+            .setTitle(R.string.obs_details_title)
             .setPositiveButton(R.string.ok, (dialogInterface, i) -> dialogInterface.dismiss())
             .setView(fragment)
             .create();
@@ -156,12 +203,12 @@ public class ObsDetailDialogFragment extends DialogFragment {
         private final Map<String, Integer> orderingByUuid = new HashMap<>();
         private final int orderingMax;
 
-        public SectionComparator(@Nullable List<String> conceptUuids) {
-            if (conceptUuids != null) {
-                for (int i = 0; i < conceptUuids.size(); i++) {
-                    orderingByUuid.put(conceptUuids.get(i), i);
+        public SectionComparator(@Nullable List<String> conceptOrdering) {
+            if (conceptOrdering != null) {
+                for (int i = 0; i < conceptOrdering.size(); i++) {
+                    orderingByUuid.put(conceptOrdering.get(i), i);
                 }
-                orderingMax = conceptUuids.size();
+                orderingMax = conceptOrdering.size();
             } else {
                 orderingMax = 0;
             }

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
@@ -47,6 +47,8 @@ import butterknife.ButterKnife;
 import butterknife.InjectView;
 import de.greenrobot.event.EventBus;
 
+import static org.projectbuendia.client.utils.Utils.DateStyle.MONTH_DAY;
+
 /** A {@link DialogFragment} for adding a new user. */
 public class OrderDialogFragment extends DialogFragment {
     public static final int MAX_FREQUENCY = 24;  // maximum 24 times per day
@@ -355,7 +357,7 @@ public class OrderDialogFragment extends DialogFragment {
                 days == 1 ? R.string.order_duration_stop_after_today :
                     days == 2 ? R.string.order_duration_stop_after_tomorrow :
                         R.string.order_duration_stop_after_date
-        ).replace("%s", Utils.formatShortDate(lastDay)));
+        ).replace("%s", Utils.format(lastDay, MONTH_DAY)));
     }
 
     class DurationDaysWatcher implements TextWatcher {

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderExecutionDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderExecutionDialogFragment.java
@@ -40,6 +40,9 @@ import butterknife.ButterKnife;
 import butterknife.InjectView;
 import de.greenrobot.event.EventBus;
 
+import static org.projectbuendia.client.utils.Utils.DateStyle.HOUR_MINUTE;
+import static org.projectbuendia.client.utils.Utils.DateStyle.MONTH_DAY;
+
 /** A {@link DialogFragment} for recording that an order was executed. */
 public class OrderExecutionDialogFragment extends DialogFragment {
     @InjectView(R.id.order_medication) TextView mOrderMedication;
@@ -134,8 +137,8 @@ public class OrderExecutionDialogFragment extends DialogFragment {
 
         DateTime start = Utils.getDateTime(args, "orderStartMillis");
         mOrderStartTime.setText(getString(
-            R.string.order_started_on_date_at_time,
-            Utils.formatShortDate(start.toLocalDate()), Utils.formatTimeOfDay(start)));
+            R.string.order_started_datetime,
+            Utils.format(start, Utils.DateStyle.SENTENCE_MONTH_DAY_HOUR_MINUTE)));
 
         // Describe how many times the order was executed during the selected interval.
         int count = executionTimes.size() + (orderExecutedNow ? 1 : 0);
@@ -146,19 +149,19 @@ public class OrderExecutionDialogFragment extends DialogFragment {
                     : R.string.order_execution_today_singular_html) :
                 (plural ? R.string.order_execution_historical_plural_html
                     : R.string.order_execution_historical_singular_html),
-            count, Utils.formatShortDate(date))));
+            count, Utils.format(date, MONTH_DAY))));
 
         // Show the list of times that the order was executed during the selected interval.
         boolean editable = args.getBoolean("editable");
         Utils.showIf(mOrderExecutionList, executionTimes.size() > 0 || editable);
         List<String> htmlItems = new ArrayList<>();
         for (DateTime executionTime : executionTimes) {
-            htmlItems.add(Utils.formatTimeOfDay(executionTime));
+            htmlItems.add(Utils.format(executionTime, HOUR_MINUTE));
         }
         if (editable) {
             DateTime encounterTime = Utils.getDateTime(args, "encounterTimeMillis");
             htmlItems.add(orderExecutedNow ?
-                "<b>" + Utils.formatTimeOfDay(encounterTime) + "</b>" :
+                "<b>" + Utils.format(encounterTime, HOUR_MINUTE) + "</b>" :
                 "<b>&nbsp;</b>");  // keep total height stable
         }
         mOrderExecutionList.setText(Html.fromHtml(Joiner.on("<br>").join(htmlItems)));

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/VoidObservationsDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/VoidObservationsDialogFragment.java
@@ -24,6 +24,8 @@ import java.util.List;
 import butterknife.ButterKnife;
 import de.greenrobot.event.EventBus;
 
+import static org.projectbuendia.client.utils.Utils.DateStyle.MONTH_DAY;
+
 public class VoidObservationsDialogFragment extends DialogFragment {
 
     private LayoutInflater mInflater;
@@ -63,7 +65,7 @@ public class VoidObservationsDialogFragment extends DialogFragment {
 
         for (ObsRow row: rows) {
 
-            Title = row.conceptName + " " + Utils.formatShortDate(row.time);
+            Title = row.conceptName + " " + Utils.format(row.time, MONTH_DAY);
 
             if(!isExistingHeader(Title)){
                 listDataHeader.add(Title);
@@ -77,7 +79,7 @@ public class VoidObservationsDialogFragment extends DialogFragment {
 
             for (ObsRow row: rows){
 
-                verifyTitle = row.conceptName + " " + Utils.formatShortDate(row.time);
+                verifyTitle = row.conceptName + " " + Utils.format(row.time, MONTH_DAY);
 
                 if (verifyTitle.equals(header)){
                     child.add(row);

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/ExpandableObsRowAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/ExpandableObsRowAdapter.java
@@ -17,6 +17,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import static org.projectbuendia.client.utils.Utils.DateStyle.HOUR_MINUTE;
+import static org.projectbuendia.client.utils.Utils.DateStyle.MONTH_DAY;
+
 public class ExpandableObsRowAdapter extends BaseExpandableListAdapter {
     private final ContextUtils u;
     private final List<Section> mSections;
@@ -57,13 +60,13 @@ public class ExpandableObsRowAdapter extends BaseExpandableListAdapter {
     @Override public Object getGroup(int groupIndex) {
         Section section = mSections.get(groupIndex);
         return Utils.format("%s " + BULLET + " %s",
-            section.conceptName, Utils.formatShortDate(section.date));
+            section.conceptName, Utils.format(section.date, MONTH_DAY));
     }
 
     @Override public Object getChild(int groupIndex, int childIndex) {
         ObsRow row = mSectionRows.get(groupIndex).get(childIndex);
         return Utils.format("%s " + EM_DASH + " %s",
-            Utils.formatTimeOfDay(row.time), row.valueName);
+            Utils.format(row.time, HOUR_MINUTE), row.valueName);
     }
 
     @Override public int getGroupCount() {

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/ExpandableObsRowAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/ExpandableObsRowAdapter.java
@@ -42,8 +42,8 @@ public class ExpandableObsRowAdapter extends BaseExpandableListAdapter {
 
     @Override public View getGroupView(
         int groupIndex, boolean isExpanded, View view, ViewGroup parent) {
-        view = u.reuseOrInflate(view, R.layout.obs_section, parent);
-        u.setText(R.id.section_heading, (String) getGroup(groupIndex));
+        view = u.reuseOrInflate(view, R.layout.obs_heading, parent);
+        u.setText(R.id.heading_text, (String) getGroup(groupIndex));
         return view;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/lists/ExpandableVoidObsRowAdapter.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/lists/ExpandableVoidObsRowAdapter.java
@@ -49,8 +49,8 @@ public class ExpandableVoidObsRowAdapter extends BaseExpandableListAdapter {
     @Override
     public View getGroupView(int groupIndex, boolean isExpanded,
                              View view, ViewGroup parent) {
-        view = u.reuseOrInflate(view, R.layout.obs_section, parent);
-        u.setText(R.id.section_heading, (String) getGroup(groupIndex));
+        view = u.reuseOrInflate(view, R.layout.obs_heading, parent);
+        u.setText(R.id.heading_text, (String) getGroup(groupIndex));
         return view;
     }
 

--- a/app/src/main/java/org/projectbuendia/client/utils/ContextUtils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/ContextUtils.java
@@ -21,6 +21,7 @@ import org.projectbuendia.client.models.Sex;
 import org.projectbuendia.client.resolvables.ResStatus;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -120,6 +121,19 @@ public class ContextUtils extends ContextWrapper {
     /** Strings are always available in the app-wide resources. */
     public String str(int id, Object... args) {
         return App.str(id, args);
+    }
+
+    /** Formats a list of items in a localized fashion. */
+    public String formatItems(String... items) {
+        int n = items.length;
+        return n == 0 ? ""
+            : n == 1 ? items[0]
+            : n == 2 ? str(R.string.two_items, items[0], items[1])
+            : str(
+                R.string.more_than_two_items,
+                Joiner.on(", ").join(Arrays.copyOfRange(items, 0, n - 1)),
+                items[n - 1]
+            );
     }
 
     /** Formats a location heading with an optional patient count. */

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import com.android.volley.AuthFailureError;
 import com.android.volley.Request;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.joda.time.DateTime;
@@ -161,12 +162,7 @@ public class Utils {
     }
 
 
-    // ==== String handling ====
-
-    /** Performs a null-safe check for a null or empty String. */
-    public static boolean isEmpty(@Nullable String str) {
-        return str == null || str.length() == 0;
-    }
+    // ==== Collections ====
 
     /** Performs a null-safe check for a null or empty array. */
     public static <T> boolean isEmpty(@Nullable T[] array) {
@@ -178,9 +174,9 @@ public class Utils {
         return collection == null || collection.size() == 0;
     }
 
-    /** Performs a null-safe check for a String with at least one character. */
-    public static boolean hasChars(@Nullable String str) {
-        return str != null && str.length() > 0;
+    /** Converts nulls to empty Lists. */
+    public static <T> List<T> toNonnull(@Nullable List<T> list) {
+        return list != null ? list : ImmutableList.of();
     }
 
     /** Performs a null-safe check for an array with at least one item. */
@@ -191,6 +187,19 @@ public class Utils {
     /** Performs a null-safe check for a Collection with at least one item. */
     public static boolean hasItems(@Nullable Collection collection) {
         return collection != null && collection.size() > 0;
+    }
+
+
+    // ==== Strings ====
+
+    /** Performs a null-safe check for a null or empty String. */
+    public static boolean isEmpty(@Nullable String str) {
+        return str == null || str.length() == 0;
+    }
+
+    /** Performs a null-safe check for a String with at least one character. */
+    public static boolean hasChars(@Nullable String str) {
+        return str != null && str.length() > 0;
     }
 
     /** Converts empty strings to null. */

--- a/app/src/main/java/org/projectbuendia/client/utils/Utils.java
+++ b/app/src/main/java/org/projectbuendia/client/utils/Utils.java
@@ -54,6 +54,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -162,9 +163,34 @@ public class Utils {
 
     // ==== String handling ====
 
-    /** Performs a null-safe check for a null or empty string. */
+    /** Performs a null-safe check for a null or empty String. */
     public static boolean isEmpty(@Nullable String str) {
-        return str == null || str.isEmpty();
+        return str == null || str.length() == 0;
+    }
+
+    /** Performs a null-safe check for a null or empty array. */
+    public static <T> boolean isEmpty(@Nullable T[] array) {
+        return array == null || array.length == 0;
+    }
+
+    /** Performs a null-safe check for a null or empty Collection. */
+    public static boolean isEmpty(@Nullable Collection collection) {
+        return collection == null || collection.size() == 0;
+    }
+
+    /** Performs a null-safe check for a String with at least one character. */
+    public static boolean hasChars(@Nullable String str) {
+        return str != null && str.length() > 0;
+    }
+
+    /** Performs a null-safe check for an array with at least one item. */
+    public static <T> boolean hasItems(@Nullable T[] array) {
+        return array != null && array.length > 0;
+    }
+
+    /** Performs a null-safe check for a Collection with at least one item. */
+    public static boolean hasItems(@Nullable Collection collection) {
+        return collection != null && collection.size() > 0;
     }
 
     /** Converts empty strings to null. */
@@ -261,17 +287,20 @@ public class Utils {
         }
     }
 
+    /** Converts objects of integer types to longs. */
+    public static Long toLongOrNull(Object obj) {
+        if (obj instanceof Integer) return (long) (Integer) obj;
+        if (obj instanceof Long) return (long) obj;
+        if (obj instanceof BigInteger) return ((BigInteger) obj).longValue();
+        if (obj instanceof String) return toLongOrNull((String) obj);
+        return null;
+    }
+
     /** Converts objects of integer types to BigIntegers. */
     public static BigInteger toBigInteger(Object obj) {
-        if (obj instanceof Integer) {
-            return BigInteger.valueOf(((Integer) obj).longValue());
-        }
-        if (obj instanceof Long) {
-            return BigInteger.valueOf((Long) obj);
-        }
-        if (obj instanceof BigInteger) {
-            return (BigInteger) obj;
-        }
+        if (obj instanceof Integer) return BigInteger.valueOf(((Integer) obj).longValue());
+        if (obj instanceof Long) return BigInteger.valueOf((Long) obj);
+        if (obj instanceof BigInteger) return (BigInteger) obj;
         return null;
     }
 

--- a/app/src/main/res/layout/fragment_patient_chart.xml
+++ b/app/src/main/res/layout/fragment_patient_chart.xml
@@ -9,70 +9,9 @@
     OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
     specific language governing permissions and limitations under the License.
 -->
-<RelativeLayout
-    android:id="@+id/patient_chart_root"
+<WebView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context="org.projectbuendia.client.ui.chart.PatientChartActivity">
+    android:id="@+id/chart_webview"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent" />
 
-  <LinearLayout
-      android:id="@+id/patient_chart_status_section"
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="16dp"
-      android:orientation="horizontal">
-
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/admission_day_number"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/since_admission"
-        app:attributeValue="–"/>
-
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/symptom_day_number"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/since_symptom_onset"
-        app:attributeValue="–"/>
-
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/patient_placement"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/location"
-        app:attributeValue="–"/>
-
-    <org.projectbuendia.client.widgets.PatientAttributeView
-        android:id="@+id/ebola_test_results"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        app:attributeName="@string/ebola_test_label"
-        app:attributeValue="–"/>
-
-    <TextView
-        android:id="@+id/special_labels"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.2"
-        android:textSize="12sp"
-        android:gravity="end"
-        android:textColor="@color/red"
-        tools:text="Pregnant&#10;IV Fitted"/>
-  </LinearLayout>
-
-  <WebView
-      android:id="@+id/chart_webview"
-      android:layout_width="match_parent"
-      android:layout_height="fill_parent"
-      android:layout_below="@+id/patient_chart_status_section" />
-
-</RelativeLayout>

--- a/app/src/main/res/layout/obs_detail_dialog_fragment.xml
+++ b/app/src/main/res/layout/obs_detail_dialog_fragment.xml
@@ -5,6 +5,15 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8sp"
+        android:paddingBottom="8sp"
+        android:paddingLeft="16sp"
+        android:paddingRight="16sp"
+        android:id="@+id/message"/>
+
     <ExpandableListView
         android:id="@+id/obs_list"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/obs_heading.xml
+++ b/app/src/main/res/layout/obs_heading.xml
@@ -6,10 +6,13 @@
     android:layout_height="match_parent">
 
     <TextView
-        android:id="@+id/section_heading"
+        android:id="@+id/heading_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="8sp"
+        android:paddingTop="8sp"
+        android:paddingBottom="8sp"
+        android:paddingLeft="16sp"
+        android:paddingRight="16sp"
         android:textColor="#000000"
         android:textSize="19sp"
         android:textStyle="bold"

--- a/app/src/main/res/layout/obs_item.xml
+++ b/app/src/main/res/layout/obs_item.xml
@@ -9,8 +9,10 @@
         android:id="@+id/item_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="48sp"
-        android:padding="8sp"
+        android:paddingTop="8sp"
+        android:paddingBottom="8sp"
+        android:paddingLeft="48sp"
+        android:paddingRight="16sp"
         android:textColor="#000000"
         android:textSize="19sp"/>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,6 +11,10 @@
     specific language governing permissions and limitations under the License.
 -->
 <resources>
+  <string name="quoted_text">«%s»</string>
+  <string name="two_items">%s et %s</string>
+  <string name="more_than_two_items">%s, et %s</string>
+
   <!-- Statuses -->
   <string name="status_unknown">Inconnu</string>
   <string name="status_well">Bien</string>
@@ -179,7 +183,7 @@
   <string name="family_name_cannot_be_null">Nom de famille ne doit pas être null</string>
   <string name="invalid_username">Nom d\'utilisateur doit être compris entre 2 et 50 caractères. Seuls les lettres, chiffres, ".", "-", et "_" sont autorisés.</string>
   <string name="ebola_test_label">Essai d\'Ebola</string>
-  <string name="latest_pcr_label_with_date">Essai d\'Ebola test (%s)</string>
+  <string name="latest_pcr_label_with_date">Essai d\'Ebola (%s)</string>
   <string name="action_add_test_result">Ajouter le résultat du test</string>
   <string name="pregnant_abbreviation">enc</string>
   <string name="pregnant">Enceinte</string>
@@ -393,4 +397,13 @@ S\'il vous plaît patienter pendant que les données du patient et l\'emplacemen
   <string name="troubleshoot_action_check_settings">Vérifiez les paramètres</string>
   <string name="voiding">vide</string>
   <string name="void_observations">Observations Vides</string>
+
+  <!-- Observation details dialog -->
+  <string name="obs_details_title">Observations</string>
+  <string name="obs_details_interval">Les observations enregistrée entre %1$s et %2$s:</string>
+  <string name="obs_details_interval_empty">Aucune observation n\'a été enregistrée entre %1$s et %2$s.</string>
+  <string name="obs_details_concept">Toutes les observations de %s:</string>
+  <string name="obs_details_concept_interval">Observations de %1$s enregistrée entre %2$s et %3$s:</string>
+  <string name="obs_details_concept_empty">Aucune observation de %1$s n\'a été enregistrée.</string>
+  <string name="obs_details_concept_interval_empty">Aucune observation de %1$s n\'a été enregistrée entre %2$s et %3$s.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,6 +14,14 @@
   <string name="quoted_text">«%s»</string>
   <string name="two_items">%s et %s</string>
   <string name="more_than_two_items">%s, et %s</string>
+  <string name="month_day_format">d MMM</string>
+  <string name="sentence_month_day_format">\'le\' d MMM</string>
+  <string name="year_month_day_format">d MMM yyyy</string>
+  <string name="sentence_year_month_day_format">\'le\' d MMM yyyy</string>
+  <string name="hour_minute_format">HH\'h\'mm</string>
+  <string name="sentence_hour_minute_format">HH\'h\'mm</string>
+  <string name="month_day_hour_minute_format">MMM d, HH\'h\'mm</string>
+  <string name="sentence_month_day_hour_minute_format">\'le\' d MMM \'à\' HH\'h\'mm</string>
 
   <!-- Statuses -->
   <string name="status_unknown">Inconnu</string>
@@ -119,7 +127,7 @@
   <string name="order_execution_today_plural_html">Donné &lt;b&gt;%1$d&lt;/b&gt; fois aujourd\'hui, %2$s</string>
   <string name="order_execution_mark_as_given">Marquer comme donné maintenant</string>
   <string name="order_execution_marked_as_given">&#x2714; Marqué comme donné maintenant</string>
-  <string name="order_started_on_date_at_time">Commencé le %1$s à %2$s</string>
+  <string name="order_started_datetime">Commencé %s</string>
 
   <string name="string_with_paren">%1$s (%2$s)</string>
   <string name="unknown_tent">Tente inconnu</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
   specific language governing permissions and limitations under the License.
 -->
 <resources>
+  <string name="quoted_text">"%s"</string>
+  <string name="two_items">%s and %s</string>
+  <string name="more_than_two_items">%s, and %s</string>
+
   <!-- Statuses -->
   <string name="status_unknown">Unknown</string>
   <string name="status_well">Well</string>
@@ -395,4 +399,13 @@
   <string name="string_with_paren">%1$s (%2$s)</string>
   <string name="voiding">Void</string>
   <string name="void_observations">Void Observations</string>
+
+  <!-- Observation details dialog -->
+  <string name="obs_details_title">Observations</string>
+  <string name="obs_details_interval">Observations recorded between %1$s and %2$s:</string>
+  <string name="obs_details_interval_empty">No observations were recorded between %1$s and %2$s.</string>
+  <string name="obs_details_concept">All observations of %s:</string>
+  <string name="obs_details_concept_interval">Observations of %1$s recorded between %2$s and %3$s:</string>
+  <string name="obs_details_concept_empty">No observations of %1$s have been recorded.</string>
+  <string name="obs_details_concept_interval_empty">No observations of %1$s were recorded between %2$s and %3$s.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,14 @@
   <string name="quoted_text">"%s"</string>
   <string name="two_items">%s and %s</string>
   <string name="more_than_two_items">%s, and %s</string>
+  <string name="month_day_format">MMM d</string>
+  <string name="sentence_month_day_format">MMM d</string>
+  <string name="year_month_day_format">MMM d, yyyy</string>
+  <string name="sentence_year_month_day_format">MMM d, yyyy</string>
+  <string name="hour_minute_format">HH:mm</string>
+  <string name="sentence_hour_minute_format">HH:mm</string>
+  <string name="month_day_hour_minute_format">MMM d, HH:mm</string>
+  <string name="sentence_month_day_hour_minute_format">\'on\' MMM d \'at\' HH:mm</string>
 
   <!-- Statuses -->
   <string name="status_unknown">Unknown</string>
@@ -122,7 +130,7 @@
   <string name="order_execution_today_plural_html">Given &lt;b&gt;%1$d&lt;/b&gt; times today, %2$s</string>
   <string name="order_execution_mark_as_given">Mark as given now</string>
   <string name="order_execution_marked_as_given">&#x2714; Marked as given now</string>
-  <string name="order_started_on_date_at_time">Started on %1$s at %2$s</string>
+  <string name="order_started_datetime">Started %s</string>
 
   <string name="unknown_tent">Unknown tent</string>
   <string name="unknown_zone">Unknown zone</string>


### PR DESCRIPTION
This adds support for:
  - Styling and formatting a row of tiles that stays fixed at the top of the screen while the rest of the chart scrolls.
  - Display formats for relative dates and locations, so that profile formats can replace all the existing fixed tiles.
  - Handlers for tapping on tiles, so the user can still edit dates and assign locations.  This included several improvements to the observation details dialog.