### PR TITLE
Many improvements to the order dialog, including a "stop now" button

### DIFF
--- a/app/src/main/java/org/projectbuendia/client/events/actions/OrderStopRequestedEvent.java
+++ b/app/src/main/java/org/projectbuendia/client/events/actions/OrderStopRequestedEvent.java
@@ -1,0 +1,21 @@
+// Copyright 2015 The Project Buendia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distrib-
+// uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+// specific language governing permissions and limitations under the License.
+
+package org.projectbuendia.client.events.actions;
+
+/** Event indicating that the user has requested to delete an order. */
+public class OrderStopRequestedEvent {
+    public final String orderUuid;
+
+    public OrderStopRequestedEvent(String orderUuid) {
+        this.orderUuid = orderUuid;
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/ui/TextChangedWatcher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/TextChangedWatcher.java
@@ -1,0 +1,20 @@
+package org.projectbuendia.client.ui;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+
+public class TextChangedWatcher implements TextWatcher {
+    private final Runnable callback;
+
+    public TextChangedWatcher(Runnable callback) {
+        this.callback = callback;
+    }
+
+    @Override public void beforeTextChanged(CharSequence c, int x, int y, int z) { }
+
+    @Override public void onTextChanged(CharSequence c, int x, int y, int z) { }
+
+    @Override public void afterTextChanged(Editable editable) {
+        callback.run();
+    }
+}

--- a/app/src/main/java/org/projectbuendia/client/ui/TextChangedWatcher.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/TextChangedWatcher.java
@@ -5,6 +5,7 @@ import android.text.TextWatcher;
 
 public class TextChangedWatcher implements TextWatcher {
     private final Runnable callback;
+    private boolean inCallback = false;
 
     public TextChangedWatcher(Runnable callback) {
         this.callback = callback;
@@ -15,6 +16,13 @@ public class TextChangedWatcher implements TextWatcher {
     @Override public void onTextChanged(CharSequence c, int x, int y, int z) { }
 
     @Override public void afterTextChanged(Editable editable) {
-        callback.run();
+        if (callback != null && !inCallback) {
+            inCallback = true;
+            try {
+                callback.run();
+            } finally {
+                inCallback = false;
+            }
+        }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -392,8 +392,8 @@ public final class PatientChartActivity extends LoggedInActivity {
             Utils.showDialogIf(mFormSubmissionDialog, show);
         }
 
-        @Override public void showOrderDialog(String patientUuid, Order order) {
-            OrderDialogFragment.newInstance(patientUuid, order)
+        @Override public void showOrderDialog(String patientUuid, Order order, List<DateTime> executionTimes) {
+            OrderDialogFragment.newInstance(patientUuid, order, executionTimes)
                 .show(getSupportFragmentManager(), null);
         }
 

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/EditPatientDialogFragment.java
@@ -18,8 +18,6 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.DialogFragment;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
@@ -43,6 +41,7 @@ import org.projectbuendia.client.models.Obs;
 import org.projectbuendia.client.models.Patient;
 import org.projectbuendia.client.models.Sex;
 import org.projectbuendia.client.ui.BigToast;
+import org.projectbuendia.client.ui.TextChangedWatcher;
 import org.projectbuendia.client.utils.Utils;
 
 import java.util.List;
@@ -162,9 +161,8 @@ public class EditPatientDialogFragment extends DialogFragment {
         mSex.setSelection(sex);
 
         mBirthdate = birthdate;
-        TextWatcher ageEditedWatcher = new AgeEditedWatcher();
-        mAgeYears.addTextChangedListener(ageEditedWatcher);
-        mAgeMonths.addTextChangedListener(ageEditedWatcher);
+        mAgeYears.addTextChangedListener(new TextChangedWatcher(() -> mAgeChanged = true));
+        mAgeMonths.addTextChangedListener(new TextChangedWatcher(() -> mAgeChanged = true));
     }
 
     public void onSubmit(DialogInterface dialog) {
@@ -280,13 +278,5 @@ public class EditPatientDialogFragment extends DialogFragment {
         // If all fields are populated, default to the end of the given name field.
         mGivenName.requestFocus();
         mGivenName.setSelection(mGivenName.getText().length());
-    }
-
-    private class AgeEditedWatcher implements TextWatcher {
-        @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
-        @Override public void onTextChanged(CharSequence s, int start, int before, int count) { }
-        @Override public void afterTextChanged(Editable s) {
-            mAgeChanged = true;
-        }
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/dialogs/OrderDialogFragment.java
@@ -388,7 +388,7 @@ public class OrderDialogFragment extends DialogFragment {
         if (frequency == 0) mGiveForDays.setText("");
 
         mTimesPerDayLabel.setText(
-            days == 1 ? R.string.order_time_per_day : R.string.order_times_per_day);
+            frequency == 1 ? R.string.order_time_per_day : R.string.order_times_per_day);
 
         mGiveForDaysLabel.setText(
             days == 1 ? R.string.order_give_for_day : R.string.order_give_for_days);

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -45,7 +45,8 @@
           android:inputType="textCapSentences|textNoSuggestions"
           android:maxLength="80"
           android:imeOptions="actionNext"
-          android:nextFocusDown="@id/order_dosage" />
+          android:nextFocusDown="@id/order_dosage"
+          android:nextFocusRight="@id/order_dosage" />
     </TableRow>
 
     <TableRow
@@ -70,7 +71,9 @@
           android:inputType="textNoSuggestions"
           android:maxLength="40"
           android:imeOptions="actionNext"
-          android:nextFocusRight="@id/order_frequency" />
+          android:nextFocusLeft="@id/order_medication"
+          android:nextFocusRight="@id/order_route"
+          android:nextFocusDown="@id/order_route" />
 
       <EditText
           android:id="@+id/order_route"
@@ -81,7 +84,9 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_column="2"
-          android:hint="@string/order_route" />
+          android:hint="@string/order_route"
+          android:nextFocusDown="@id/order_frequency" />
+
     </TableRow>
 
     <TableRow
@@ -156,6 +161,7 @@
       <TextView
           android:id="@+id/order_duration_label"
           style="@style/field_label"
+          android:minLines="2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_weight="1"
@@ -186,7 +192,7 @@
           android:layout_span="2"
           android:layout_weight="1"
           android:ems="15"
-          android:inputType="textMultiLine|textCapSentences|textNoSuggestions"
+          android:inputType="textMultiLine|textCapSentences"
           android:lines="2"
           android:minLines="2"
           android:maxLines="2"

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -109,7 +109,7 @@
 
       <TextView
           android:id="@+id/order_times_per_day_label"
-          android:layout_width="300sp"
+          android:layout_weight="1"
           android:layout_column="2"
           android:layout_gravity="top|start"
           android:layout_marginStart="4sp"
@@ -142,7 +142,7 @@
 
       <TextView
           android:id="@+id/order_give_for_days_label"
-          android:layout_width="600sp"
+          android:layout_weight="1"
           android:layout_column="2"
           android:layout_gravity="top|start"
           android:layout_marginStart="4sp"
@@ -157,6 +157,8 @@
           android:id="@+id/order_duration_label"
           style="@style/field_label"
           android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
           android:layout_column="1"
           android:layout_gravity="top|start"
           android:layout_marginStart="4sp"

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -12,6 +12,7 @@
 -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -108,7 +109,7 @@
 
       <TextView
           android:id="@+id/order_times_per_day_label"
-          android:layout_width="300dip"
+          android:layout_width="300sp"
           android:layout_column="2"
           android:layout_gravity="top|start"
           android:layout_marginStart="4sp"
@@ -160,7 +161,7 @@
           android:layout_gravity="top|start"
           android:layout_marginStart="4sp"
           android:layout_span="2"
-          android:text="@string/order_duration_unspecified"/>
+          tools:text="(commencé le 29 août; après 10 doses, arrêter le 31 août)"/>
     </TableRow>
 
     <TableRow

--- a/app/src/main/res/layout/order_dialog_fragment.xml
+++ b/app/src/main/res/layout/order_dialog_fragment.xml
@@ -198,14 +198,23 @@
       android:layout_height="wrap_content"
       android:orientation="horizontal">
 
-  <Button
-      android:id="@+id/order_delete"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="16sp"
-      android:layout_marginBottom="16sp"
-      android:padding="16sp"
-      android:text="@string/order_delete"/>
+    <Button
+        android:id="@+id/order_stop_now"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16sp"
+        android:layout_marginBottom="16sp"
+        android:padding="16sp"
+        android:text="@string/order_stop_now"/>
+
+    <Button
+        android:id="@+id/order_delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16sp"
+        android:layout_marginBottom="16sp"
+        android:padding="16sp"
+        android:text="@string/order_delete"/>
   </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/patient_dialog_fragment.xml
+++ b/app/src/main/res/layout/patient_dialog_fragment.xml
@@ -34,6 +34,8 @@
           android:layout_height="wrap_content"
           android:inputType="textCapCharacters"
           android:singleLine="true"
+          android:nextFocusDown="@id/patient_id"
+          android:nextFocusRight="@id/patient_id"
           android:ems="5" />
     </TableRow>
 
@@ -49,6 +51,9 @@
           android:inputType="numberDecimal"
           android:digits="0123456789"
           android:singleLine="true"
+          android:nextFocusLeft="@id/patient_id_prefix"
+          android:nextFocusDown="@id/patient_given_name"
+          android:nextFocusRight="@id/patient_given_name"
           android:ems="10" />
     </TableRow>
 
@@ -63,6 +68,9 @@
           android:layout_height="wrap_content"
           android:inputType="textCapWords|textPersonName"
           android:singleLine="true"
+          android:nextFocusLeft="@id/patient_id"
+          android:nextFocusDown="@id/patient_family_name"
+          android:nextFocusRight="@id/patient_family_name"
           android:ems="10" />
     </TableRow>
 
@@ -77,6 +85,9 @@
           android:layout_height="wrap_content"
           android:inputType="textCapWords|textPersonName"
           android:singleLine="true"
+          android:nextFocusLeft="@id/patient_given_name"
+          android:nextFocusDown="@id/patient_age_years"
+          android:nextFocusRight="@id/patient_age_years"
           android:ems="10" />
     </TableRow>
 
@@ -97,6 +108,9 @@
             android:digits="0123456789"
             android:singleLine="true"
             android:ems="3"
+            android:nextFocusLeft="@id/patient_family_name"
+            android:nextFocusDown="@id/patient_age_months"
+            android:nextFocusRight="@id/patient_age_months"
             android:maxLength="3"/>
         <TextView
             android:layout_height="wrap_content"
@@ -112,6 +126,9 @@
             android:digits="0123456789"
             android:singleLine="true"
             android:ems="2"
+            android:nextFocusLeft="@id/patient_age_years"
+            android:nextFocusDown="@id/patient_sex"
+            android:nextFocusRight="@id/patient_sex"
             android:maxLength="2"/>
         <TextView
             android:layout_height="wrap_content"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -112,7 +112,8 @@
   <string name="order_stop_now">Arrêter maintenant</string>
   <string name="order_delete">Supprimer cette traitement</string>
   <string name="title_confirmation">Confirmation</string>
-  <string name="confirm_order_delete">Vraiment supprimer?</string>
+  <string name="confirm_order_stop">Arrêter ce traitement maintenant?</string>
+  <string name="confirm_order_delete">Supprimer ce traitement?</string>
   <string name="delete">Supprimer</string>
 
   <string name="route_of_administration">Voie d\'administration</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -12,16 +12,19 @@
 -->
 <resources>
   <string name="quoted_text">«%s»</string>
-  <string name="two_items">%s et %s</string>
-  <string name="more_than_two_items">%s, et %s</string>
+  <string name="two_items">%$1s et %$2s</string>
+  <string name="more_than_two_items">%$1s, et %$2s</string>
   <string name="month_day_format">d MMM</string>
   <string name="sentence_month_day_format">\'le\' d MMM</string>
   <string name="year_month_day_format">d MMM yyyy</string>
   <string name="sentence_year_month_day_format">\'le\' d MMM yyyy</string>
   <string name="hour_minute_format">HH\'h\'mm</string>
-  <string name="sentence_hour_minute_format">HH\'h\'mm</string>
+  <string name="sentence_hour_minute_format">\'à\' HH\'h\'mm</string>
   <string name="month_day_hour_minute_format">MMM d, HH\'h\'mm</string>
   <string name="sentence_month_day_hour_minute_format">\'le\' d MMM \'à\' HH\'h\'mm</string>
+  <string name="sentence_yesterday">hier</string>
+  <string name="sentence_today">aujourd\'hui</string>
+  <string name="sentence_tomorrow">demain</string>
 
   <!-- Statuses -->
   <string name="status_unknown">Inconnu</string>
@@ -98,17 +101,24 @@
   <string name="order_give_for">Donne pour</string>
   <string name="order_give_for_days">jours</string>
   <string name="order_give_for_day">jour</string>
-  <string name="order_duration_stop_after_today">(arrêter après aujourd\'hui)</string>
-  <string name="order_duration_stop_after_tomorrow">(arrêter après demain)</string>
-  <string name="order_duration_stop_after_date">(arrêter après %s)</string>
-  <string name="order_duration_unspecified">(pas de durée spécifique)</string>
-  <string name="order_duration_indefinitely">(indéfiniment)</string>
-  <string name="order_duration_administer_once">(seul dose)</string>
+
+  <string name="order_one_dose_only">(seul dose)</string>
+  <string name="order_start_now_indefinitely">(commencer maintenant; continuer indéfiniment)</string>
+  <string name="order_start_now_stop_after_doses">(commencer maintenant; arrêter après %d doses)</string>
+  <string name="order_start_now_after_doses_stop_date">(commencer maintenant; après %1$d doses, arrêter %2$s)</string>
+
+  <string name="order_one_dose_only_ordered_date">(seul dose, commandé %s)</string>
+  <string name="order_started_date_stopped_date">(commencé %1$s; arrêté %2$s)</string>
+  <string name="order_started_date_indefinitely">(commencé %s; continuer indéfiniment)</string>
+  <string name="order_started_date_stop_after_doses">(commencé %1$s; arrêter après %2$d doses)</string>
+  <string name="order_started_date_after_doses_stop_date">(commencé %1$s; après %2$d doses, arrêter %3$s)</string>
+
   <string name="order_notes">Remarques</string>
   <string name="enter_medication">Entrez le médicament</string>
   <string name="order_give_for_days_cannot_be_zero">Doit être vide ou supérieure à 0</string>
   <string name="order_cannot_exceed_n_times_per_day">Ne peut pas dépasser %d fois par jour</string>
   <string name="order_cannot_exceed_n_days">Ne peut pas dépasser %d jours</string>
+  <string name="order_cannot_stop_in_past">Ne peut pas etre arrêté dans le passé</string>
   <string name="order_stop_now">Arrêter maintenant</string>
   <string name="order_delete">Supprimer cette traitement</string>
   <string name="title_confirmation">Confirmation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,16 +12,19 @@
 -->
 <resources>
   <string name="quoted_text">"%s"</string>
-  <string name="two_items">%s and %s</string>
-  <string name="more_than_two_items">%s, and %s</string>
+  <string name="two_items">%1$s and %2$s</string>
+  <string name="more_than_two_items">%1$s, and %2$s</string>
   <string name="month_day_format">MMM d</string>
-  <string name="sentence_month_day_format">MMM d</string>
+  <string name="sentence_month_day_format">\'on\' MMM d</string>
   <string name="year_month_day_format">MMM d, yyyy</string>
-  <string name="sentence_year_month_day_format">MMM d, yyyy</string>
+  <string name="sentence_year_month_day_format">\'on\' MMM d, yyyy</string>
   <string name="hour_minute_format">HH:mm</string>
-  <string name="sentence_hour_minute_format">HH:mm</string>
+  <string name="sentence_hour_minute_format">\'at\' HH:mm</string>
   <string name="month_day_hour_minute_format">MMM d, HH:mm</string>
   <string name="sentence_month_day_hour_minute_format">\'on\' MMM d \'at\' HH:mm</string>
+  <string name="sentence_yesterday">yesterday</string>
+  <string name="sentence_today">today</string>
+  <string name="sentence_tomorrow">tomorrow</string>
 
   <!-- Statuses -->
   <string name="status_unknown">Unknown</string>
@@ -101,17 +104,24 @@
   <string name="order_give_for">Give for</string>
   <string name="order_give_for_days">days</string>
   <string name="order_give_for_day">day</string>
-  <string name="order_duration_stop_after_today">(stop after today)</string>
-  <string name="order_duration_stop_after_tomorrow">(stop after tomorrow)</string>
-  <string name="order_duration_stop_after_date">(stop after %s)</string>
-  <string name="order_duration_unspecified">(no specific duration)</string>
-  <string name="order_duration_indefinitely">(indefinitely)</string>
-  <string name="order_duration_administer_once">(one dose only)</string>
+
+  <string name="order_one_dose_only">(one dose only)</string>
+  <string name="order_start_now_indefinitely">(start now; continue indefinitely)</string>
+  <string name="order_start_now_stop_after_doses">(start now; stop after %d doses)</string>
+  <string name="order_start_now_after_doses_stop_date">(start now; after %1$d doses, stop %2$s)</string>
+
+  <string name="order_one_dose_only_ordered_date">(one dose only, ordered %s)</string>
+  <string name="order_started_date_stopped_date">(started %1$s; stopped %2$s)</string>
+  <string name="order_started_date_indefinitely">(started %s; continue indefinitely)</string>
+  <string name="order_started_date_stop_after_doses">(started %1$s; stop after %2$d doses)</string>
+  <string name="order_started_date_after_doses_stop_date">(started %1$s; after %2$d doses, stop %3$s)</string>
+
   <string name="order_notes">Notes</string>
   <string name="enter_medication">Enter a medication</string>
   <string name="order_give_for_days_cannot_be_zero">Must be empty or greater than 0</string>
   <string name="order_cannot_exceed_n_times_per_day">Cannot exceed %d times per day</string>
   <string name="order_cannot_exceed_n_days">Cannot exceed %d days</string>
+  <string name="order_cannot_stop_in_past">Cannot be stopped in the past</string>
   <string name="order_stop_now">Stop now</string>
   <string name="order_delete">Delete this treatment</string>
   <string name="title_confirmation">Confirmation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,8 @@
   <string name="order_stop_now">Stop now</string>
   <string name="order_delete">Delete this treatment</string>
   <string name="title_confirmation">Confirmation</string>
-  <string name="confirm_order_delete">Really delete?</string>
+  <string name="confirm_order_stop">Stop this treatment now?</string>
+  <string name="confirm_order_delete">Delete this treatment?</string>
   <string name="delete">Delete</string>
 
   <string name="route_of_administration">Route of administration</string>


### PR DESCRIPTION
Previously the logic for editing the duration of an order was confusing and inconsistent, and the text in the order dialog didn't really make it clear what was happening.

With this change, the "number of days" field has a consistent meaning regardless of whether it's a new order or you're editing an order, and there is an explicit (if somewhat verbose) explanation of exactly what the order schedule is or was.

Examples:

"(started yesterday; after 4 doses, stop tomorrow)"
"(start now; continue indefinitely)"
"(commencer maintenant; après 15 doses, arrêter le 6 sept.)"