### PR TITLE
Add a "None of the above" button to multiple-select groups.

### DIFF
--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectOneTableWidgetGroupBuilder.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectOneTableWidgetGroupBuilder.java
@@ -116,9 +116,9 @@ public class BinarySelectOneTableWidgetGroupBuilder implements
         cb.setText(label);
         cb.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View v) {
-                ((CheckBox) v).setChecked(true);
+                Boolean newState = ((CheckBox) v).isChecked() ? false : null;
                 for (BinarySelectOneWidget widget : mWidgets) {
-                    widget.setState(false);
+                    widget.setState(newState);
                 }
             }
         });

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectOneTableWidgetGroupBuilder.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectOneTableWidgetGroupBuilder.java
@@ -29,7 +29,7 @@ import java.util.List;
  * group; see {@link WidgetGroupBuilderFactory}.
  */
 public class BinarySelectOneTableWidgetGroupBuilder implements
-        WidgetGroupBuilder<TableWidgetGroup, BinarySelectOneTableWidgetGroupBuilder> {
+        WidgetGroupBuilder<TableWidgetGroup, BinarySelectOneTableWidgetGroupBuilder>, View.OnClickListener {
 
     private static final String TAG = BinarySelectOneTableWidgetGroupBuilder.class.getName();
 
@@ -91,6 +91,7 @@ public class BinarySelectOneTableWidgetGroupBuilder implements
                 .inflate(R.layout.template_binary_select_one_widget_group, null /*parent*/);
 
         for (BinarySelectOneWidget widget : mWidgets) {
+            widget.setOnClickCallback(this);
             group.addView(widget);
         }
 
@@ -98,6 +99,15 @@ public class BinarySelectOneTableWidgetGroupBuilder implements
         group.addRow(mNoneButton);
         setTopMargin(context, mNoneButton, 12);
         return group;
+    }
+
+    @Override public void onClick(View view) {
+        if (view instanceof BinarySelectOneWidget) {
+            BinarySelectOneWidget widget = (BinarySelectOneWidget) view;
+            if (widget.getState() == true) {
+                mNoneButton.setChecked(false);
+            }
+        }
     }
 
     private CheckBox createNoneButton(Context context, String label, ViewGroup parent) {
@@ -108,7 +118,7 @@ public class BinarySelectOneTableWidgetGroupBuilder implements
             @Override public void onClick(View v) {
                 ((CheckBox) v).setChecked(true);
                 for (BinarySelectOneWidget widget : mWidgets) {
-                    widget.clearAnswer();
+                    widget.setState(false);
                 }
             }
         });

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectOneTableWidgetGroupBuilder.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectOneTableWidgetGroupBuilder.java
@@ -3,6 +3,10 @@ package org.odk.collect.android.widgets2.group;
 import android.content.Context;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewGroup.MarginLayoutParams;
+import android.widget.CheckBox;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -15,8 +19,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A {@link WidgetGroupBuilder} that builds {@link TableWidgetGroup}s with a bunch of
- * {@link BinarySelectOneWidget}s.
+ * A {@link WidgetGroupBuilder} that builds a {@link TableWidgetGroup}
+ * containing several {@link BinarySelectOneWidget}s.  In Buendia, this
+ * is the way we present a set of choices that allows any number of choices
+ * to be selected.  This is logically equivalent to a group of checkboxes,
+ * but JavaRosa has no concept of a boolean control type; booleans are
+ * represented as select-one controls with "yes" and "no" as the two choices.
+ * This builder is triggered by the appearance "binary-select-one" on the
+ * group; see {@link WidgetGroupBuilderFactory}.
  */
 public class BinarySelectOneTableWidgetGroupBuilder implements
         WidgetGroupBuilder<TableWidgetGroup, BinarySelectOneTableWidgetGroupBuilder> {
@@ -25,6 +35,7 @@ public class BinarySelectOneTableWidgetGroupBuilder implements
 
     private final Appearance mAppearance;
     private final List<BinarySelectOneWidget> mWidgets;
+    private CheckBox mNoneButton;
 
     public BinarySelectOneTableWidgetGroupBuilder(Appearance appearance) {
         mAppearance = appearance;
@@ -83,6 +94,30 @@ public class BinarySelectOneTableWidgetGroupBuilder implements
             group.addView(widget);
         }
 
+        mNoneButton = createNoneButton(context, context.getString(R.string.none_of_the_above), group);
+        group.addRow(mNoneButton);
+        setTopMargin(context, mNoneButton, 12);
         return group;
+    }
+
+    private CheckBox createNoneButton(Context context, String label, ViewGroup parent) {
+        CheckBox cb = (CheckBox) LayoutInflater.from(context).inflate(
+            R.layout.template_check_box_button, parent, false);
+        cb.setText(label);
+        cb.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                ((CheckBox) v).setChecked(true);
+                for (BinarySelectOneWidget widget : mWidgets) {
+                    widget.clearAnswer();
+                }
+            }
+        });
+        return cb;
+    }
+
+    private void setTopMargin(Context context, View view, int marginSp) {
+        MarginLayoutParams params = (MarginLayoutParams) view.getLayoutParams();
+        params.topMargin = (int) (marginSp * context.getResources().getDisplayMetrics().scaledDensity);
+        view.setLayoutParams(params);
     }
 }

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectTableBuilder.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/BinarySelectTableBuilder.java
@@ -122,7 +122,7 @@ public class BinarySelectTableBuilder implements
             BinarySelectWidget widget = (BinarySelectWidget) view;
             // When any choices are set to "yes", all other choices revert to
             // the "unanswered" state instead of the "no" state.
