### PR TITLE
Improve and fix bugs in the order execution dialog.

### DIFF
--- a/app/src/main/assets/chart.css
+++ b/app/src/main/assets/chart.css
@@ -135,7 +135,7 @@ th[scope="rowgroup"] {
   width: 0.3rem;
   margin-left: -0.15rem;
   position: absolute;
-  top: 70%;
+  top: 75%;
   bottom: 0;
   opacity: 0.3;
   background: #000;

--- a/app/src/main/java/org/projectbuendia/client/models/Order.java
+++ b/app/src/main/java/org/projectbuendia/client/models/Order.java
@@ -137,7 +137,7 @@ public final @Immutable class Order extends Model implements Serializable {
         int dayIndex = Days.daysBetween(start.toLocalDate(), day).getDays();
         Duration timeOfDay = new Duration(daySpan.getStart(), time);
         float fractionOfDay = (float) timeOfDay.getMillis() / daySpan.toDurationMillis();
-        return (int) ((dayIndex + fractionOfDay) * instructions.frequency);
+        return (int) ((dayIndex + fractionOfDay) * getNumDivisionsPerDay());
     }
 
     /**

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/DeleteObsTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/DeleteObsTask.java
@@ -9,6 +9,7 @@ import com.android.volley.toolbox.RequestFuture;
 
 import org.projectbuendia.client.App;
 import org.projectbuendia.client.events.CrudEventBus;
+import org.projectbuendia.client.events.data.ItemDeletedEvent;
 import org.projectbuendia.client.events.data.ObsDeleteFailedEvent;
 import org.projectbuendia.client.events.data.ObsDeleteFailedEvent.Reason;
 import org.projectbuendia.client.models.Obs;
@@ -62,8 +63,7 @@ public class DeleteObsTask extends AsyncTask<Void, Void, ObsDeleteFailedEvent> {
     }
 
     @Override protected void onPostExecute(ObsDeleteFailedEvent event) {
-        if (event != null) {
-            mBus.post(event);
-        }
+        mBus.post(event != null ? event  // error
+            : new ItemDeletedEvent(mObs.uuid)); // success
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/models/tasks/DeleteOrderTask.java
+++ b/app/src/main/java/org/projectbuendia/client/models/tasks/DeleteOrderTask.java
@@ -72,13 +72,7 @@ public class DeleteOrderTask extends AsyncTask<Void, Void, OrderDeleteFailedEven
     }
 
     @Override protected void onPostExecute(OrderDeleteFailedEvent event) {
-        // If an error occurred, post the error event.
-        if (event != null) {
-            mBus.post(event);
-            return;
-        }
-
-        // Otherwise, broadcast that the deletion succeeded.
-        mBus.post(new ItemDeletedEvent(mOrderUuid));
+        mBus.post(event != null ? event  // error
+            : new ItemDeletedEvent(mOrderUuid)); // success
     }
 }

--- a/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
+++ b/app/src/main/java/org/projectbuendia/client/ui/chart/PatientChartActivity.java
@@ -374,7 +374,7 @@ public final class PatientChartActivity extends LoggedInActivity {
 
         @Override public void showOrderExecutionDialog(
             Order order, Interval interval, List<Obs> executions) {
-            OrderExecutionDialogFragment.newInstance(order, interval, executions)
+            OrderExecutionDialogFragment.create(order, interval, executions)
                 .show(getSupportFragmentManager(), null);
         }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -136,7 +136,7 @@
 
   <string name="route_of_administration">Voie d\'administration</string>
 
-  <string name="order_execution_title">L\'historique de traitement</string>
+  <string name="order_execution_title">L\'historique de traitement pour %s</string>
   <string name="order_medication_route">%1$s %2$s</string>
   <string name="order_dosage_unary">%1$s</string>
   <string name="order_dosage_series">%1$s, donné %2$d fois par jour</string>
@@ -144,8 +144,8 @@
   <string name="order_frequency_value">%1$dx/jour</string>
   <string name="order_execution_historical_singular_html">Donné &lt;b&gt;%1$d&lt;/b&gt; fois %2$s</string>
   <string name="order_execution_historical_plural_html">Donné &lt;b&gt;%1$d&lt;/b&gt; fois %2$s</string>
-  <string name="order_execution_today_singular_html">Donné &lt;b&gt;%1$d&lt;/b&gt; fois aujourd\'hui, %2$s</string>
-  <string name="order_execution_today_plural_html">Donné &lt;b&gt;%1$d&lt;/b&gt; fois aujourd\'hui, %2$s</string>
+  <string name="order_execution_today_singular_html">Donné &lt;b&gt;une&lt;/b&gt; fois aujourd\'hui</string>
+  <string name="order_execution_today_plural_html">Donné &lt;b&gt;%1$d&lt;/b&gt; fois aujourd\'hui</string>
   <string name="order_execution_mark_as_given_now">Marquer comme donné maintenant</string>
   <string name="order_execution_marked_as_given_now">&#x2714; Marqué comme donné maintenant</string>
   <string name="order_execution_delete_selected">Supprimer les sélectionnés</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,7 @@
 
   <string name="route_of_administration">Route of administration</string>
 
-  <string name="order_execution_title">Treatment history for %s</string>
+  <string name="order_execution_title">Treatment history %s</string>
   <string name="order_medication_route">%1$s %2$s</string>
   <string name="order_dosage_unary">%1$s</string>
   <string name="order_dosage_series">%1$s, given %2$dx daily</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,7 @@
 
   <string name="route_of_administration">Route of administration</string>
 
-  <string name="order_execution_title">Treatment history</string>
+  <string name="order_execution_title">Treatment history for %s</string>
   <string name="order_medication_route">%1$s %2$s</string>
   <string name="order_dosage_unary">%1$s</string>
   <string name="order_dosage_series">%1$s, given %2$dx daily</string>
@@ -147,8 +147,8 @@
   <string name="order_frequency_value">%1$dx/day</string>
   <string name="order_execution_historical_singular_html">Given &lt;b&gt;once&lt;/b&gt; %2$s</string>
   <string name="order_execution_historical_plural_html">Given &lt;b&gt;%1$d&lt;/b&gt; times %2$s</string>
-  <string name="order_execution_today_singular_html">Given &lt;b&gt;once&lt;/b&gt; today, %2$s</string>
-  <string name="order_execution_today_plural_html">Given &lt;b&gt;%1$d&lt;/b&gt; times today, %2$s</string>
+  <string name="order_execution_today_singular_html">Given &lt;b&gt;once&lt;/b&gt; today</string>
+  <string name="order_execution_today_plural_html">Given &lt;b&gt;%1$d&lt;/b&gt; times today</string>
   <string name="order_execution_mark_as_given_now">Mark as given now</string>
   <string name="order_execution_marked_as_given_now">&#x2714; Marked as given now</string>
   <string name="order_execution_delete_selected">Delete selected</string>


### PR DESCRIPTION
Issues: Closes #397.
Scope: OrderExecutionDialogFragment

#### User-visible changes

There are several small changes to the dialog:
  - The title of the dialog gives the date, making it clear it's a history for one day ("Treatment history for Sep 23").
  - The summary text ("Given 3 times...") now updates to reflect deleted executions, as well as added executions.
  - The grid updates when you delete an execution (previously it did not, and the effect of the deletion would not appear until the chart was redrawn).
  - Bug #397 (missing order execution ticks) is fixed; this problem did not have to do with time zones but actually with orders that had no frequency.
  - The ticks are ever so slightly shorter to prevent them from colliding with the order execution counts in the cells ("0/1").

#### Internal changes <!-- optional -->

The OrderExecutionDialogFragment is now a subclass of BaseDialogFragment like most of the other dialogs.