-            if (widget.getState() == true && mNoneButton.isChecked()) {
+            if (widget.getState() == Boolean.TRUE && mNoneButton.isChecked()) {
                 mNoneButton.setChecked(false);
                 setAllChoices(null);
                 widget.setState(true);

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/TableWidgetGroup.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/TableWidgetGroup.java
@@ -7,7 +7,6 @@ import android.widget.TableLayout;
 import android.widget.TableRow;
 
 import org.odk.collect.android.widgets2.common.TypedWidget;
-import org.odk.collect.android.widgets2.selectone.BinarySelectOneWidget;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,8 +17,9 @@ import java.util.List;
 public class TableWidgetGroup extends TableLayout implements WidgetGroup {
 
     private int mNumColumns = 2;
+    private int mColumnsFilled = 0;
 
-    private TableRow mLastTableRow = null;
+    private TableRow mCurrentRow = null;
     private List<TypedWidget<?>> mWidgets = new ArrayList<TypedWidget<?>>();
 
     public TableWidgetGroup(Context context, AttributeSet attrs) {
@@ -28,38 +28,45 @@ public class TableWidgetGroup extends TableLayout implements WidgetGroup {
 
     public TableWidgetGroup setNumColumns(int numColumns) {
         mNumColumns = numColumns;
-
         return this;
     }
 
-    @Override
-    public void addView(View child) {
-        if (mLastTableRow == null || mLastTableRow.getChildCount() == mNumColumns) {
-            mLastTableRow = new TableRow(getContext());
-            mLastTableRow.setWeightSum(mNumColumns);
-
-            super.addView(mLastTableRow);
+    public void addCell(View child, int span) {
+        if (mCurrentRow == null || mColumnsFilled + span > mNumColumns) {
+            mCurrentRow = new TableRow(getContext());
+            mColumnsFilled = 0;
+            super.addView(mCurrentRow);
         }
 
-        child.setLayoutParams(new TableRow.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1f));
+        TableRow.LayoutParams params =
+            new TableRow.LayoutParams(0, LayoutParams.WRAP_CONTENT);
+        params.span = span;
+        child.setLayoutParams(params);
 
-        mLastTableRow.addView(child);
+        mCurrentRow.addView(child);
+        mColumnsFilled += span;
 
         if (child instanceof TypedWidget<?>) {
             mWidgets.add((TypedWidget<?>) child);
         }
     }
 
-    @Override
-    public List<TypedWidget<?>> getWidgets() {
+    @Override public void addView(View child) {
+        addCell(child, 1);
+    }
+
+    void addRow(View child) {
+        addCell(child, mNumColumns);
+    }
+
+    @Override public List<TypedWidget<?>> getWidgets() {
         return mWidgets;
     }
 
-    @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    @Override protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         // If there are any columns, set all columns to be stretchable. This works around bug
         // https://code.google.com/p/android/issues/detail?id=19343.
-        if (getChildCount() > 1 || (mLastTableRow != null && mLastTableRow.getChildCount() > 0)) {
+        if (getChildCount() > 1 || (mCurrentRow != null && mCurrentRow.getChildCount() > 0)) {
             setStretchAllColumns(true);
         }
 

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/WidgetGroupBuilderFactory.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/group/WidgetGroupBuilderFactory.java
@@ -14,7 +14,7 @@ public class WidgetGroupBuilderFactory {
         Appearance appearance = Appearance.fromString(group.getAppearanceHint());
 
         if (appearance.hasQualifier("binary-select-one")) {
-            return new BinarySelectOneTableWidgetGroupBuilder(appearance);
+            return new BinarySelectTableBuilder(appearance);
         }
 
         return null;

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/selectone/BinarySelectOneWidget.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/selectone/BinarySelectOneWidget.java
@@ -2,9 +2,6 @@ package org.odk.collect.android.widgets2.selectone;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.res.ColorStateList;
-import android.graphics.PorterDuff;
-import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
@@ -71,6 +68,7 @@ public class BinarySelectOneWidget extends TypedWidget<SelectOneData> implements
 
         if (mOnClickCallback != null) {
             mOnClickCallback.onClick(this);
+
         }
     }
 
@@ -82,14 +80,6 @@ public class BinarySelectOneWidget extends TypedWidget<SelectOneData> implements
         mState = state;
         mCheckBox.setChecked(mState == Boolean.TRUE);
         mCheckBox.setTextColor(mState == Boolean.FALSE ? 0xffc80080 : 0xff000000);
-
-        if (Build.VERSION.SDK_INT >= 21) {
-            mCheckBox.setButtonTintMode(PorterDuff.Mode.SCREEN);
-            mCheckBox.setButtonTintList(
-                mState == Boolean.FALSE ?
-                    new ColorStateList(new int[0][0], new int[] {0x80ff0000}) : null
-            );
-        }
     }
 
     @Override public boolean forceSetAnswer(Object answer) {

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/selectone/BinarySelectWidget.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/selectone/BinarySelectWidget.java
@@ -68,15 +68,15 @@ public class BinarySelectWidget extends TypedWidget<SelectOneData> implements Vi
     @Override public void onClick(View view) {
         clearActivityFocus((Activity) view.getContext());
         FormEntryActivity.hideKeyboard(view.getContext(), view);
+        mState = mCheckBox.isChecked() ? true : null;
 
         if (mOnClickCallback != null) {
             mOnClickCallback.onClick(this);
-
         }
     }
 
     public Boolean getState() {
-        return mCheckBox.isChecked();
+        return mState;
     }
 
     public void setState(Boolean state) {
@@ -94,9 +94,9 @@ public class BinarySelectWidget extends TypedWidget<SelectOneData> implements Vi
     }
 
     @Override public SelectOneData getAnswer() {
-        return new SelectOneData(
-            mState == Boolean.TRUE ? new Selection(mYesChoice) :
-                mState == Boolean.FALSE ? new Selection(mNoChoice) : new Selection());
+        if (mState == Boolean.TRUE) return new SelectOneData(new Selection(mYesChoice));
+        if (mState == Boolean.FALSE) return new SelectOneData(new Selection(mNoChoice));
+        return null;
     }
 
     @Override public void clearAnswer() {

--- a/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/selectone/BinarySelectWidget.java
+++ b/third_party/odkcollect/src/main/java/org/odk/collect/android/widgets2/selectone/BinarySelectWidget.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Tapping the button toggles the state between "yes" and "unanswered"; the
  * setState() method allows setting the state to "yes", "unanswered", or "no".
  */
-public class BinarySelectOneWidget extends TypedWidget<SelectOneData> implements View.OnClickListener {
+public class BinarySelectWidget extends TypedWidget<SelectOneData> implements View.OnClickListener {
 
     private SelectChoice mYesChoice;
     private SelectChoice mNoChoice;
@@ -36,7 +36,10 @@ public class BinarySelectOneWidget extends TypedWidget<SelectOneData> implements
     private OnClickListener mOnClickCallback = null;
     private Boolean mState = null;  // true, false, or null (null means "unanswered")
 
-    public BinarySelectOneWidget(
+    private static final int OFF_TEXT_COLOR = 0xff999999;
+    private static final int DEFAULT_TEXT_COLOR = 0xff000000;
+
+    public BinarySelectWidget(
             Context context, FormEntryPrompt prompt, Appearance appearance, boolean forceReadOnly) {
         super(context, prompt, appearance, forceReadOnly);
 
@@ -79,7 +82,7 @@ public class BinarySelectOneWidget extends TypedWidget<SelectOneData> implements
     public void setState(Boolean state) {
         mState = state;
         mCheckBox.setChecked(mState == Boolean.TRUE);
-        mCheckBox.setTextColor(mState == Boolean.FALSE ? 0xffc80080 : 0xff000000);
+        mCheckBox.setTextColor(mState == Boolean.FALSE ? OFF_TEXT_COLOR : DEFAULT_TEXT_COLOR);
     }
 
     @Override public boolean forceSetAnswer(Object answer) {

--- a/third_party/odkcollect/src/main/res/values-fr/strings.xml
+++ b/third_party/odkcollect/src/main/res/values-fr/strings.xml
@@ -3,6 +3,7 @@
 <string name="title_discard_observations">Jeter ces observations?</string>
 <string name="yes">Oui</string>
 <string name="no">Non</string>
+<string name="none_of_the_above">Aucune des choses ci-dessus</string>
 <string name="form_entry_save">Enregistrer</string>
 <string name="form_entry_discard">Jeter</string>
 <string name="question_is_required">Champ manquant: %s</string>

--- a/third_party/odkcollect/src/main/res/values/strings.xml
+++ b/third_party/odkcollect/src/main/res/values/strings.xml
@@ -152,6 +152,7 @@
 <string name="view_hierarchy">Go To Prompt</string>
 <string name="yes">Yes</string>
 <string name="no">No</string>
+<string name="none_of_the_above">None of the above</string>
 <string name="general_preferences">General Settings</string>
 <string name="click_to_web">Tap to visit http://opendatakit.org</string>
 <string name="client">User Interface</string>


### PR DESCRIPTION
Issues: Closes #367.
Scope: BinarySelectOneWidget and its table group builder

#### User-visible changes

In each multiple-select question:

1. Previously each option would be recorded with a "yes" or a "no" value; the default value is "no" and tapping an option toggles between "yes" and "no".  Thus, submitting the form without doing anything would record a "no" for all the options.  Now, the default value is "unanswered" and tapping an option toggles between "yes" and "unanswered", so that submitting the form without doing anything doesn't record anything for such questions.

2. There is a new "None of the above" button at the bottom.  Tapping this button sets the state of all the options to "no".  This button is the only way to set options to "no" (rather than "unanswered").  When "None of the above" is selected, tapping any other option clears the "None of the above" button and reverts all the other options to "unanswered".

The appearance of options changes slightly:

  - "Yes" state: Previously, black text on green background.  Unchanged.
  - "No" state: Previously, black text on white background.  Now, grey text on white background.
  - "Unanswered" state: Previously, black text on white background.  Unchanged.

#### Internal changes <!-- optional -->

The unwieldy name "BinarySelectOneTableWidgetGroupBuilder" (which ought to win some sort of prize) has been renamed to the more concise "BinarySelectTableBuilder".

#### Verification performed

I tested this manually on a tablet and confirmed that the options light up and clear as expected, in response to taps on the option buttons and the "None of the above" button.  I submitted the form and confirmed that nothing is recorded if nothing is tapped, and that "no" is recorded for all options if "None of the above" is selected.

#### Rationale and alternatives considered  <!-- optional -->

This design was intended to meet the following goals:

  - We don't want to record "no" for a symptom when the patient hasn't been examined at all for that symptom.
  - We do want a way for medics to record "no" for all symptoms when they've examined the patient.
  - We don't want the UX to be too complicated.

#### Screenshots <!-- optional -->

Here is a short video of the interaction:

[none-of-the-above-mp4.zip](https://github.com/projectbuendia/client/files/3882186/none-of-the-above-mp4.zip)

Here's what it looks like with a couple of options selected:

![none-of-the-above-with-selections](https://user-images.githubusercontent.com/236086/69474423-fe3ab980-0d8e-11ea-8544-d64432b4f1f5.png)

And here it is with the "None of the above" button selected:

![none-of-the-above-none-selected](https://user-images.githubusercontent.com/236086/69474421-f713ab80-0d8e-11ea-9f4d-a2558ea4bb84.png)

